### PR TITLE
ci: add ADR governance compliance

### DIFF
--- a/.adr-kit.yaml
+++ b/.adr-kit.yaml
@@ -1,0 +1,18 @@
+# ADR kit configuration for repository-level decision governance.
+adr_directory: docs/adr
+filename_pattern: "ADR-[0-9]{4}-[a-z0-9-]+\.md"
+statuses:
+  - Proposed
+  - Accepted
+  - Superseded
+  - Deprecated
+  - Rejected
+immutable_statuses:
+  - Accepted
+required_sections:
+  - Context
+  - Decision
+  - Consequences
+  - Validation
+human_acceptance_required: true
+ai_may_accept: false

--- a/.github/workflows/adr-governance.yml
+++ b/.github/workflows/adr-governance.yml
@@ -1,0 +1,29 @@
+name: ADR Governance
+
+on:
+  pull_request:
+    paths:
+      - 'docs/adr/**'
+      - '.adr-kit.yaml'
+      - 'scripts/adr-governance.py'
+      - '.github/workflows/adr-governance.yml'
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'docs/adr/**'
+      - '.adr-kit.yaml'
+      - 'scripts/adr-governance.py'
+      - '.github/workflows/adr-governance.yml'
+
+jobs:
+  adr-governance:
+    name: Validate ADRs and immutable Accepted status
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run ADR governance checks
+        run: python3 scripts/adr-governance.py

--- a/docs/adr/ADR-0001-adopt-architecture-decision-records.md
+++ b/docs/adr/ADR-0001-adopt-architecture-decision-records.md
@@ -1,0 +1,54 @@
+# ADR-0001: Adopt Architecture Decision Records
+
+- **Status:** Accepted
+- **Date:** 2026-06-01
+- **Decision owners:** Engineering team
+- **Reviewers:** Engineering team
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** Portfolio ADR governance rollout
+
+## Context
+
+This repository participates in a wider Autonomi/Saorsa engineering portfolio where architectural decisions affect protocols, storage behaviour, cryptography, APIs, operations, and long-term maintenance. AI-assisted coding makes it easier to generate large changes quickly, but it also increases the risk that design intent, trade-offs, and constraints are lost.
+
+## Decision Drivers
+
+- Preserve the reasoning behind architectural choices.
+- Make trade-offs visible during code review.
+- Give humans and AI coding tools a reliable source of architectural context.
+- Prevent silent drift from accepted engineering decisions.
+- Support cross-repository consistency across Autonomi and Saorsa projects.
+
+## Considered Options
+
+1. Keep architecture reasoning only in PR descriptions and issues.
+2. Maintain informal design notes without lifecycle governance.
+3. Adopt version-controlled Architecture Decision Records with CI governance.
+
+## Decision
+
+We will maintain Architecture Decision Records in `docs/adr/` using the repository template. New decisions start as `Proposed`; once reviewed and agreed, they may be marked `Accepted`. Accepted ADRs are immutable: if the decision changes, a new superseding ADR must be created rather than editing the accepted record.
+
+## Consequences
+
+### Positive
+
+- Architectural intent becomes searchable and reviewable.
+- AI coding agents have explicit project constraints to inspect before changing code.
+- Reviews can check decision quality, not just implementation mechanics.
+- Supersession creates an audit trail instead of rewriting history.
+
+### Negative / Trade-offs
+
+- Design work becomes more explicit and may slow rushed changes.
+- Engineers must keep ADRs aligned with meaningful architectural changes.
+
+### Neutral / Operational
+
+- CI enforces ADR format and immutable Accepted status.
+- Reviewers should reject architectural PRs with weak, missing, or AI-generated-without-debate ADRs.
+
+## Validation
+
+The ADR governance CI job must pass on every PR. Reviewers should verify that architectural changes include appropriate ADR coverage and that accepted ADRs are not modified in-place.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,51 @@
+# ADR-NNNN: <Decision Title>
+
+- **Status:** Proposed
+- **Date:** YYYY-MM-DD
+- **Decision owners:** <names/handles>
+- **Reviewers:** <names/handles>
+- **Supersedes:** <ADR-NNNN or none>
+- **Superseded by:** <ADR-NNNN or none>
+- **Related:** <issues/PRs/specs>
+
+## Context
+
+What problem, constraint, or architectural tension forced this decision?
+
+## Decision Drivers
+
+- <driver 1>
+- <driver 2>
+- <driver 3>
+
+## Considered Options
+
+1. <option A>
+2. <option B>
+3. <option C>
+
+## Decision
+
+We will <state the chosen option clearly>.
+
+## Consequences
+
+### Positive
+
+- <benefit>
+
+### Negative / Trade-offs
+
+- <cost or risk>
+
+### Neutral / Operational
+
+- <ongoing implication>
+
+## Validation
+
+How will we know this decision remains correct? Include tests, metrics, audit checks, or review triggers.
+
+## Notes for AI-assisted work
+
+AI tools may help draft this ADR, but **must not mark it Accepted without human review**. Accepted ADRs are immutable: create a new superseding ADR rather than editing an Accepted ADR.

--- a/docs/adr/TOOLING.md
+++ b/docs/adr/TOOLING.md
@@ -1,0 +1,50 @@
+# ADR Tooling and AI Harness Setup
+
+We use ADRs as engineering memory, not paperwork. They capture *why* a decision was made, what alternatives were rejected, and what consequences we accept.
+
+## Install `adrs`
+
+`adrs` is the preferred local CLI for creating, searching, and checking ADRs.
+
+```bash
+cargo install adrs
+# or, if the repo has a Rust toolchain wrapper, use that wrapper's cargo equivalent.
+```
+
+Useful commands:
+
+```bash
+adrs list
+adrs search "post-quantum"
+adrs doctor
+```
+
+## Install `adr-kit`
+
+`adr-kit` is used for agent-aware ADR analysis and policy/lint generation where available.
+
+Recommended isolated install:
+
+```bash
+uv tool install adr-kit
+# fallback
+uvx adr-kit --help
+```
+
+If the published package name differs on your machine, install from the project source used by the team and keep it isolated with `uv tool` or `pipx` rather than a global Python environment.
+
+## AI harness guidance: pi, Codex, Claude Code, OpenCode
+
+Add this project instruction to every AI coding harness profile (`AGENTS.md`, `CLAUDE.md`, Codex/OpenCode project rules, pi harness prompts, etc.):
+
+```text
+Before changing architecture, protocols, storage formats, crypto, network behaviour, public APIs, data models, or operational invariants, inspect docs/adr/.
+If the change creates or changes an architectural decision, draft or update a Proposed ADR using docs/adr/TEMPLATE.md.
+Never edit an Accepted ADR. Create a superseding ADR instead.
+Never mark an ADR Accepted autonomously; that requires human engineering review and debate.
+During review, check ADR correctness, rejected alternatives, evidence, consequences, and immutable-Accepted compliance.
+```
+
+## Review standard
+
+Do **not** "vibe code" ADRs. A useful ADR must show clear thinking: context, options, trade-offs, consequences, and validation. AI can help prepare a draft, but humans must debate and own the decision.

--- a/scripts/adr-governance.py
+++ b/scripts/adr-governance.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Repository-local ADR governance checks.
+
+Enforces:
+- ADR files live under docs/adr/ and use ADR-NNNN-short-title.md.
+- Required sections exist.
+- Status is present and from the allowed lifecycle.
+- Accepted ADRs are immutable after acceptance. If a decision changes, create a
+  new ADR and supersede by reference rather than editing the Accepted ADR.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ADR_DIR = Path("docs/adr")
+ALLOWED_STATUSES = {"Proposed", "Accepted", "Superseded", "Deprecated", "Rejected"}
+REQUIRED_SECTIONS = ["Context", "Decision", "Consequences", "Validation"]
+FILENAME_RE = re.compile(r"^ADR-\d{4}-[a-z0-9][a-z0-9-]*\.md$")
+STATUS_RE = re.compile(r"(?im)^\s*(?:[-*]\s*)?.*?Status.*?:\s*(.+?)\s*$")
+
+
+def run(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL).strip()
+
+
+def status_of(text: str) -> str | None:
+    m = STATUS_RE.search(text)
+    return m.group(1).strip().strip("*").strip() if m else None
+
+
+def base_ref() -> str | None:
+    ref = os.environ.get("GITHUB_BASE_REF")
+    if ref:
+        return f"origin/{ref}"
+    # On push, compare against first parent where available.
+    try:
+        return run(["git", "rev-parse", "HEAD^@"])
+    except Exception:
+        return None
+
+
+def changed_files_against_base(base: str) -> list[str]:
+    try:
+        return run(["git", "diff", "--name-only", f"{base}...HEAD"]).splitlines()
+    except Exception:
+        try:
+            return run(["git", "diff", "--name-only", f"{base}", "HEAD"]).splitlines()
+        except Exception:
+            return []
+
+
+def file_at(ref: str, path: str) -> str | None:
+    try:
+        return run(["git", "show", f"{ref}:{path}"])
+    except Exception:
+        return None
+
+
+def main() -> int:
+    errors: list[str] = []
+    if not ADR_DIR.exists():
+        print("No docs/adr directory; nothing to validate.")
+        return 0
+
+    adr_files = sorted(p for p in ADR_DIR.glob("ADR-*.md") if p.is_file())
+    base = base_ref()
+    changed = changed_files_against_base(base) if base else []
+    changed_adr_paths = {Path(name) for name in changed if name.startswith("docs/adr/ADR-") and name.endswith(".md")}
+
+    # Grandfather legacy ADRs when first installing governance. Enforce full
+    # structure on ADRs touched by this PR, while still checking duplicate
+    # numbers across the full directory.
+    files_to_validate = sorted((Path(p) for p in changed_adr_paths if Path(p).exists()), key=str) if base else adr_files
+
+    seen_numbers: dict[str, Path] = {}
+    for path in adr_files:
+        number = path.name.split("-", 2)[1] if "-" in path.name else path.name
+        if number in seen_numbers:
+            errors.append(f"{path}: duplicate ADR number also used by {seen_numbers[number]}")
+        seen_numbers[number] = path
+
+    for path in files_to_validate:
+        if not FILENAME_RE.match(path.name):
+            errors.append(f"{path}: filename must match ADR-NNNN-short-title.md")
+        text = path.read_text(encoding="utf-8")
+        st = status_of(text)
+        if not st:
+            errors.append(f"{path}: missing Status")
+        elif st not in ALLOWED_STATUSES:
+            errors.append(f"{path}: invalid Status '{st}' (allowed: {', '.join(sorted(ALLOWED_STATUSES))})")
+        for section in REQUIRED_SECTIONS:
+            if not re.search(rf"(?im)^##\s+{re.escape(section)}\b", text):
+                errors.append(f"{path}: missing required section '## {section}'")
+
+    if base:
+        for name in changed:
+            if not (name.startswith("docs/adr/ADR-") and name.endswith(".md")):
+                continue
+            old = file_at(base, name)
+            if old is None:
+                continue
+            old_status = status_of(old)
+            if old_status == "Accepted":
+                errors.append(
+                    f"{name}: Accepted ADRs are immutable. Create a new superseding ADR instead of editing this file."
+                )
+
+    if errors:
+        print("ADR governance failed:")
+        for e in errors:
+            print(f"- {e}")
+        return 1
+    print(f"ADR governance passed ({len(adr_files)} ADR file(s) checked).")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adr-governance.py
+++ b/scripts/adr-governance.py
@@ -38,7 +38,7 @@ def base_ref() -> str | None:
         return f"origin/{ref}"
     # On push, compare against first parent where available.
     try:
-        return run(["git", "rev-parse", "HEAD^@"])
+        return run(["git", "rev-parse", "HEAD^1"])
     except Exception:
         return None
 


### PR DESCRIPTION
## Summary

Adds repository-local ADR governance and team-standard ADR tooling:

- `docs/adr/TEMPLATE.md` with a structured ADR format
- `docs/adr/TOOLING.md` with `adrs`, `adr-kit`, Codex/Claude Code/OpenCode/pi harness guidance
- `.adr-kit.yaml` policy config
- `scripts/adr-governance.py` validation for ADR format, required sections, status values, duplicate numbers, and immutable `Accepted` ADRs
- `.github/workflows/adr-governance.yml` CI gate

For repos without existing ADRs, this also bootstraps `ADR-0001: Adopt Architecture Decision Records`.

## Why

ADRs are part of our engineering safety system, especially now we use AI coding assistance. They preserve the reasoning, rejected alternatives, consequences, and validation behind architectural decisions. `Accepted` ADRs must not be rewritten; if a decision changes, we create a superseding ADR so the audit trail remains intact.

## Review focus

- Check the ADR template is suitable for this repository.
- Check the immutable `Accepted` enforcement is strict enough.
- Check the harness guidance matches how contributors use Codex, Claude Code, OpenCode, and other agents.

## Test plan

- [x] Ran `python3 scripts/adr-governance.py` locally on the branch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR installs ADR governance infrastructure: a template, a bootstrap ADR-0001, tooling docs, a policy config (`.adr-kit.yaml`), a Python validation script, and a CI workflow. The overall design is sound, but there is one logic bug in the governance script that silently disables all checks on push-to-main events triggered by standard merge commits.

- **`HEAD^@` in `base_ref()`** returns all parent SHAs (newline-separated) for a merge commit; the resulting multi-line string is an invalid git ref, causing `changed_files_against_base` to swallow the error and return `[]`, which then skips both format validation and the immutability check on every push to `main` that arrives as a merge commit. Replacing `HEAD^@` with `HEAD^` (first parent) fixes this.
- The `files_to_validate` list comprehension redundantly wraps `Path` objects in a second `Path()` call — a minor style issue with no runtime impact.

<h3>Confidence Score: 3/5</h3>

The governance infrastructure is well-structured, but the immutability enforcement it was built around is silently bypassed on every normal merge into main.

The push trigger provides a false sense of safety for merge commits until the one-character fix is applied; the PR trigger remains effective.

scripts/adr-governance.py — specifically the base_ref() function at line 41.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/adr-governance.py | Core governance script; contains a logic bug where `HEAD^@` returns multiple parent SHAs for merge commits, silently disabling all checks on push-to-main events triggered by standard GitHub merges. |
| .github/workflows/adr-governance.yml | Workflow correctly uses fetch-depth: 0 and path filters; no issues. |
| .adr-kit.yaml | Policy config consistent with the governance script and template; looks correct. |
| docs/adr/ADR-0001-adopt-architecture-decision-records.md | Bootstrap ADR marked Accepted; all required sections present and content is appropriate. |
| docs/adr/TEMPLATE.md | Template covers all required sections and includes a useful AI-harness guidance footer; no issues. |
| docs/adr/TOOLING.md | Tooling guide; includes a hedge for uncertain package names which is reasonable but worth verifying against the team's actual installed toolchain. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow triggered] --> B{Event type?}
    B -- pull_request --> C[GITHUB_BASE_REF set]
    B -- push to main/master --> D[GITHUB_BASE_REF not set]
    C --> E[base = origin/main]
    D --> F[git rev-parse HEAD^@]
    F -- regular commit --> G[base = single parent SHA]
    F -- merge commit --> H[base = sha1 newline sha2]
    H --> I[git diff fails returns empty]
    I --> J[files_to_validate = empty list]
    J --> K[All checks silently skipped]
    G --> L[changed_files_against_base runs OK]
    E --> L
    L --> M[Format + status validation]
    L --> N[Immutability check for Accepted ADRs]
    M --> O{Errors?}
    N --> O
    O -- Yes --> P[CI fails]
    O -- No --> Q[CI passes]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/adr-governance.py:39-43
`HEAD^@` expands to **all parents** of HEAD, not just the first one. For a standard GitHub merge commit (two parents), `git rev-parse HEAD^@` returns two SHA lines, and after `.strip()` `base` becomes `"sha1
sha2"`. Both attempts inside `changed_files_against_base` then receive this as a single invalid ref, throw exceptions, and return `[]`. With an empty `changed` list, `files_to_validate` is also empty (since `base` is truthy, the `adr_files` fallback is not used), silently skipping both format validation and the immutability check on every ordinary merge-commit push to `main`.

```suggestion
    # On push, compare against first parent where available.
    try:
        return run(["git", "rev-parse", "HEAD^"])
    except Exception:
        return None
```

### Issue 2 of 2
scripts/adr-governance.py:77
`changed_adr_paths` is already a `set[Path]`, so wrapping each element in `Path(p)` is a no-op and adds mild confusion. Iterating directly over `changed_adr_paths` is cleaner.

```suggestion
    files_to_validate = sorted((p for p in changed_adr_paths if p.exists()), key=str) if base else adr_files
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: add ADR governance compliance"](https://github.com/saorsa-labs/fae/commit/85e8572fb4eade1a62faab4516d22eb0ed77f407) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34931531)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->