### PR TITLE
P4 Linux render spike

### DIFF
--- a/.github/workflows/linux-render-spike.yml
+++ b/.github/workflows/linux-render-spike.yml
@@ -1,0 +1,123 @@
+name: Linux render spike
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/linux-render-spike.yml"
+      - "crates/**"
+      - "native/rust/fae-ui-shell/**"
+      - "docs/architecture/linux-render-spike-2026-06.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/linux-render-spike.yml"
+      - "crates/**"
+      - "native/rust/fae-ui-shell/**"
+      - "docs/architecture/linux-render-spike-2026-06.md"
+
+concurrency:
+  group: linux-render-spike-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ubuntu-render-and-daemon:
+    name: Ubuntu WebKitGTK + ALSA build proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      GDK_BACKEND: x11
+      LIBGL_ALWAYS_SOFTWARE: "1"
+      WEBKIT_DISABLE_DMABUF_RENDERER: "1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+
+      - name: Install Linux shell and daemon dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            pkg-config \
+            libasound2-dev \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libx11-dev \
+            libxdo-dev \
+            libxrandr-dev \
+            libxi-dev \
+            libxcursor-dev \
+            libxkbcommon-dev \
+            libwayland-dev \
+            xvfb \
+            imagemagick
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Install Zig and cargo-zigbuild
+        run: |
+          set -euo pipefail
+          curl -fsSL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz -o /tmp/zig.tar.xz
+          tar -xf /tmp/zig.tar.xz -C /tmp
+          echo "/tmp/zig-linux-x86_64-0.13.0" >> "$GITHUB_PATH"
+          cargo install cargo-zigbuild --locked
+
+      - name: Check Rust orb shell formatting
+        working-directory: native/rust/fae-ui-shell
+        run: cargo fmt --all -- --check
+
+      - name: Lint Rust orb shell
+        working-directory: native/rust/fae-ui-shell
+        run: cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+
+      - name: Build Rust orb shell
+        working-directory: native/rust/fae-ui-shell
+        run: cargo build --all-features
+
+      - name: Smoke render opaque Settings panel under WebKitGTK/Xvfb
+        working-directory: native/rust/fae-ui-shell
+        run: |
+          set -euo pipefail
+          xvfb-run -a --server-args='-screen 0 1280x900x24' bash -c '
+            ./target/debug/fae-ui-shell --smoke-settings-panel &
+            app_pid=$!
+            sleep 7
+            import -window root "$GITHUB_WORKSPACE/linux-settings-panel.png"
+            wait "$app_pid"
+          '
+          test -s "$GITHUB_WORKSPACE/linux-settings-panel.png"
+          file "$GITHUB_WORKSPACE/linux-settings-panel.png"
+          colors=$(identify -format '%k' "$GITHUB_WORKSPACE/linux-settings-panel.png")
+          echo "settings panel screenshot colors=$colors"
+          test "$colors" -ge 8
+
+      - name: Upload Linux Settings panel screenshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-settings-panel
+          path: linux-settings-panel.png
+          if-no-files-found: error
+
+      - name: Check daemon workspace formatting
+        working-directory: crates
+        run: cargo fmt --all -- --check
+
+      - name: Lint fae-daemon production binary with ALSA backend available
+        working-directory: crates
+        run: cargo clippy -p fae-daemon --bin fae-daemon --all-features -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+
+      - name: Build fae-daemon natively on Ubuntu
+        working-directory: crates
+        run: cargo build -p fae-daemon --all-features
+
+      - name: P1 deferred proof — zigbuild fae-daemon for Linux x86_64
+        working-directory: crates
+        run: cargo zigbuild --target x86_64-unknown-linux-gnu -p fae-daemon --all-features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Right ⌥ hold / orb long-press → mic capture (16kHz) → WAV → fae-daemon
                                       │
                                       ├── Memory (SQLite + ANN + FTS5)
                                       ├── Tools (36 built-in)
-                                      ├── Skills (27 built-in)
+                                      ├── Skills (30 built-in)
                                       ├── Scheduler (~23 tasks)
                                       ├── Backup (Git Vault)
                                       └── Self-Config
@@ -338,7 +338,7 @@ cd native/macos/Fae/Sources/Fae/Resources/Skills/<skill-name>
 for f in SKILL.md scripts/*.py; do echo "\"$f\": \"$(shasum -a 256 "$f" | cut -d' ' -f1)\""; done
 ```
 
-## Built-in skills (27)
+## Built-in skills (30)
 
 | Skill | Type | Purpose |
 |-------|------|---------|
@@ -358,6 +358,9 @@ for f in SKILL.md scripts/*.py; do echo "\"$f\": \"$(shasum -a 256 "$f" | cut -d
 | `training-orchestrator` | Executable | Personal fine-tuning via mlx-tune: SFT, DPO, STT LoRA adapters |
 | `training-data-bridge` | Executable | Extract SFT/DPO training data from memory |
 | `huggingface-scout` | Executable | Search HuggingFace Hub for models/datasets |
+| `mail-himalaya` | Executable | Portable IMAP/SMTP mail via the himalaya CLI |
+| `calendar-caldav` | Executable | Portable CalDAV calendar list/create/update/delete |
+| `contacts-carddav` | Executable | Portable CardDAV contact search |
 | `self-diagnostic` | Instruction | Comprehensive health check: system, pipeline, memory, tools, speaker |
 | `channel-discord` | Executable | Discord channel integration |
 | `channel-whatsapp` | Executable | WhatsApp channel integration |

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -72,6 +72,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.12.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +372,24 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.12.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
  "shlex 1.3.0",
  "syn 2.0.117",
 ]
@@ -643,6 +683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +924,49 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "libc",
+]
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
+dependencies = [
+ "bindgen 0.72.1",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -1155,6 +1244,12 @@ checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
@@ -1523,6 +1618,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
+name = "fae-audio"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "cpal",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "fae-control-plane"
 version = "0.1.0"
 dependencies = [
@@ -1540,6 +1645,7 @@ name = "fae-daemon"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "fae-audio",
  "fae-control-plane",
  "fae-engine",
  "fae-envelope-gate",
@@ -2747,6 +2853,22 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -2754,7 +2876,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -2773,6 +2895,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -2975,6 +3106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48460c2e82a3a0de197152fdf8d2c2d5e43adc501501553e439bf2156e6f87c7"
 dependencies = [
  "fastrand",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3466,7 +3606,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e3bc3880111918b2d5018f845d48fd995f9901f16efc81d1fcfd2f4210b8219"
 dependencies = [
- "bindgen",
+ "bindgen 0.70.1",
  "cc",
  "cmake",
 ]
@@ -3535,6 +3675,35 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.12.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -3822,6 +3991,29 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni 0.21.1",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4827,7 +5019,7 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -5735,7 +5927,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -7014,6 +7206,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -7032,6 +7234,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7128,6 +7340,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -7160,6 +7381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -7205,6 +7435,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7266,6 +7511,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -7284,6 +7535,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -7299,6 +7556,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7332,6 +7595,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -7347,6 +7616,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7368,6 +7643,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -7383,6 +7664,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "fae-control-plane",
   "fae-envelope-gate",
   "fae-engine",
+  "fae-audio",
   "fae-daemon",
 ]
 

--- a/crates/README.md
+++ b/crates/README.md
@@ -14,6 +14,7 @@ core lands fully tested before any network surface exists.
 | `fae-control-plane` | Transport-free security core: capability scopes, per-command authorization, anti-DNS-rebind `Host`/`Origin` checks, CSPRNG session tokens (hashed at rest, constant-time verify), audit. | **Chunk 1 ✅** (tested) |
 | `fae-envelope-gate` | G5 peer-envelope gate (promoted from `phase0/g5-envelope-gate`, reviewed): typed, closed-`kind`, schema-versioned, signature-checked, audited boundary. No free-form peer text reaches LLM/memory/tools. | **Chunk 1 ✅** (tested) |
 | `fae-engine` | Engine-agnostic inference boundary: `ProviderAdapter` trait (`stream_chat` → Token/ToolCall/Done events) + **fail-closed `models.lock`** SHA-256 loader + `MockAdapter` + **`LocalMistralrsAdapter`** (mistral.rs 0.8, hard dep, Metal/CPU). | **Chunk 3a–b ✅** (tested) |
+| `fae-audio` | Portable cpal voice spine for daemon-side PTT capture/playback: device listing, 16 kHz mono WAV capture output, WAV playback, and deterministic unit-tested WAV/resampling helpers. | **P1 ✅** (macOS live-tested) |
 | `fae-daemon` | Daemon binary. Bootstrap (run dir `0700`, token `0600`) + **Unix-socket NDJSON listener** (default) and an **opt-in TCP-loopback HTTP/WS diagnostic listener** (`FAE_DIAGNOSTIC_TCP_PORT`): per-connection/per-request auth, `Host`/`Origin` enforcement, defensive headers, single-use stream tickets, per-message `authorize`, fail-closed audit. | **Chunk 2 ✅** (live-tested) |
 
 ## Build / test
@@ -42,4 +43,4 @@ just run            # bootstrap + demo authz (no ports opened)
 - **Carried (gate features, not chunks):** adversarial-memory enforcement (W3), supply-chain `models.lock`/signed-updates (W4), peer-tool design, metadata threat-model sign-off. Peer-memory / peer-tool / group paths stay blocked until G5 is enforced in code (+ groups: TreeKEM). CUDA-perf + Gemma-4-12B + same-weights parity = early-Phase-1 tasks on a GPU box.
 
 ## Not yet wired
-Memory (`fae.db` migration — G4), pipeline, skills, scheduler, TTS/STT, Apple tools (`objc2`), x0x — all selective ports/rewrites per the G3 audit, behind this control plane.
+Memory (`fae.db` migration — G4), pipeline, skills, scheduler, Apple tools (`objc2`), x0x — all selective ports/rewrites per the G3 audit, behind this control plane. Daemon TTS and cpal capture/playback are wired as local control-plane commands; Swift still owns the default macOS mic/speaker lane until the portable lane is promoted.

--- a/crates/fae-audio/Cargo.toml
+++ b/crates/fae-audio/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fae-audio"
+version = "0.1.0"
+description = "Portable audio capture/playback spine for fae-daemon."
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+base64 = { workspace = true }
+cpal = "0.15"
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/fae-audio/src/lib.rs
+++ b/crates/fae-audio/src/lib.rs
@@ -43,6 +43,8 @@ pub enum AudioError {
 pub struct AudioDeviceInfo {
     pub inputs: Vec<String>,
     pub outputs: Vec<String>,
+    pub default_input: Option<String>,
+    pub default_output: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -113,11 +115,15 @@ impl AudioManager {
             return AudioDeviceInfo {
                 inputs: Vec::new(),
                 outputs: Vec::new(),
+                default_input: None,
+                default_output: None,
             };
         }
         rx.recv().unwrap_or_else(|_| AudioDeviceInfo {
             inputs: Vec::new(),
             outputs: Vec::new(),
+            default_input: None,
+            default_output: None,
         })
     }
 
@@ -189,9 +195,7 @@ impl AudioWorker {
 
     fn capture_start_impl(&mut self) -> AudioResult<String> {
         let host = cpal::default_host();
-        let device = host
-            .default_input_device()
-            .ok_or(AudioError::NoInputDevice)?;
+        let device = select_input_device(&host)?;
         let supported = device
             .default_input_config()
             .map_err(|error| AudioError::DeviceConfig(error.to_string()))?;
@@ -264,9 +268,10 @@ impl AudioWorker {
             .map_err(|_| AudioError::CaptureStateUnavailable)?
             .clone();
         let mono = resample_linear(&raw, session.input_rate, TARGET_SAMPLE_RATE);
-        let duration_ms = duration_ms(mono.len(), TARGET_SAMPLE_RATE);
+        let normalized = normalize_capture_gain(&mono);
+        let duration_ms = duration_ms(normalized.len(), TARGET_SAMPLE_RATE);
         Ok(CapturedAudio {
-            wav: encode_wav_pcm16(&mono, TARGET_SAMPLE_RATE),
+            wav: encode_wav_pcm16(&normalized, TARGET_SAMPLE_RATE),
             duration_ms,
             sample_rate: TARGET_SAMPLE_RATE,
         })
@@ -292,6 +297,12 @@ impl AudioWorker {
 
 fn devices_impl() -> AudioDeviceInfo {
     let host = cpal::default_host();
+    let default_input = host
+        .default_input_device()
+        .and_then(|device| device.name().ok());
+    let default_output = host
+        .default_output_device()
+        .and_then(|device| device.name().ok());
     let inputs = host
         .input_devices()
         .map(|devices| devices.filter_map(|device| device.name().ok()).collect())
@@ -300,15 +311,71 @@ fn devices_impl() -> AudioDeviceInfo {
         .output_devices()
         .map(|devices| devices.filter_map(|device| device.name().ok()).collect())
         .unwrap_or_default();
-    AudioDeviceInfo { inputs, outputs }
+    AudioDeviceInfo {
+        inputs,
+        outputs,
+        default_input,
+        default_output,
+    }
+}
+
+fn select_input_device(host: &cpal::Host) -> AudioResult<cpal::Device> {
+    select_named_device(
+        host.input_devices(),
+        std::env::var("FAE_AUDIO_INPUT_DEVICE").ok(),
+        AudioError::NoInputDevice,
+    )?
+    .or_else(|| host.default_input_device())
+    .ok_or(AudioError::NoInputDevice)
+}
+
+fn select_output_device(host: &cpal::Host) -> AudioResult<cpal::Device> {
+    select_named_device(
+        host.output_devices(),
+        std::env::var("FAE_AUDIO_OUTPUT_DEVICE").ok(),
+        AudioError::NoOutputDevice,
+    )?
+    .or_else(|| host.default_output_device())
+    .ok_or(AudioError::NoOutputDevice)
+}
+
+fn select_named_device<I>(
+    devices: Result<I, cpal::DevicesError>,
+    requested: Option<String>,
+    missing: AudioError,
+) -> AudioResult<Option<cpal::Device>>
+where
+    I: IntoIterator<Item = cpal::Device>,
+{
+    let Some(requested) = requested.filter(|name| !name.trim().is_empty()) else {
+        return Ok(None);
+    };
+    let requested_lower = requested.to_ascii_lowercase();
+    let devices = devices.map_err(|error| AudioError::DeviceConfig(error.to_string()))?;
+    for device in devices {
+        let name = match device.name() {
+            Ok(name) => name,
+            Err(_) => continue,
+        };
+        if name.to_ascii_lowercase().contains(&requested_lower) {
+            return Ok(Some(device));
+        }
+    }
+    Err(match missing {
+        AudioError::NoInputDevice => {
+            AudioError::DeviceConfig(format!("input device matching '{requested}' not found"))
+        }
+        AudioError::NoOutputDevice => {
+            AudioError::DeviceConfig(format!("output device matching '{requested}' not found"))
+        }
+        other => other,
+    })
 }
 
 fn play_wav_impl(wav: &[u8]) -> AudioResult<u64> {
     let decoded = decode_wav_mono(wav)?;
     let host = cpal::default_host();
-    let device = host
-        .default_output_device()
-        .ok_or(AudioError::NoOutputDevice)?;
+    let device = select_output_device(&host)?;
     let supported = device
         .default_output_config()
         .map_err(|error| AudioError::DeviceConfig(error.to_string()))?;
@@ -612,6 +679,33 @@ fn decode_float32(data: &[u8], channels: usize, sample_rate: u32) -> AudioResult
     })
 }
 
+fn normalize_capture_gain(input: &[f32]) -> Vec<f32> {
+    if input.is_empty() {
+        return Vec::new();
+    }
+    let rms = (input
+        .iter()
+        .map(|sample| f64::from(*sample) * f64::from(*sample))
+        .sum::<f64>()
+        / input.len() as f64)
+        .sqrt() as f32;
+    if rms < 0.001 {
+        return input.to_vec();
+    }
+    let peak = input
+        .iter()
+        .map(|sample| sample.abs())
+        .fold(0.0_f32, f32::max);
+    let target_rms = 0.10_f32;
+    let rms_gain = (target_rms / rms).clamp(1.0, 12.0);
+    let peak_gain = if peak > 0.0 { 0.98 / peak } else { rms_gain };
+    let gain = rms_gain.min(peak_gain.max(1.0));
+    input
+        .iter()
+        .map(|sample| (sample * gain).clamp(-1.0, 1.0))
+        .collect()
+}
+
 fn duration_ms(samples: usize, sample_rate: u32) -> u64 {
     if sample_rate == 0 {
         return 0;
@@ -680,6 +774,32 @@ mod tests {
         }
         worker.reap_captures();
         assert!(worker.captures.is_empty());
+    }
+
+    #[test]
+    fn capture_gain_lifts_quiet_speech_without_clipping() {
+        let quiet: Vec<f32> = (0..16_000)
+            .map(|i| ((i as f32 * 440.0 * std::f32::consts::TAU) / 16_000.0).sin() * 0.01)
+            .collect();
+        let normalized = normalize_capture_gain(&quiet);
+        let rms = (normalized
+            .iter()
+            .map(|sample| f64::from(*sample) * f64::from(*sample))
+            .sum::<f64>()
+            / normalized.len() as f64)
+            .sqrt();
+        let peak = normalized
+            .iter()
+            .map(|sample| sample.abs())
+            .fold(0.0_f32, f32::max);
+        assert!(rms > 0.07, "rms after gain: {rms}");
+        assert!(peak <= 0.98, "peak after gain: {peak}");
+    }
+
+    #[test]
+    fn capture_gain_leaves_near_silence_alone() {
+        let silence = vec![0.0001_f32; 128];
+        assert_eq!(normalize_capture_gain(&silence), silence);
     }
 
     #[test]

--- a/crates/fae-audio/src/lib.rs
+++ b/crates/fae-audio/src/lib.rs
@@ -1,0 +1,689 @@
+//! Portable cpal-backed audio capture/playback for the Fae daemon.
+#![forbid(unsafe_code)]
+#![cfg_attr(
+    not(test),
+    deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
+)]
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{mpsc, Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{SampleFormat, StreamConfig};
+use serde::Serialize;
+
+/// Daemon capture target: S18 push-to-talk WAV payloads are 16 kHz mono f32
+/// internally and 16-bit PCM WAV on the wire.
+pub const TARGET_SAMPLE_RATE: u32 = 16_000;
+const CAPTURE_CAP: Duration = Duration::from_secs(30);
+const REAP_AFTER: Duration = Duration::from_secs(35);
+const WORKER_TICK: Duration = Duration::from_millis(100);
+
+#[derive(Debug, thiserror::Error)]
+pub enum AudioError {
+    #[error("no input device available")]
+    NoInputDevice,
+    #[error("no output device available")]
+    NoOutputDevice,
+    #[error("device configuration failed: {0}")]
+    DeviceConfig(String),
+    #[error("stream failed: {0}")]
+    Stream(String),
+    #[error("capture not found")]
+    CaptureNotFound,
+    #[error("capture state unavailable")]
+    CaptureStateUnavailable,
+    #[error("bad wav: {0}")]
+    BadWav(&'static str),
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AudioDeviceInfo {
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CapturedAudio {
+    pub wav: Vec<u8>,
+    pub duration_ms: u64,
+    pub sample_rate: u32,
+}
+
+type AudioResult<T> = Result<T, AudioError>;
+
+enum AudioRequest {
+    Devices(mpsc::Sender<AudioDeviceInfo>),
+    CaptureStart(mpsc::Sender<AudioResult<String>>),
+    CaptureStop {
+        capture_id: String,
+        reply: mpsc::Sender<AudioResult<CapturedAudio>>,
+    },
+    Play {
+        wav: Vec<u8>,
+        reply: mpsc::Sender<AudioResult<u64>>,
+    },
+}
+
+struct CaptureSession {
+    samples: Arc<Mutex<Vec<f32>>>,
+    stream: Option<cpal::Stream>,
+    input_rate: u32,
+    started: Instant,
+    finished_at: Option<Instant>,
+}
+
+/// Shared daemon audio manager. Public methods are thread-safe; all cpal
+/// streams live on a dedicated worker thread because CoreAudio streams are not
+/// `Send` on macOS.
+pub struct AudioManager {
+    tx: mpsc::Sender<AudioRequest>,
+}
+
+impl Default for AudioManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AudioManager {
+    #[must_use]
+    pub fn new() -> AudioManager {
+        Self::new_with_cap(CAPTURE_CAP)
+    }
+
+    fn new_with_cap(capture_cap: Duration) -> AudioManager {
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let worker = AudioWorker {
+                captures: HashMap::new(),
+                next_id: AtomicU64::new(1),
+                capture_cap,
+            };
+            worker.run(rx);
+        });
+        AudioManager { tx }
+    }
+
+    pub fn devices(&self) -> AudioDeviceInfo {
+        let (reply, rx) = mpsc::channel();
+        if self.tx.send(AudioRequest::Devices(reply)).is_err() {
+            return AudioDeviceInfo {
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+            };
+        }
+        rx.recv().unwrap_or_else(|_| AudioDeviceInfo {
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+        })
+    }
+
+    pub fn capture_start(&self) -> AudioResult<String> {
+        let (reply, rx) = mpsc::channel();
+        self.tx
+            .send(AudioRequest::CaptureStart(reply))
+            .map_err(|_| AudioError::CaptureStateUnavailable)?;
+        rx.recv().map_err(|_| AudioError::CaptureStateUnavailable)?
+    }
+
+    pub fn capture_stop(&self, capture_id: &str) -> AudioResult<CapturedAudio> {
+        let (reply, rx) = mpsc::channel();
+        self.tx
+            .send(AudioRequest::CaptureStop {
+                capture_id: capture_id.to_owned(),
+                reply,
+            })
+            .map_err(|_| AudioError::CaptureStateUnavailable)?;
+        rx.recv().map_err(|_| AudioError::CaptureStateUnavailable)?
+    }
+
+    pub fn play_wav(&self, wav: &[u8]) -> AudioResult<u64> {
+        let (reply, rx) = mpsc::channel();
+        self.tx
+            .send(AudioRequest::Play {
+                wav: wav.to_vec(),
+                reply,
+            })
+            .map_err(|_| AudioError::CaptureStateUnavailable)?;
+        rx.recv().map_err(|_| AudioError::CaptureStateUnavailable)?
+    }
+}
+
+struct AudioWorker {
+    captures: HashMap<String, CaptureSession>,
+    next_id: AtomicU64,
+    capture_cap: Duration,
+}
+
+impl AudioWorker {
+    fn run(mut self, rx: mpsc::Receiver<AudioRequest>) {
+        loop {
+            self.reap_captures();
+            match rx.recv_timeout(WORKER_TICK) {
+                Ok(request) => self.handle(request),
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+    }
+
+    fn handle(&mut self, request: AudioRequest) {
+        match request {
+            AudioRequest::Devices(reply) => {
+                let _ = reply.send(devices_impl());
+            }
+            AudioRequest::CaptureStart(reply) => {
+                let _ = reply.send(self.capture_start_impl());
+            }
+            AudioRequest::CaptureStop { capture_id, reply } => {
+                let _ = reply.send(self.capture_stop_impl(&capture_id));
+            }
+            AudioRequest::Play { wav, reply } => {
+                let _ = reply.send(play_wav_impl(&wav));
+            }
+        }
+    }
+
+    fn capture_start_impl(&mut self) -> AudioResult<String> {
+        let host = cpal::default_host();
+        let device = host
+            .default_input_device()
+            .ok_or(AudioError::NoInputDevice)?;
+        let supported = device
+            .default_input_config()
+            .map_err(|error| AudioError::DeviceConfig(error.to_string()))?;
+        let input_rate = supported.sample_rate().0;
+        let config: StreamConfig = supported.clone().into();
+        let channels = usize::from(config.channels);
+        let samples = Arc::new(Mutex::new(Vec::<f32>::new()));
+        let err_fn = |error| eprintln!("fae-audio: input stream error: {error}");
+        let stream = match supported.sample_format() {
+            SampleFormat::F32 => {
+                let target = Arc::clone(&samples);
+                device.build_input_stream(
+                    &config,
+                    move |data: &[f32], _| append_interleaved_f32(&target, data, channels),
+                    err_fn,
+                    None,
+                )
+            }
+            SampleFormat::I16 => {
+                let target = Arc::clone(&samples);
+                device.build_input_stream(
+                    &config,
+                    move |data: &[i16], _| append_interleaved_i16(&target, data, channels),
+                    err_fn,
+                    None,
+                )
+            }
+            SampleFormat::U16 => {
+                let target = Arc::clone(&samples);
+                device.build_input_stream(
+                    &config,
+                    move |data: &[u16], _| append_interleaved_u16(&target, data, channels),
+                    err_fn,
+                    None,
+                )
+            }
+            other => {
+                return Err(AudioError::DeviceConfig(format!(
+                    "unsupported input format {other:?}"
+                )))
+            }
+        }
+        .map_err(|error| AudioError::Stream(error.to_string()))?;
+        stream
+            .play()
+            .map_err(|error| AudioError::Stream(error.to_string()))?;
+        let id = format!("cap-{}", self.next_id.fetch_add(1, Ordering::Relaxed));
+        self.captures.insert(
+            id.clone(),
+            CaptureSession {
+                samples,
+                stream: Some(stream),
+                input_rate,
+                started: Instant::now(),
+                finished_at: None,
+            },
+        );
+        Ok(id)
+    }
+
+    fn capture_stop_impl(&mut self, capture_id: &str) -> AudioResult<CapturedAudio> {
+        let session = self
+            .captures
+            .remove(capture_id)
+            .ok_or(AudioError::CaptureNotFound)?;
+        drop(session.stream);
+        let raw = session
+            .samples
+            .lock()
+            .map_err(|_| AudioError::CaptureStateUnavailable)?
+            .clone();
+        let mono = resample_linear(&raw, session.input_rate, TARGET_SAMPLE_RATE);
+        let duration_ms = duration_ms(mono.len(), TARGET_SAMPLE_RATE);
+        Ok(CapturedAudio {
+            wav: encode_wav_pcm16(&mono, TARGET_SAMPLE_RATE),
+            duration_ms,
+            sample_rate: TARGET_SAMPLE_RATE,
+        })
+    }
+
+    fn reap_captures(&mut self) {
+        let now = Instant::now();
+        for session in self.captures.values_mut() {
+            if session.finished_at.is_none()
+                && now.duration_since(session.started) >= self.capture_cap
+            {
+                session.stream = None;
+                session.finished_at = Some(now);
+            }
+        }
+        self.captures.retain(|_, session| {
+            session
+                .finished_at
+                .is_none_or(|finished| now.duration_since(finished) <= REAP_AFTER)
+        });
+    }
+}
+
+fn devices_impl() -> AudioDeviceInfo {
+    let host = cpal::default_host();
+    let inputs = host
+        .input_devices()
+        .map(|devices| devices.filter_map(|device| device.name().ok()).collect())
+        .unwrap_or_default();
+    let outputs = host
+        .output_devices()
+        .map(|devices| devices.filter_map(|device| device.name().ok()).collect())
+        .unwrap_or_default();
+    AudioDeviceInfo { inputs, outputs }
+}
+
+fn play_wav_impl(wav: &[u8]) -> AudioResult<u64> {
+    let decoded = decode_wav_mono(wav)?;
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or(AudioError::NoOutputDevice)?;
+    let supported = device
+        .default_output_config()
+        .map_err(|error| AudioError::DeviceConfig(error.to_string()))?;
+    let output_rate = supported.sample_rate().0;
+    let samples = if decoded.sample_rate == output_rate {
+        decoded.samples
+    } else {
+        resample_linear(&decoded.samples, decoded.sample_rate, output_rate)
+    };
+    let played_ms = duration_ms(samples.len(), output_rate);
+    let config: StreamConfig = supported.clone().into();
+    let channels = usize::from(config.channels);
+    let index = Arc::new(AtomicU64::new(0));
+    let done = Arc::new(std::sync::atomic::AtomicBool::new(samples.is_empty()));
+    let samples = Arc::new(samples);
+    let err_fn = |error| eprintln!("fae-audio: output stream error: {error}");
+    let stream = match supported.sample_format() {
+        SampleFormat::F32 => {
+            build_output_stream::<f32>(&device, &config, channels, &samples, &index, &done, err_fn)
+        }
+        SampleFormat::I16 => {
+            build_output_stream::<i16>(&device, &config, channels, &samples, &index, &done, err_fn)
+        }
+        SampleFormat::U16 => {
+            build_output_stream::<u16>(&device, &config, channels, &samples, &index, &done, err_fn)
+        }
+        other => {
+            return Err(AudioError::DeviceConfig(format!(
+                "unsupported output format {other:?}"
+            )))
+        }
+    }
+    .map_err(|error| AudioError::Stream(error.to_string()))?;
+    stream
+        .play()
+        .map_err(|error| AudioError::Stream(error.to_string()))?;
+    while !done.load(Ordering::Relaxed) {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    std::thread::sleep(Duration::from_millis(25));
+    drop(stream);
+    Ok(played_ms)
+}
+
+fn append_interleaved_f32(target: &Arc<Mutex<Vec<f32>>>, data: &[f32], channels: usize) {
+    append_interleaved(
+        target,
+        data.chunks(channels)
+            .map(|frame| average_f32(frame.iter().copied())),
+    );
+}
+
+fn append_interleaved_i16(target: &Arc<Mutex<Vec<f32>>>, data: &[i16], channels: usize) {
+    append_interleaved(
+        target,
+        data.chunks(channels)
+            .map(|frame| average_f32(frame.iter().map(|sample| f32::from(*sample) / 32768.0))),
+    );
+}
+
+fn append_interleaved_u16(target: &Arc<Mutex<Vec<f32>>>, data: &[u16], channels: usize) {
+    append_interleaved(
+        target,
+        data.chunks(channels).map(|frame| {
+            average_f32(
+                frame
+                    .iter()
+                    .map(|sample| (f32::from(*sample) - 32768.0) / 32768.0),
+            )
+        }),
+    );
+}
+
+fn append_interleaved<I>(target: &Arc<Mutex<Vec<f32>>>, frames: I)
+where
+    I: Iterator<Item = f32>,
+{
+    if let Ok(mut samples) = target.lock() {
+        samples.extend(frames.map(|sample| sample.clamp(-1.0, 1.0)));
+    }
+}
+
+fn average_f32<I>(values: I) -> f32
+where
+    I: IntoIterator<Item = f32>,
+{
+    let mut sum = 0.0_f32;
+    let mut count = 0_u32;
+    for value in values {
+        sum += value;
+        count = count.saturating_add(1);
+    }
+    if count == 0 {
+        0.0
+    } else {
+        sum / count as f32
+    }
+}
+
+fn build_output_stream<T>(
+    device: &cpal::Device,
+    config: &StreamConfig,
+    channels: usize,
+    samples: &Arc<Vec<f32>>,
+    index: &Arc<AtomicU64>,
+    done: &Arc<std::sync::atomic::AtomicBool>,
+    err_fn: impl FnMut(cpal::StreamError) + Send + 'static,
+) -> Result<cpal::Stream, cpal::BuildStreamError>
+where
+    T: cpal::Sample + cpal::SizedSample + FromF32Sample,
+{
+    let samples = Arc::clone(samples);
+    let index = Arc::clone(index);
+    let done = Arc::clone(done);
+    device.build_output_stream(
+        config,
+        move |output: &mut [T], _| {
+            for frame in output.chunks_mut(channels) {
+                let sample_index = index.fetch_add(1, Ordering::Relaxed) as usize;
+                let value = samples.get(sample_index).copied().unwrap_or(0.0);
+                if sample_index >= samples.len() {
+                    done.store(true, Ordering::Relaxed);
+                }
+                for out in frame {
+                    *out = T::from_f32_sample(value);
+                }
+            }
+        },
+        err_fn,
+        None,
+    )
+}
+
+trait FromF32Sample {
+    fn from_f32_sample(value: f32) -> Self;
+}
+
+impl FromF32Sample for f32 {
+    fn from_f32_sample(value: f32) -> Self {
+        value.clamp(-1.0, 1.0)
+    }
+}
+
+impl FromF32Sample for i16 {
+    fn from_f32_sample(value: f32) -> Self {
+        #[allow(clippy::cast_possible_truncation)]
+        let scaled = (value.clamp(-1.0, 1.0) * 32767.0).round() as i16;
+        scaled
+    }
+}
+
+impl FromF32Sample for u16 {
+    fn from_f32_sample(value: f32) -> Self {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let scaled = ((value.clamp(-1.0, 1.0) * 32767.0) + 32768.0).round() as u16;
+        scaled
+    }
+}
+
+#[must_use]
+pub fn resample_linear(input: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
+    if input.is_empty() || from_rate == 0 || to_rate == 0 {
+        return Vec::new();
+    }
+    if from_rate == to_rate {
+        return input.to_vec();
+    }
+    let out_len_u64 = (input.len() as u64)
+        .saturating_mul(u64::from(to_rate))
+        .div_ceil(u64::from(from_rate));
+    let out_len = usize::try_from(out_len_u64)
+        .unwrap_or(usize::MAX)
+        .min(usize::MAX / 2);
+    let ratio = from_rate as f64 / to_rate as f64;
+    let mut output = Vec::with_capacity(out_len);
+    for i in 0..out_len {
+        let src = i as f64 * ratio;
+        let left = src.floor() as usize;
+        let frac = (src - left as f64) as f32;
+        let a = input.get(left).copied().unwrap_or(0.0);
+        let b = input.get(left.saturating_add(1)).copied().unwrap_or(a);
+        output.push(a.mul_add(1.0 - frac, b * frac));
+    }
+    output
+}
+
+#[must_use]
+pub fn encode_wav_pcm16(samples: &[f32], sample_rate: u32) -> Vec<u8> {
+    let data_len = (samples.len() * 2) as u32;
+    let mut wav = Vec::with_capacity(44 + samples.len() * 2);
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&(36 + data_len).to_le_bytes());
+    wav.extend_from_slice(b"WAVE");
+    wav.extend_from_slice(b"fmt ");
+    wav.extend_from_slice(&16u32.to_le_bytes());
+    wav.extend_from_slice(&1u16.to_le_bytes());
+    wav.extend_from_slice(&1u16.to_le_bytes());
+    wav.extend_from_slice(&sample_rate.to_le_bytes());
+    wav.extend_from_slice(&(sample_rate * 2).to_le_bytes());
+    wav.extend_from_slice(&2u16.to_le_bytes());
+    wav.extend_from_slice(&16u16.to_le_bytes());
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&data_len.to_le_bytes());
+    for &sample in samples {
+        let clamped = sample.clamp(-1.0, 1.0);
+        #[allow(clippy::cast_possible_truncation)]
+        let value = (clamped * 32768.0).round().clamp(-32768.0, 32767.0) as i16;
+        wav.extend_from_slice(&value.to_le_bytes());
+    }
+    wav
+}
+
+struct DecodedWav {
+    samples: Vec<f32>,
+    sample_rate: u32,
+}
+
+fn decode_wav_mono(wav: &[u8]) -> AudioResult<DecodedWav> {
+    if wav.len() < 44 || &wav[0..4] != b"RIFF" || &wav[8..12] != b"WAVE" {
+        return Err(AudioError::BadWav("missing RIFF/WAVE header"));
+    }
+    let mut offset = 12_usize;
+    let mut fmt: Option<(u16, u16, u32, u16)> = None;
+    let mut data: Option<&[u8]> = None;
+    while offset.saturating_add(8) <= wav.len() {
+        let id = &wav[offset..offset + 4];
+        let size = u32::from_le_bytes([
+            wav[offset + 4],
+            wav[offset + 5],
+            wav[offset + 6],
+            wav[offset + 7],
+        ]) as usize;
+        offset = offset.saturating_add(8);
+        if offset.saturating_add(size) > wav.len() {
+            return Err(AudioError::BadWav("chunk exceeds file length"));
+        }
+        let chunk = &wav[offset..offset + size];
+        if id == b"fmt " {
+            if chunk.len() < 16 {
+                return Err(AudioError::BadWav("short fmt chunk"));
+            }
+            let format = u16::from_le_bytes([chunk[0], chunk[1]]);
+            let channels = u16::from_le_bytes([chunk[2], chunk[3]]);
+            let sample_rate = u32::from_le_bytes([chunk[4], chunk[5], chunk[6], chunk[7]]);
+            let bits = u16::from_le_bytes([chunk[14], chunk[15]]);
+            fmt = Some((format, channels, sample_rate, bits));
+        } else if id == b"data" {
+            data = Some(chunk);
+        }
+        offset = offset.saturating_add(size + (size % 2));
+    }
+    let (format, channels, sample_rate, bits) =
+        fmt.ok_or(AudioError::BadWav("missing fmt chunk"))?;
+    let data = data.ok_or(AudioError::BadWav("missing data chunk"))?;
+    if channels == 0 {
+        return Err(AudioError::BadWav("zero channels"));
+    }
+    match (format, bits) {
+        (1, 16) => decode_pcm16(data, usize::from(channels), sample_rate),
+        (3, 32) => decode_float32(data, usize::from(channels), sample_rate),
+        _ => Err(AudioError::BadWav("unsupported wav format")),
+    }
+}
+
+fn decode_pcm16(data: &[u8], channels: usize, sample_rate: u32) -> AudioResult<DecodedWav> {
+    let frame_bytes = channels.saturating_mul(2);
+    if frame_bytes == 0 || data.len() % frame_bytes != 0 {
+        return Err(AudioError::BadWav("misaligned pcm data"));
+    }
+    let mut samples = Vec::with_capacity(data.len() / frame_bytes);
+    for frame in data.chunks(frame_bytes) {
+        let mut sum = 0.0_f32;
+        for chunk in frame.chunks_exact(2) {
+            let value = i16::from_le_bytes([chunk[0], chunk[1]]);
+            sum += f32::from(value) / 32768.0;
+        }
+        samples.push(sum / channels as f32);
+    }
+    Ok(DecodedWav {
+        samples,
+        sample_rate,
+    })
+}
+
+fn decode_float32(data: &[u8], channels: usize, sample_rate: u32) -> AudioResult<DecodedWav> {
+    let frame_bytes = channels.saturating_mul(4);
+    if frame_bytes == 0 || data.len() % frame_bytes != 0 {
+        return Err(AudioError::BadWav("misaligned float data"));
+    }
+    let mut samples = Vec::with_capacity(data.len() / frame_bytes);
+    for frame in data.chunks(frame_bytes) {
+        let mut sum = 0.0_f32;
+        for chunk in frame.chunks_exact(4) {
+            sum += f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        }
+        samples.push((sum / channels as f32).clamp(-1.0, 1.0));
+    }
+    Ok(DecodedWav {
+        samples,
+        sample_rate,
+    })
+}
+
+fn duration_ms(samples: usize, sample_rate: u32) -> u64 {
+    if sample_rate == 0 {
+        return 0;
+    }
+    (samples as u64).saturating_mul(1_000) / u64::from(sample_rate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wav_encode_round_trip() -> Result<(), AudioError> {
+        let samples = [-1.0, -0.25, 0.0, 0.25, 1.0];
+        let wav = encode_wav_pcm16(&samples, TARGET_SAMPLE_RATE);
+        let decoded = decode_wav_mono(&wav)?;
+        assert_eq!(decoded.sample_rate, TARGET_SAMPLE_RATE);
+        assert_eq!(decoded.samples.len(), samples.len());
+        for (actual, expected) in decoded.samples.iter().zip(samples) {
+            assert!((actual - expected).abs() < 0.0001);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn resample_48k_to_16k_preserves_sine_frequency() {
+        let input_rate = 48_000_u32;
+        let target_rate = 16_000_u32;
+        let freq = 440.0_f32;
+        let input: Vec<f32> = (0..input_rate)
+            .map(|i| ((i as f32 * freq * std::f32::consts::TAU) / input_rate as f32).sin())
+            .collect();
+        let output = resample_linear(&input, input_rate, target_rate);
+        let crossings = output
+            .windows(2)
+            .filter(|pair| pair[0] <= 0.0 && pair[1] > 0.0)
+            .count();
+        assert!((i64::try_from(crossings).unwrap_or(0) - 440).abs() <= 1);
+    }
+
+    #[test]
+    fn capture_cap_reaping_marks_then_removes_finished_sessions() {
+        let mut worker = AudioWorker {
+            captures: HashMap::new(),
+            next_id: AtomicU64::new(1),
+            capture_cap: Duration::from_millis(1),
+        };
+        worker.captures.insert(
+            "old".to_owned(),
+            CaptureSession {
+                samples: Arc::new(Mutex::new(Vec::new())),
+                stream: None,
+                input_rate: TARGET_SAMPLE_RATE,
+                started: Instant::now() - Duration::from_secs(60),
+                finished_at: None,
+            },
+        );
+        worker.reap_captures();
+        assert!(worker
+            .captures
+            .get("old")
+            .and_then(|session| session.finished_at)
+            .is_some());
+        if let Some(session) = worker.captures.get_mut("old") {
+            session.finished_at = Some(Instant::now() - REAP_AFTER - Duration::from_secs(1));
+        }
+        worker.reap_captures();
+        assert!(worker.captures.is_empty());
+    }
+
+    #[test]
+    fn bad_wav_is_rejected() {
+        assert!(decode_wav_mono(b"not a wav").is_err());
+    }
+}

--- a/crates/fae-control-plane/src/lib.rs
+++ b/crates/fae-control-plane/src/lib.rs
@@ -187,8 +187,12 @@ pub fn required_scopes(command: &str) -> Option<&'static [Scope]> {
         "host.ping" | "host.version" | "runtime.status" => &[Scope::StatusRead],
         "conversation.inject_text" => &[Scope::ConversationWrite],
         "conversation.subscribe" => &[Scope::ConversationRead],
-        "audio.start_capture" | "audio.stop_capture" => &[Scope::AudioCapture],
-        "audio.playback_control" => &[Scope::AudioPlayback],
+        "audio.capture_start"
+        | "audio.capture_stop"
+        | "audio.start_capture"
+        | "audio.stop_capture" => &[Scope::AudioCapture],
+        "audio.devices" => &[Scope::StatusRead],
+        "audio.play" | "audio.playback_control" => &[Scope::AudioPlayback],
         // S19: daemon-side Kokoro TTS — synthesis produces playback audio.
         "tts.synthesize" => &[Scope::AudioPlayback],
         "memory.search" => &[Scope::MemoryRead],
@@ -228,6 +232,7 @@ impl ClientClass {
                     Scope::StatusRead,
                     Scope::ConversationWrite,
                     Scope::ConversationRead,
+                    Scope::AudioCapture,
                     Scope::AudioPlayback,
                 ]
             }
@@ -805,6 +810,41 @@ mod tests {
     }
 
     #[test]
+    fn audio_commands_use_capture_playback_and_status_scopes() {
+        let capture = client(&[Scope::AudioCapture], 1000, None);
+        assert_eq!(
+            authorize(&capture, &cmd("audio.capture_start"), 10),
+            AuthzDecision::Allow
+        );
+        assert_eq!(
+            authorize(&capture, &cmd("audio.capture_stop"), 10),
+            AuthzDecision::Allow
+        );
+        assert_eq!(
+            authorize(&capture, &cmd("audio.play"), 10),
+            AuthzDecision::Deny(DenyReason::MissingScope)
+        );
+        assert_eq!(
+            authorize(&capture, &cmd("audio.start_capture"), 10),
+            AuthzDecision::Allow
+        );
+        let playback = client(&[Scope::AudioPlayback], 1000, None);
+        assert_eq!(
+            authorize(&playback, &cmd("audio.play"), 10),
+            AuthzDecision::Allow
+        );
+        assert_eq!(
+            authorize(&playback, &cmd("audio.playback_control"), 10),
+            AuthzDecision::Allow
+        );
+        let status = client(&[Scope::StatusRead], 1000, None);
+        assert_eq!(
+            authorize(&status, &cmd("audio.devices"), 10),
+            AuthzDecision::Allow
+        );
+    }
+
+    #[test]
     fn host_validation_rejects_rebind_and_lan() {
         assert!(host_header_allowed("127.0.0.1:12700", 12700));
         assert!(host_header_allowed("[::1]:12700", 12700));
@@ -1023,13 +1063,13 @@ mod tests {
     }
 
     #[test]
-    fn default_scopes_are_conservative() {
+    fn default_scopes_include_frontend_voice_lane_but_not_sensitive_tools() {
         assert!(ClientClass::X0xPeerBridge.default_scopes().is_empty());
-        assert!(!ClientClass::SwiftFrontend
-            .default_scopes()
-            .contains(&Scope::AudioCapture));
-        assert!(ClientClass::SwiftFrontend
-            .default_scopes()
-            .contains(&Scope::ConversationWrite));
+        let frontend = ClientClass::SwiftFrontend.default_scopes();
+        assert!(frontend.contains(&Scope::AudioCapture));
+        assert!(frontend.contains(&Scope::AudioPlayback));
+        assert!(frontend.contains(&Scope::ConversationWrite));
+        assert!(!frontend.contains(&Scope::ToolExecuteDangerous));
+        assert!(!frontend.contains(&Scope::MemoryWrite));
     }
 }

--- a/crates/fae-daemon/Cargo.toml
+++ b/crates/fae-daemon/Cargo.toml
@@ -12,6 +12,7 @@ name = "fae-daemon"
 path = "src/main.rs"
 
 [dependencies]
+fae-audio = { path = "../fae-audio" }
 fae-control-plane = { path = "../fae-control-plane" }
 fae-envelope-gate = { path = "../fae-envelope-gate" }
 fae-engine = { path = "../fae-engine" }

--- a/crates/fae-daemon/scripts/fae_audio_repro.py
+++ b/crates/fae-daemon/scripts/fae_audio_repro.py
@@ -101,6 +101,13 @@ def main() -> int:
         client.command(
             "conversation.inject_text",
             {
+                "system": (
+                    "The next user message contains an audio clip and "
+                    "intentionally has empty text content. You MUST listen to "
+                    "the attached WAV audio, transcribe the speech, and output "
+                    "exactly one line beginning '[heard]: ' followed by the "
+                    "transcript. Do not output an empty string."
+                ),
                 "messages": [
                     {
                         "role": "user",

--- a/crates/fae-daemon/scripts/fae_audio_repro.py
+++ b/crates/fae-daemon/scripts/fae_audio_repro.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Live repro for fae-daemon audio NDJSON commands.
+
+Starts after fae-daemon is already running. Reads bootstrap token from the
+selected HOME/data dir, then runs:
+  authenticate -> audio.devices -> capture_start -> sleep -> capture_stop
+  -> save WAV -> audio.play -> conversation.inject_text(audio) -> tts.synthesize
+  -> audio.play(tts)
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import socket
+import sys
+import time
+import wave
+from pathlib import Path
+
+PROTOCOL_VERSION = 2
+CLIENT_ID = "swift-frontend-bootstrap"
+
+
+def data_run_dir(home: Path) -> Path:
+    if sys.platform == "darwin":
+        return home / "Library" / "Application Support" / "fae" / "run"
+    return Path(os.environ.get("XDG_DATA_HOME", home / ".local" / "share")) / "fae" / "run"
+
+
+class Client:
+    def __init__(self, socket_path: Path):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(str(socket_path))
+        self.file = self.sock.makefile("rwb", buffering=0)
+        self.next_id = 1
+
+    def command(self, command: str, payload: dict | None = None) -> dict:
+        request_id = f"r{self.next_id}"
+        self.next_id += 1
+        frame = {
+            "v": PROTOCOL_VERSION,
+            "request_id": request_id,
+            "command": command,
+            "payload": payload or {},
+        }
+        self.file.write((json.dumps(frame) + "\n").encode())
+        line = self.file.readline()
+        if not line:
+            raise RuntimeError("daemon closed socket")
+        response = json.loads(line)
+        print(f"{command} -> {json.dumps(response, sort_keys=True)[:900]}")
+        return response
+
+
+def require_ok(response: dict) -> dict:
+    if not response.get("ok"):
+        raise RuntimeError(response)
+    return response.get("result") or {}
+
+
+def validate_wav(path: Path) -> None:
+    with wave.open(str(path), "rb") as wav:
+        print(
+            "saved_wav -> "
+            f"channels={wav.getnchannels()} rate={wav.getframerate()} "
+            f"frames={wav.getnframes()} duration={wav.getnframes() / wav.getframerate():.3f}s"
+        )
+        if wav.getnchannels() != 1 or wav.getframerate() != 16_000:
+            raise RuntimeError("captured WAV is not 16 kHz mono")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--home", default=os.environ.get("HOME", ""))
+    parser.add_argument("--out", default="/tmp/fae-cpal-capture.wav")
+    parser.add_argument("--capture-seconds", type=float, default=3.0)
+    args = parser.parse_args()
+
+    home = Path(args.home).expanduser()
+    run_dir = data_run_dir(home)
+    token = (run_dir / "bootstrap.token").read_text().strip()
+    client = Client(run_dir / "fae-daemon.sock")
+    require_ok(
+        client.command(
+            "session.authenticate", {"client_id": CLIENT_ID, "token": token}
+        )
+    )
+    require_ok(client.command("audio.devices"))
+    capture_id = require_ok(client.command("audio.capture_start"))["capture_id"]
+    print(f"Speak now for {args.capture_seconds:.1f}s...")
+    time.sleep(args.capture_seconds)
+    captured = require_ok(client.command("audio.capture_stop", {"capture_id": capture_id}))
+    wav_bytes = base64.b64decode(captured["wav_base64"])
+    out = Path(args.out)
+    out.write_bytes(wav_bytes)
+    validate_wav(out)
+    require_ok(client.command("audio.play", {"wav_base64": captured["wav_base64"]}))
+    heard = require_ok(
+        client.command(
+            "conversation.inject_text",
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "",
+                        "audio_wav_base64": captured["wav_base64"],
+                    }
+                ],
+                "max_tokens": 128,
+            },
+        )
+    )
+    print(f"heard_turn -> {json.dumps(heard, sort_keys=True)}")
+    tts = require_ok(client.command("tts.synthesize", {"text": heard.get("text", "hello")}))
+    require_ok(client.command("audio.play", {"wav_base64": tts["wav_base64"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/fae-daemon/src/diagnostic.rs
+++ b/crates/fae-daemon/src/diagnostic.rs
@@ -15,6 +15,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use fae_audio::AudioManager;
 use fae_control_plane::{
     append_audit_jsonl, host_header_allowed, origin_allowed, AuditDecision, AuditEvent, AuthError,
     ClientRecord, ClientRegistry, ConsumedTicket, Response as CpResponse, Scope, TicketStore,
@@ -31,7 +32,7 @@ use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::WebSocketStream;
 
-use crate::session::{handle_frame, session_from_ticket, SessionState};
+use crate::session::{handle_frame, session_from_ticket, SessionBackends, SessionState};
 use crate::{next_event_id, now_ms};
 
 /// WS stream endpoints live under this prefix; the full path is the ticket's
@@ -53,6 +54,7 @@ pub struct DiagnosticState {
     pub registry: Arc<ClientRegistry>,
     pub engine: Arc<dyn ProviderAdapter>,
     pub tts: Arc<dyn TtsAdapter>,
+    pub audio: Arc<AudioManager>,
     pub tickets: Arc<Mutex<TicketStore>>,
     pub audit_path: PathBuf,
     pub port: u16,
@@ -399,6 +401,7 @@ async fn handle_ws(stream: TcpStream, state: Arc<DiagnosticState>) -> std::io::R
         &state.registry,
         state.engine.as_ref(),
         state.tts.as_ref(),
+        state.audio.as_ref(),
         &state.audit_path,
     )
     .await
@@ -410,6 +413,7 @@ async fn ws_message_loop(
     registry: &ClientRegistry,
     engine: &dyn ProviderAdapter,
     tts: &dyn TtsAdapter,
+    audio: &AudioManager,
     audit_path: &Path,
 ) -> std::io::Result<()> {
     while let Some(message) = ws.next().await {
@@ -424,7 +428,8 @@ async fn ws_message_loop(
         }
         let now = now_ms();
         let event_id = next_event_id(now);
-        let outcome = handle_frame(registry, engine, tts, &mut session, line, now, event_id).await;
+        let backends = SessionBackends { engine, tts, audio };
+        let outcome = handle_frame(registry, &backends, &mut session, line, now, event_id).await;
 
         // Same fail-closed audit contract as the Unix socket: no response before
         // the frame is durably audited.

--- a/crates/fae-daemon/src/main.rs
+++ b/crates/fae-daemon/src/main.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use fae_audio::AudioManager;
 use fae_control_plane::{
     generate_token, hash_token, ClientClass, ClientRecord, ClientRegistry, TicketStore,
     PROTOCOL_VERSION,
@@ -79,6 +80,7 @@ async fn main() -> DaemonResult<()> {
     let tts = build_tts_engine();
     let tts_info = tts.describe();
     println!("tts     : {} ({})", tts_info.backend, tts_info.model_id);
+    let audio = Arc::new(AudioManager::new());
     println!("audit   : {} (jsonl)", audit_path.display());
     println!("client  : authenticate with {{\"command\":\"session.authenticate\",\"payload\":{{\"client_id\":\"swift-frontend-bootstrap\",\"token\":<file>}}}}");
 
@@ -88,6 +90,7 @@ async fn main() -> DaemonResult<()> {
             registry: Arc::clone(&registry),
             engine: Arc::clone(&engine),
             tts: Arc::clone(&tts),
+            audio: Arc::clone(&audio),
             tickets: Arc::clone(&tickets),
             audit_path: audit_path.clone(),
             port,
@@ -102,7 +105,7 @@ async fn main() -> DaemonResult<()> {
     println!();
 
     // Serves until the process is killed. Fails closed on bind/permission error.
-    transport::serve_unix(socket_path, registry, engine, tts, audit_path).await?;
+    transport::serve_unix(socket_path, registry, engine, tts, audio, audit_path).await?;
     Ok(())
 }
 

--- a/crates/fae-daemon/src/session.rs
+++ b/crates/fae-daemon/src/session.rs
@@ -6,6 +6,7 @@
 //! live here so the whole frame lifecycle is unit-testable without a socket —
 //! the same control-plane-first discipline the workspace was built on.
 
+use fae_audio::AudioManager;
 use fae_control_plane::{
     authorize, AuditDecision, AuditEvent, AuthzDecision, ClientRecord, ClientRegistry, Command,
     ConsumedTicket, Response, AUTHENTICATE_COMMAND, PROTOCOL_VERSION,
@@ -23,6 +24,13 @@ const DAEMON_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub enum SessionState {
     Unauthenticated,
     Authenticated(ClientRecord),
+}
+
+/// Runtime backends used by command dispatch.
+pub struct SessionBackends<'a> {
+    pub engine: &'a dyn ProviderAdapter,
+    pub tts: &'a dyn TtsAdapter,
+    pub audio: &'a AudioManager,
 }
 
 /// The `session.authenticate` payload.
@@ -46,8 +54,7 @@ pub struct FrameOutcome {
 /// `tts.synthesize`; all other commands ignore them.
 pub async fn handle_frame(
     registry: &ClientRegistry,
-    engine: &dyn ProviderAdapter,
-    tts: &dyn TtsAdapter,
+    backends: &SessionBackends<'_>,
     state: &mut SessionState,
     line: &str,
     now_ms: u64,
@@ -78,7 +85,7 @@ pub async fn handle_frame(
             // Clone the record out so we no longer borrow `state`; the session
             // is already established and never mutated by a command frame.
             let record = record.clone();
-            handle_command(engine, tts, &record, &cmd, now_ms, event_id).await
+            handle_command(backends, &record, &cmd, now_ms, event_id).await
         }
     }
 }
@@ -208,8 +215,7 @@ fn handle_auth(
 }
 
 async fn handle_command(
-    engine: &dyn ProviderAdapter,
-    tts: &dyn TtsAdapter,
+    backends: &SessionBackends<'_>,
     record: &ClientRecord,
     cmd: &Command,
     now_ms: u64,
@@ -247,7 +253,7 @@ async fn handle_command(
         // shell persists `audit` before writing this response, so nothing is
         // observable pre-audit. When mutating commands land, their side effect
         // MUST move behind the audit write in the shell.
-        AuthzDecision::Allow => match dispatch(engine, tts, cmd).await {
+        AuthzDecision::Allow => match dispatch(backends, cmd).await {
             Ok(result) => Response::ok(&cmd.request_id, result),
             Err(code) => Response::error(&cmd.request_id, code, "command could not be completed"),
         },
@@ -271,8 +277,7 @@ async fn handle_command(
 /// `conversation.inject_text` through the engine (chunk 3c). Everything else is
 /// authorized-but-unimplemented (fail loud, not a silent success).
 async fn dispatch(
-    engine: &dyn ProviderAdapter,
-    tts: &dyn TtsAdapter,
+    backends: &SessionBackends<'_>,
     cmd: &Command,
 ) -> Result<serde_json::Value, &'static str> {
     match cmd.command.as_str() {
@@ -281,18 +286,73 @@ async fn dispatch(
             Ok(serde_json::json!({ "version": DAEMON_VERSION, "protocol": PROTOCOL_VERSION }))
         }
         "runtime.status" => {
-            let info = engine.describe();
-            let tts_info = tts.describe();
+            let info = backends.engine.describe();
+            let tts_info = backends.tts.describe();
             Ok(serde_json::json!({
                 "status": "ok",
                 "engine": { "backend": info.backend, "model_id": info.model_id },
                 "tts": { "backend": tts_info.backend, "model_id": tts_info.model_id },
             }))
         }
-        "conversation.inject_text" => inject_text(engine, cmd).await,
-        "tts.synthesize" => synthesize_tts(tts, cmd).await,
+        "conversation.inject_text" => inject_text(backends.engine, cmd).await,
+        "tts.synthesize" => synthesize_tts(backends.tts, cmd).await,
+        "audio.devices" => {
+            serde_json::to_value(backends.audio.devices()).map_err(|_| "internal_error")
+        }
+        "audio.capture_start" | "audio.start_capture" => audio_capture_start(backends.audio),
+        "audio.capture_stop" | "audio.stop_capture" => audio_capture_stop(backends.audio, cmd),
+        "audio.play" | "audio.playback_control" => audio_play(backends.audio, cmd),
         _ => Err("not_implemented"),
     }
+}
+
+fn audio_capture_start(audio: &AudioManager) -> Result<serde_json::Value, &'static str> {
+    let capture_id = audio.capture_start().map_err(|error| {
+        eprintln!("fae-daemon: audio.capture_start failed: {error}");
+        "audio_error"
+    })?;
+    Ok(serde_json::json!({ "capture_id": capture_id }))
+}
+
+fn audio_capture_stop(
+    audio: &AudioManager,
+    cmd: &Command,
+) -> Result<serde_json::Value, &'static str> {
+    use base64::Engine as _;
+    let capture_id = cmd
+        .payload
+        .get("capture_id")
+        .and_then(serde_json::Value::as_str)
+        .ok_or("bad_request")?;
+    let captured = audio.capture_stop(capture_id).map_err(|error| {
+        eprintln!("fae-daemon: audio.capture_stop failed: {error}");
+        match error {
+            fae_audio::AudioError::CaptureNotFound => "not_found",
+            _ => "audio_error",
+        }
+    })?;
+    Ok(serde_json::json!({
+        "wav_base64": base64::engine::general_purpose::STANDARD.encode(captured.wav),
+        "duration_ms": captured.duration_ms,
+        "sample_rate": captured.sample_rate,
+    }))
+}
+
+fn audio_play(audio: &AudioManager, cmd: &Command) -> Result<serde_json::Value, &'static str> {
+    use base64::Engine as _;
+    let encoded = cmd
+        .payload
+        .get("wav_base64")
+        .and_then(serde_json::Value::as_str)
+        .ok_or("bad_request")?;
+    let wav = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| "bad_request")?;
+    let played_ms = audio.play_wav(&wav).map_err(|error| {
+        eprintln!("fae-daemon: audio.play failed: {error}");
+        "audio_error"
+    })?;
+    Ok(serde_json::json!({ "played_ms": played_ms }))
 }
 
 /// Default Kokoro voice when the client does not name one.
@@ -587,6 +647,21 @@ mod tests {
         fae_engine::MockTtsAdapter::new("test-tts")
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_frame(
+        registry: &ClientRegistry,
+        engine: &dyn ProviderAdapter,
+        tts: &dyn TtsAdapter,
+        audio: &AudioManager,
+        state: &mut SessionState,
+        line: &str,
+        now_ms: u64,
+        event_id: String,
+    ) -> FrameOutcome {
+        let backends = SessionBackends { engine, tts, audio };
+        super::handle_frame(registry, &backends, state, line, now_ms, event_id).await
+    }
+
     fn registry() -> ClientRegistry {
         let mut registry = ClientRegistry::new();
         let scopes: HashSet<Scope> = [Scope::StatusRead, Scope::ConversationWrite]
@@ -632,6 +707,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &frame("host.ping", serde_json::Value::Null),
             10,
@@ -655,6 +731,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             "{not json",
             10,
@@ -677,6 +754,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &auth_frame("c1", "good-token"),
             10,
@@ -696,6 +774,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &auth_frame("c1", "wrong"),
             10,
@@ -720,6 +799,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &frame("host.ping", serde_json::Value::Null),
             11,
@@ -743,6 +823,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &frame("runtime.shutdown", serde_json::Value::Null),
             11,
@@ -767,6 +848,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &frame(
                 "conversation.inject_text",
@@ -839,6 +921,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn audio_capture_requires_capture_scope() {
+        let reg = registry();
+        let mut state =
+            SessionState::Authenticated(reg.authenticate("c1", "good-token", 10).expect("auth"));
+        let out = handle_frame(
+            &reg,
+            &mock(),
+            &mock_tts(),
+            &AudioManager::new(),
+            &mut state,
+            &frame("audio.capture_start", serde_json::json!({})),
+            11,
+            "e2".to_owned(),
+        )
+        .await;
+        assert!(!out.response.ok);
+        assert_eq!(
+            out.response.error.as_ref().map(|e| e.code.as_str()),
+            Some("missing_scope")
+        );
+    }
+
+    #[tokio::test]
+    async fn audio_devices_uses_status_scope() {
+        let reg = registry();
+        let mut state =
+            SessionState::Authenticated(reg.authenticate("c1", "good-token", 10).expect("auth"));
+        let out = handle_frame(
+            &reg,
+            &mock(),
+            &mock_tts(),
+            &AudioManager::new(),
+            &mut state,
+            &frame("audio.devices", serde_json::json!({})),
+            11,
+            "e2".to_owned(),
+        )
+        .await;
+        assert!(out.response.ok);
+        let result = out.response.result.expect("result");
+        assert!(result.get("inputs").is_some());
+        assert!(result.get("outputs").is_some());
+    }
+
+    #[tokio::test]
     async fn authed_tts_synthesize_returns_wav() {
         use base64::Engine as _;
         let reg = registry_with_playback();
@@ -848,6 +975,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &frame(
                 "tts.synthesize",
@@ -889,6 +1017,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &frame("tts.synthesize", serde_json::json!({ "text": "hello" })),
             11,
@@ -909,6 +1038,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &frame("tts.synthesize", serde_json::json!({ "text": "  " })),
             11,
@@ -1032,6 +1162,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &frame(
                 "conversation.inject_text",
@@ -1060,6 +1191,7 @@ mod tests {
             &reg,
             &mock(),
             &mock_tts(),
+            &AudioManager::new(),
             &mut state,
             &frame(
                 "conversation.inject_text",

--- a/crates/fae-daemon/src/transport.rs
+++ b/crates/fae-daemon/src/transport.rs
@@ -9,12 +9,13 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use fae_audio::AudioManager;
 use fae_control_plane::{append_audit_jsonl, ClientRegistry, Response};
 use fae_engine::{ProviderAdapter, TtsAdapter};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 
-use crate::session::{handle_frame, SessionState};
+use crate::session::{handle_frame, SessionBackends, SessionState};
 use crate::{next_event_id, now_ms};
 
 /// Reject any single NDJSON frame larger than this **before authentication**.
@@ -38,6 +39,7 @@ pub async fn serve_unix(
     registry: Arc<ClientRegistry>,
     engine: Arc<dyn ProviderAdapter>,
     tts: Arc<dyn TtsAdapter>,
+    audio: Arc<AudioManager>,
     audit_path: PathBuf,
 ) -> std::io::Result<()> {
     // Clear any stale socket left by a previous run (bind fails on EADDRINUSE).
@@ -59,6 +61,7 @@ pub async fn serve_unix(
         let registry = Arc::clone(&registry);
         let engine = Arc::clone(&engine);
         let tts = Arc::clone(&tts);
+        let audio = Arc::clone(&audio);
         let audit_path = audit_path.clone();
         tokio::spawn(async move {
             if let Err(error) = handle_connection(
@@ -66,6 +69,7 @@ pub async fn serve_unix(
                 &registry,
                 engine.as_ref(),
                 tts.as_ref(),
+                audio.as_ref(),
                 &audit_path,
             )
             .await
@@ -82,6 +86,7 @@ async fn handle_connection(
     registry: &ClientRegistry,
     engine: &dyn ProviderAdapter,
     tts: &dyn TtsAdapter,
+    audio: &AudioManager,
     audit_path: &Path,
 ) -> std::io::Result<()> {
     let (read_half, mut write_half) = stream.into_split();
@@ -112,7 +117,8 @@ async fn handle_connection(
 
         let now = now_ms();
         let event_id = next_event_id(now);
-        let outcome = handle_frame(registry, engine, tts, &mut state, trimmed, now, event_id).await;
+        let backends = SessionBackends { engine, tts, audio };
+        let outcome = handle_frame(registry, &backends, &mut state, trimmed, now, event_id).await;
 
         // Fail closed: a frame must be audited before its response is sent. If
         // the audit write fails, surface an error response and drop the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,10 @@ Detailed version history moved from CLAUDE.md. For current architecture, see `CL
 - Added `fae-audio`, a cpal-backed daemon audio crate for portable PTT capture and WAV playback.
 - Added daemon NDJSON commands `audio.devices`, `audio.capture_start`, `audio.capture_stop`, and `audio.play` behind the existing control-plane auth/scopes.
 - Added a live repro script at `crates/fae-daemon/scripts/fae_audio_repro.py` for capture → playback → audio turn → TTS → playback validation.
+- Added capture gain normalization plus `FAE_AUDIO_INPUT_DEVICE` / `FAE_AUDIO_OUTPUT_DEVICE` overrides for reproducible cpal diagnostics.
 
 ### Tests
-- Added WAV encode round-trip, 48 kHz → 16 kHz sine resampling, capture-cap reaping, audio command scope, and daemon auth rejection coverage.
+- Added WAV encode round-trip, 48 kHz → 16 kHz sine resampling, capture gain, capture-cap reaping, audio command scope, and daemon auth rejection coverage.
 
 ## v0.8.183 — Autonomous Self-Improvement Loop (2026-03-30)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed version history moved from CLAUDE.md. For current architecture, see `CLAUDE.md`.
 
+## Unreleased — Skills-first cross-platform P1
+
+### New Features
+- Added `fae-audio`, a cpal-backed daemon audio crate for portable PTT capture and WAV playback.
+- Added daemon NDJSON commands `audio.devices`, `audio.capture_start`, `audio.capture_stop`, and `audio.play` behind the existing control-plane auth/scopes.
+- Added a live repro script at `crates/fae-daemon/scripts/fae_audio_repro.py` for capture → playback → audio turn → TTS → playback validation.
+
+### Tests
+- Added WAV encode round-trip, 48 kHz → 16 kHz sine resampling, capture-cap reaping, audio command scope, and daemon auth rejection coverage.
+
 ## v0.8.183 — Autonomous Self-Improvement Loop (2026-03-30)
 
 ### New Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Detailed version history moved from CLAUDE.md. For current architecture, see `CLAUDE.md`.
 
+## Unreleased — Skills-first cross-platform P3
+
+### New Features
+- Added an orb-owned Settings panel in `fae-ui-shell` with `settings_snapshot` / `settings_set` bridge sync to Swift `FaeCore.patchConfig`.
+- Added adjustable Settings controls for tool access, thinking depth, LLM temperature, TTS speed, awareness cadence, and privacy posture, plus informational always-on capability cards.
+- Kept the SwiftUI Settings window available as **Settings (legacy)…** during parity migration.
+
+### Tests
+- Added Rust bridge protocol coverage for `settings_snapshot` and the legacy settings menu action.
+- Live-verified panel-driven `tts.speed` persistence plus Right Option and orb long-press PTT regressions.
+
 ## Unreleased — Skills-first cross-platform P2
 
 ### New Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Detailed version history moved from CLAUDE.md. For current architecture, see `CLAUDE.md`.
 
+## Unreleased — Skills-first cross-platform P2
+
+### New Features
+- Added executable built-in skills `mail-himalaya`, `calendar-caldav`, and `contacts-carddav` with agentskills.io-compatible frontmatter plus Fae SHA-256 manifests.
+- Added PEP 723 Python CalDAV/CardDAV scripts for portable calendar/contact workflows with Keychain-injected environment variables.
+- Added `himalaya` to the extended tool augmentation registry for portable IMAP/SMTP mail.
+
+### Tests
+- Extended bundled skill discovery/manifest coverage for the productivity skills and added registry coverage for `himalaya`.
+
 ## Unreleased — Skills-first cross-platform P1
 
 ### New Features

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Detailed version history moved from CLAUDE.md. For current architecture, see `CLAUDE.md`.
 
+## Unreleased — Skills-first cross-platform P4
+
+### CI / Build
+- Added a dedicated `linux-render-spike` GitHub Actions workflow for Ubuntu WebKitGTK shell builds and ALSA-backed daemon builds.
+- Added an Xvfb smoke mode for the Rust UI shell that opens the opaque Settings panel, captures a WebKitGTK screenshot artifact in CI, and rejects blank captures via ImageMagick color-count validation.
+- Folded the P1-deferred Linux `fae-daemon` build proof into the same Ubuntu job with `libasound2-dev`, `pkg-config`, and `cargo zigbuild`.
+- Switched Linux `wry` panels to `WebViewBuilderExtUnix::build_gtk` against tao's GTK container after the generic `build(&window)` path produced blank Xvfb captures.
+
+### Docs
+- Added `docs/architecture/linux-render-spike-2026-06.md` to track opaque Settings panel, pill transparency, and Linux shell go/no-go findings.
+
 ## Unreleased — Skills-first cross-platform P3
 
 ### New Features

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -42,7 +42,7 @@ Gemma 4 E4B benchmarked 2026-04-02: 100% tool calling, 100% Fae capability, 100%
 ## Key Capabilities
 
 - **37 built-in tools** (bash, calendar, mail, web_search, screenshot, click, etc.)
-- **29 built-in skills** (voice-identity, forge, toolbox, channels, training-orchestrator, etc.)
+- **30 built-in skills** (forge, toolbox, channels, training-orchestrator, mail-himalaya, CalDAV/CardDAV productivity, etc.)
 - **~23 scheduled tasks** (memory reflection, overnight research, morning briefing, etc.)
 - **Memory**: hybrid ANN (60%) + FTS5 (40%) search, entity graph (persons/orgs/locations)
 - **Self-improvement**: implicit feedback → meta-optimization (directive, config, skills, memory seeds via hill-climbing) → SFT/DPO export → LoRA training → evaluation → deploy

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,12 +1,13 @@
 # Fae — Current State
 
 > What fae actually is today, not what was planned.
-> Last updated: 2026-04-07
+> Last updated: 2026-06-13
 
 ## Tech Stack (v0.8.189)
 
-- **Language**: Pure Swift (no Rust, no C bindings)
-- **UI**: SwiftUI + AppKit
+- **Primary runtime language**: Swift macOS app (no embedded Rust core / C ABI in the active runtime path)
+- **Portable UI shell**: Rust `fae-ui-shell` for the canonical orb, whisper pill, Messages/Scheduler/Skills panels, and the new orb-owned Settings panel
+- **UI**: Rust orb host for new product surfaces; SwiftUI + AppKit remain as migration/legacy surfaces including Settings (legacy)
 - **ML Framework**: MLX (Apple Silicon, on-device only)
 - **Database**: SQLite via GRDB + sqlite-vec (ANN) + FTS5
 - **Update**: Sparkle 2 (EdDSA signed)
@@ -43,6 +44,7 @@ Gemma 4 E4B benchmarked 2026-04-02: 100% tool calling, 100% Fae capability, 100%
 
 - **37 built-in tools** (bash, calendar, mail, web_search, screenshot, click, etc.)
 - **30 built-in skills** (forge, toolbox, channels, training-orchestrator, mail-himalaya, CalDAV/CardDAV productivity, etc.)
+- **Orb-owned Settings panel** (Rust/wry): bridge-synced settings snapshot/set controls for tool access, thinking, temperature, TTS speed, awareness cadence, and privacy posture
 - **~23 scheduled tasks** (memory reflection, overnight research, morning briefing, etc.)
 - **Memory**: hybrid ANN (60%) + FTS5 (40%) search, entity graph (persons/orgs/locations)
 - **Self-improvement**: implicit feedback → meta-optimization (directive, config, skills, memory seeds via hill-climbing) → SFT/DPO export → LoRA training → evaluation → deploy

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -6,7 +6,7 @@
 ## Tech Stack (v0.8.189)
 
 - **Primary runtime language**: Swift macOS app (no embedded Rust core / C ABI in the active runtime path)
-- **Portable UI shell**: Rust `fae-ui-shell` for the canonical orb, whisper pill, Messages/Scheduler/Skills panels, and the new orb-owned Settings panel
+- **Portable UI shell**: Rust `fae-ui-shell` for the canonical orb, whisper pill, Messages/Scheduler/Skills panels, and the new orb-owned Settings panel; Ubuntu WebKitGTK CI now proves the opaque Settings panel renders under Xvfb
 - **UI**: Rust orb host for new product surfaces; SwiftUI + AppKit remain as migration/legacy surfaces including Settings (legacy)
 - **ML Framework**: MLX (Apple Silicon, on-device only)
 - **Database**: SQLite via GRDB + sqlite-vec (ANN) + FTS5
@@ -44,7 +44,7 @@ Gemma 4 E4B benchmarked 2026-04-02: 100% tool calling, 100% Fae capability, 100%
 
 - **37 built-in tools** (bash, calendar, mail, web_search, screenshot, click, etc.)
 - **30 built-in skills** (forge, toolbox, channels, training-orchestrator, mail-himalaya, CalDAV/CardDAV productivity, etc.)
-- **Orb-owned Settings panel** (Rust/wry): bridge-synced settings snapshot/set controls for tool access, thinking, temperature, TTS speed, awareness cadence, and privacy posture
+- **Orb-owned Settings panel** (Rust/wry): bridge-synced settings snapshot/set controls for tool access, thinking, temperature, TTS speed, awareness cadence, and privacy posture; Linux panels use `build_gtk` and have a CI screenshot artifact guard
 - **~23 scheduled tasks** (memory reflection, overnight research, morning briefing, etc.)
 - **Memory**: hybrid ANN (60%) + FTS5 (40%) search, entity graph (persons/orgs/locations)
 - **Self-improvement**: implicit feedback → meta-optimization (directive, config, skills, memory seeds via hill-climbing) → SFT/DPO export → LoRA training → evaluation → deploy

--- a/docs/architecture/fae-rust-orb-ui-shell.md
+++ b/docs/architecture/fae-rust-orb-ui-shell.md
@@ -115,7 +115,7 @@ Settings, Messages, Scheduler, and Skills now have live orb-owned panel behavior
 
 ### Webview panels
 
-`Settings…` opens an opaque `wry` panel owned by the Rust shell. Swift sends a structured `settings_snapshot`; the panel sends `settings_set { key, value }` back to the Swift bridge, which validates/coerces and persists through `FaeCore.patchConfig()`. `Settings (legacy)…` keeps the previous SwiftUI window available until parity is complete.
+`Settings…` opens an opaque `wry` panel owned by the Rust shell. Swift sends a structured `settings_snapshot`; the panel sends `settings_set { key, value }` back to the Swift bridge, which validates/coerces and persists through `FaeCore.patchConfig()`. `Settings (legacy)…` keeps the previous SwiftUI window available until parity is complete. On Linux, panels are built through `WebViewBuilderExtUnix::build_gtk` against tao's GTK container; the generic `build(&window)` path compiled but rendered blank under Xvfb.
 
 `Open Browser/Data Panel` opens a `wry` webview with placeholder sections for charts, video/rich media, and tools/permissions. This proves the new rule: rich output belongs in browser/webview panels, not in a custom canvas.
 
@@ -198,7 +198,7 @@ The Swift UI should be treated as legacy/migration source. Do not add new produc
 
 ## Cross-platform notes
 
-`wgpu` supports the orb renderer on modern desktop and mobile GPU APIs. `tao`, `muda`, and `wry` cover desktop shell/menu/webview behavior; mobile packaging and lifecycle need dedicated follow-up work.
+`wgpu` supports the orb renderer on modern desktop and mobile GPU APIs. `tao`, `muda`, and `wry` cover desktop shell/menu/webview behavior; mobile packaging and lifecycle need dedicated follow-up work. The P4 Linux render spike passed for the opaque Settings panel on Ubuntu/WebKitGTK/Xvfb with a screenshot artifact and color-count guard; transparent pill behavior remains compositor-sensitive and should not be used as the Linux go/no-go criterion.
 
 For a full cross-platform product shell, compare:
 

--- a/docs/architecture/fae-rust-orb-ui-shell.md
+++ b/docs/architecture/fae-rust-orb-ui-shell.md
@@ -94,7 +94,8 @@ The renderer uses `ControlFlow::Poll` only while active and `ControlFlow::Wait` 
 
 Menu items include:
 
-- Settings…
+- Settings… (Rust/wry panel)
+- Settings (legacy)… (SwiftUI fallback during parity migration)
 - Open Browser/Data Panel
 - Reset Conversation
 - Hide Fae
@@ -110,9 +111,11 @@ Menu items include:
 - Rescue Mode…
 - Quit Fae
 
-Only a subset has live POC behavior today. The rest are bridge stubs.
+Settings, Messages, Scheduler, and Skills now have live orb-owned panel behavior. The remaining menu items are bridge stubs or Swift-backed actions.
 
-### Webview panel
+### Webview panels
+
+`Settings…` opens an opaque `wry` panel owned by the Rust shell. Swift sends a structured `settings_snapshot`; the panel sends `settings_set { key, value }` back to the Swift bridge, which validates/coerces and persists through `FaeCore.patchConfig()`. `Settings (legacy)…` keeps the previous SwiftUI window available until parity is complete.
 
 `Open Browser/Data Panel` opens a `wry` webview with placeholder sections for charts, video/rich media, and tools/permissions. This proves the new rule: rich output belongs in browser/webview panels, not in a custom canvas.
 
@@ -131,6 +134,7 @@ status    -> startup/error/status appears through the orb while non-ready, inclu
 conversation -> transcript entries are stored by the orb host for the Messages affordance and live-refreshed panels
 scheduler_snapshot -> scheduler tasks/statuses populate the orb-owned Scheduler panel
 skills_snapshot -> skill inventory/statuses populate the orb-owned Skills panel
+settings_snapshot -> settings sections/cards populate the orb-owned Settings panel
 ```
 
 Example JSONL commands:
@@ -140,12 +144,14 @@ Example JSONL commands:
 {"type":"conversation","role":"user","text":"Hello Fae"}
 {"type":"conversation","role":"fae","text":"Hello — I’m here."}
 {"type":"show_messages"}
+{"type":"settings_snapshot","sections":[],"cards":[]}
 ```
 
 ### Shell menu -> runtime command
 
 ```text
 settings
+settings_legacy
 open_browser_data_panel
 reset_conversation
 hide_fae
@@ -178,7 +184,7 @@ Possible future transports if needed:
 The Swift app remains the authoritative live implementation for now and launches the Rust orb host when a bundled or configured binary is available:
 
 - voice pipeline
-- settings
+- settings persistence and legacy Settings fallback
 - permissions/onboarding
 - memory
 - scheduler runtime
@@ -188,7 +194,7 @@ The Swift app remains the authoritative live implementation for now and launches
 
 The Swift bridge resolves the orb host from `FAE_UI_SHELL_BIN`, then from `Fae.app/Contents/MacOS/fae-ui-shell`, then from the local development target path. Shell-enabled bundle recipes copy/sign the Rust binary into the app bundle when it has been built explicitly.
 
-The Swift UI should be treated as legacy/migration source. Do not add new product UI surfaces to canvas, and do not restore Cowork as a product surface. Scheduler/Skills product entry points stay orb-owned while their backing runtime remains Swift; Swift sends compact snapshots over the bridge to populate those panels.
+The Swift UI should be treated as legacy/migration source. Do not add new product UI surfaces to canvas, and do not restore Cowork as a product surface. Settings/Scheduler/Skills product entry points stay orb-owned while their backing runtime remains Swift; Swift sends compact snapshots over the bridge to populate those panels.
 
 ## Cross-platform notes
 

--- a/docs/architecture/linux-render-spike-2026-06.md
+++ b/docs/architecture/linux-render-spike-2026-06.md
@@ -1,0 +1,94 @@
+# Linux render spike — June 2026
+
+Status: P4 CI proof passed  
+Scope: `native/rust/fae-ui-shell` on Ubuntu/WebKitGTK plus the P1-deferred Linux `fae-daemon` ALSA build proof.
+
+## Question
+
+Does the P3 opaque Settings panel render cleanly on Linux WebKitGTK? This is the critical cross-platform thesis. The whisper pill's transparent webview is expected to be compositor-sensitive and may fail or show artifacts on Linux; that does not invalidate the opaque-panel path.
+
+## CI guard
+
+Added `.github/workflows/linux-render-spike.yml` with a single `ubuntu-latest` job:
+
+1. Installs GTK/WebKitGTK, X11/Wayland build headers, `libasound2-dev`, `pkg-config`, Xvfb, ImageMagick, stable Rust, Zig, and `cargo-zigbuild`.
+2. Runs `cargo fmt --all -- --check`, strict `cargo clippy`, and `cargo build` for `native/rust/fae-ui-shell`.
+3. Runs `fae-ui-shell --smoke-settings-panel` under Xvfb and captures `linux-settings-panel.png` as an artifact. This opens the real opaque Settings panel via wry/WebKitGTK using a deterministic sample `settings_snapshot`.
+4. Rejects blank compositor captures by requiring the screenshot to contain at least eight colors; the passing run produced 2,380 colors.
+5. Runs daemon formatting, production-binary strict clippy, native Ubuntu build, and `cargo zigbuild --target x86_64-unknown-linux-gnu -p fae-daemon --all-features` from `crates/`, closing the P1-deferred ALSA/pkg-config proof in the same Linux job.
+
+The existing no-Rust-reintroduction CI guard now explicitly allows this dedicated render-spike workflow while continuing to forbid accidental Rust in default Swift CI and default root `just` recipes.
+
+## Local preflight
+
+macOS local checks before pushing the CI workflow:
+
+```text
+$ just check-ui-shell
+cd native/rust/fae-ui-shell && cargo fmt --all
+cd native/rust/fae-ui-shell && cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.33s
+cd native/rust/fae-ui-shell && cargo check --workspace --all-targets
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
+```
+
+```text
+$ ./scripts/ci/guard-no-rust-reintro.sh
+[guard-no-rust] checking active CI workflows for rust/cargo reintroduction...
+[guard-no-rust] allowing explicit Linux render-spike Rust workflow: .github/workflows/linux-render-spike.yml
+[guard-no-rust] checking justfile default dev recipes (build/test/check)...
+[guard-no-rust] OK
+```
+
+```text
+$ cd crates && just check
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+...
+test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+Smoke mode also exits cleanly on macOS:
+
+```text
+$ cd native/rust/fae-ui-shell && timeout 8s cargo run -- --smoke-settings-panel
+code=0
+```
+
+## Runtime observations
+
+| Surface | X11 / Xvfb CI | Wayland desktop | Go/no-go |
+| --- | --- | --- | --- |
+| Opaque Settings panel | Passed in CI: `linux-settings-panel.png` rendered real text/controls/cards under WebKitGTK/Xvfb; artifact has 2,380 colors | Pending desktop Linux access | CI gate passed |
+| wgpu orb | Build-covered by CI; runtime pending desktop Linux access | Pending desktop Linux access | Pending runtime |
+| Whisper pill transparency | Expected to misbehave under Linux compositors (tauri#12800/#9220); not a P4 blocker | Pending desktop Linux access | Likely replace/augment with wgpu-rendered captions on Linux |
+| Messages panel | Build-covered; runtime pending desktop Linux access | Pending desktop Linux access | Pending runtime |
+| Drag + long-press gestures | Build-covered; runtime pending desktop Linux access | Pending desktop Linux access | Pending runtime |
+
+## Current recommendation
+
+- Keep opaque `wry` panels as the cross-platform path: the CI screenshot shows the Settings panel rendering correctly on WebKitGTK once Linux uses `WebViewBuilderExtUnix::build_gtk` against tao's GTK container.
+- Treat transparent pill behavior as a separate Linux compositor problem. Prefer a Linux-specific caption strategy rendered by wgpu or an opaque mini-panel rather than relying on transparent WebKitGTK.
+- Keep the Linux render-spike workflow as a non-default guard; it is explicit product-shell validation, not a reintroduction of Rust into Swift default CI.
+
+## Evidence
+
+The durable source of truth for the current branch head is PR #10's check rollup: <https://github.com/saorsa-labs/fae/pull/10>. The Linux render-spike job must pass on the branch head before P4 is considered closed.
+
+Representative passing tails from the CI proof:
+
+```text
+/home/runner/work/fae/fae/linux-settings-panel.png: PNG image data, 1280 x 900, 8-bit/color RGB, non-interlaced
+settings panel screenshot colors=2380
+
+Run cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 46.96s
+
+Run cargo clippy -p fae-daemon --bin fae-daemon --all-features -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 55s
+Run cargo build -p fae-daemon --all-features
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 45s
+Run cargo zigbuild --target x86_64-unknown-linux-gnu -p fae-daemon --all-features
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 37s
+```

--- a/docs/architecture/skill-and-tool-interop-2026-06-05.md
+++ b/docs/architecture/skill-and-tool-interop-2026-06-05.md
@@ -25,7 +25,7 @@ The two are reconcilable with a thin **bidirectional adapter** — Fae stays spe
 | Schema | — | `schemaVersion: 1` | → `metadata.fae.schemaVersion` |
 | Integrity | — (spec has none) | `integrity.checksums` (SHA-256) | → `metadata.fae.integrity` **(Fae-computed on import, see §4)** |
 
-**Body conventions:** adopt Hermes' section order (`# X Skill` · intro · `## When to Use / Prerequisites / How to Run / Quick Reference / Procedure / Pitfalls / Verification`) for Fae-authored and exported skills — improves quality and makes Fae skills portable-readable by other harnesses.
+**Body conventions:** adopt Hermes' section order (`# X Skill` · intro · `## When to Use / Prerequisites / How to Run / Quick Reference / Procedure / Pitfalls / Verification`) for Fae-authored and exported skills — improves quality and makes Fae skills portable-readable by other harnesses. The P2 productivity wave (`mail-himalaya`, `calendar-caldav`, `contacts-carddav`) is the reference implementation for executable built-ins that keep agentskills.io-compatible frontmatter while enforcing Fae's stricter SHA-256 `MANIFEST.json` integrity layer.
 
 **Progressive disclosure:** already 1:1 — Fae injects names+descriptions in the prompt (`SkillManager.promptMetadata()`) and loads the full body on `activate_skill`. The standard's three tiers (metadata ~100 tok → body <5000 tok → resources on demand) map exactly. No change.
 

--- a/docs/architecture/skills-first-cross-platform-2026-06-13.md
+++ b/docs/architecture/skills-first-cross-platform-2026-06-13.md
@@ -79,7 +79,7 @@ which is the bridge.
 | **P1 — Voice spine in Rust** | cpal capture + playback in fae-daemon | daemon + orb host = a complete *talking* Fae on any OS; capture is trivially portable post-S18 (16 kHz buffer + endpoint + WAV) |
 | **P2 — Productivity skills wave** | mail (himalaya/IMAP), calendar (CalDAV incl. iCloud), contacts (CardDAV); agentskills.io-compatible frontmatter | Cross-platform hands that ALSO improve macOS Fae today (mail doesn't exist yet). Additive — `AppleTools.swift` stays as the privileged macOS path |
 | **P3 — Orb host absorbs UI** | settings → onboarding → approvals as wry panels (macOS first) | Settings panel is implemented in the Rust orb host with Swift bridge sync; onboarding/approvals remain later work. Panels are designed opaque-fallback-tolerant |
-| **P4 — Linux render spike** | orb + pill + one panel on Ubuntu (X11 + Wayland) | Measure WebKitGTK pain directly before committing panel architecture to it |
+| **P4 — Linux render spike** | orb + pill + opaque Settings panel on Ubuntu (CI/Xvfb, then X11 + Wayland desktop) | CI/Xvfb passed for the opaque Settings panel on WebKitGTK with artifact color validation; Linux desktop X11/Wayland and transparent pill compositor behavior remain follow-up |
 | **P5 — Ship gates** | release.yml daemon embedding; models.lock generation + fail-closed enforcement | Daemon-default cannot ship without them |
 
 ### What stays Swift (deliberately)

--- a/docs/architecture/skills-first-cross-platform-2026-06-13.md
+++ b/docs/architecture/skills-first-cross-platform-2026-06-13.md
@@ -78,7 +78,7 @@ which is the bridge.
 |---|---|---|
 | **P1 — Voice spine in Rust** | cpal capture + playback in fae-daemon | daemon + orb host = a complete *talking* Fae on any OS; capture is trivially portable post-S18 (16 kHz buffer + endpoint + WAV) |
 | **P2 — Productivity skills wave** | mail (himalaya/IMAP), calendar (CalDAV incl. iCloud), contacts (CardDAV); agentskills.io-compatible frontmatter | Cross-platform hands that ALSO improve macOS Fae today (mail doesn't exist yet). Additive — `AppleTools.swift` stays as the privileged macOS path |
-| **P3 — Orb host absorbs UI** | settings → onboarding → approvals as wry panels (macOS first) | Shrinks the AppKit/SwiftUI surface where wry is solid; panels designed opaque-fallback-tolerant |
+| **P3 — Orb host absorbs UI** | settings → onboarding → approvals as wry panels (macOS first) | Settings panel is implemented in the Rust orb host with Swift bridge sync; onboarding/approvals remain later work. Panels are designed opaque-fallback-tolerant |
 | **P4 — Linux render spike** | orb + pill + one panel on Ubuntu (X11 + Wayland) | Measure WebKitGTK pain directly before committing panel architecture to it |
 | **P5 — Ship gates** | release.yml daemon embedding; models.lock generation + fail-closed enforcement | Daemon-default cannot ship without them |
 
@@ -97,7 +97,7 @@ which is the bridge.
   (mic → daemon ASR+LLM → TTS → speaker) with zero Swift.
 - macOS Fae gains working mail + CalDAV calendar skills with credentials in
   Keychain, no cloud lock-in.
-- The orb host owns settings/onboarding/approvals on macOS; AppKit windows for
+- The orb host owns Settings on macOS via a `settings_snapshot` / `settings_set` wry panel; onboarding/approvals remain next migration targets. AppKit windows for
   those are deleted.
 - Release artifacts contain fae-daemon with an enforced models.lock.
 

--- a/docs/reports/skills-first-cross-platform-p1-2026-06-13.md
+++ b/docs/reports/skills-first-cross-platform-p1-2026-06-13.md
@@ -245,7 +245,7 @@ client  : authenticate with {"command":"session.authenticate","payload":{"client
 fae-daemon: listening on /tmp/fae-audio-p1-home/Library/Application Support/fae/run/fae-daemon.sock (NDJSON)
 ```
 
-### Capture → save WAV → playback → audio turn → TTS → playback
+### Capture → save WAV → playback → audio turn → TTS → playback (mock lane)
 
 Command:
 
@@ -285,24 +285,77 @@ Audit log with timestamps:
 2026-06-12T23:34:28.611000 audio.play allow allow
 ```
 
+### Warm-cache real Gemma/Kokoro closure proof
+
+After P1 acceptance, I reran the repro with the real cached Gemma/Kokoro lane and no sandbox `HOME`:
+
+```bash
+HF_HOME="$HOME/.cache/huggingface" \
+FAE_MODEL_ID=google/gemma-4-E4B-it \
+FAE_NO_PARENT_WATCH=1 \
+FAE_AUDIO_INPUT_DEVICE='MacBook Pro Microphone' \
+FAE_AUDIO_OUTPUT_DEVICE='MacBook Pro Speakers' \
+target/debug/fae-daemon
+```
+
+Daemon warm-load evidence:
+
+```text
+engine  : loading mistral.rs model google/gemma-4-E4B-it (this can take a while)…
+2026-06-13T08:53:54.893608Z INFO mistralrs_core: git revision: c22c2e2b622a815821e59056c2b5952b4cbbe010
+2026-06-13T08:53:54.893913Z INFO mistralrs_core: Pipeline input modalities are [📝 Text, 🖼️ Vision, 🎬 Video, 🔊 Audio]
+2026-06-13T08:53:54.893939Z INFO mistralrs_core: Pipeline output modalities are [📝 Text]
+engine  : mistralrs (google/gemma-4-E4B-it)
+voices  : /Users/davidirvine/Library/Application Support/fae/voices (custom voices, optional)
+tts     : voice-tts (prince-canuma/Kokoro-82M)
+fae-daemon: listening on /Users/davidirvine/Library/Application Support/fae/run/fae-daemon.sock (NDJSON)
+```
+
+Known phrase spoken via macOS `say`: `hello fae audio proof`.
+
+Command:
+
+```bash
+python3 -u crates/fae-daemon/scripts/fae_audio_repro.py \
+  --home "$HOME" \
+  --out /tmp/fae-cpal-warm-real-6.wav \
+  --capture-seconds 3.5
+```
+
+Real transcript:
+
+```text
+audio.devices -> {"ok": true, "request_id": "r2", "result": {"default_input": "MacBook Pro Microphone", "default_output": "MacBook Pro Speakers", "inputs": ["David’s iPhone Microphone", "MacBook Pro Microphone", "Microsoft Teams Audio"], "outputs": ["MacBook Pro Speakers", "Microsoft Teams Audio"]}, "v": 2}
+audio.capture_start -> {"ok": true, "request_id": "r3", "result": {"capture_id": "cap-3"}, "v": 2}
+Speak now for 3.5s...
+audio.capture_stop -> {"ok": true, "request_id": "r4", "result": {"duration_ms": 3498, "sample_rate": 16000, "wav_base64": "..."}, "v": 2}
+saved_wav -> channels=1 rate=16000 frames=55979 duration=3.499s
+audio.play -> {"ok": true, "request_id": "r5", "result": {"played_ms": 3498}, "v": 2}
+conversation.inject_text -> {"ok": true, "request_id": "r6", "result": {"finish_reason": "stop", "text": "[heard]: hello fay audio proof", "tool_calls": []}, "v": 2}
+heard_turn -> {"finish_reason": "stop", "text": "[heard]: hello fay audio proof", "tool_calls": []}
+tts.synthesize -> {"ok": true, "request_id": "r7", "result": {"sample_rate": 24000, "wav_base64": "..."}, "v": 2}
+audio.play -> {"ok": true, "request_id": "r8", "result": {"played_ms": 2250}, "v": 2}
+```
+
+`[heard]: hello fay audio proof` is an acceptable phonetic transcript of `hello fae audio proof`; P1 headline criterion is closed.
+
 Shutdown by exact PID:
 
 ```text
-PID=$(cat /tmp/fae-audio-p1-daemon.pid); kill "$PID"
-stopped 50979
+PID=$(cat /tmp/fae-audio-p1-warm-real-daemon.pid); kill "$PID"
+stopped 68133
 ```
 
 ## 4. Deviations from prompt + why
 
 - `fae-audio` is a new crate. This keeps the cpal worker, WAV parsing/encoding, and resampling out of `fae-daemon` session dispatch.
-- The live end-to-end `[heard]:` transcript was exercised with the daemon mock engine (`echo: [audio:48172 bytes]`) rather than a completed real Gemma turn. I attempted `FAE_MODEL_ID=google/gemma-4-E4B-it` with the cached HF repo, but daemon startup remained at `engine  : loading mistral.rs model google/gemma-4-E4B-it (this can take a while)…` for ~10 minutes with no control socket, so I killed the exact PID and kept the mock proof as the audio-lane evidence.
-- Cross-compilation is blocked by host sysroot tooling (`alsa-sys` requires Linux ALSA pkg-config/sysroot on this macOS machine). The code path compiles locally for macOS; `cd crates && just check` is green.
+- The initial mock-lane evidence was superseded by the warm-cache real Gemma/Kokoro proof above. The real run required capture gain normalization and a stronger audio-transcription repro prompt while preserving the empty audio-message content contract.
+- Cross-compilation is blocked by host sysroot tooling (`alsa-sys` requires Linux ALSA pkg-config/sysroot on this macOS machine). Per owner direction, this is deferred to P4's Ubuntu CI job. The code path compiles locally for macOS; `cd crates && just check` is green.
 - Exact root `just check` timed out in Swift Contacts/CoreData XPC/TCC access, outside the Rust P1 changes. `just build` and the documented local `swift test --skip VocabularyHarvestTests` path passed.
 
 ## 5. Known gaps / follow-ups
 
-- Configure a Linux ALSA sysroot or run the cross-compile proof on an actual Linux builder to satisfy the `cargo zigbuild --target x86_64-unknown-linux-gnu -p fae-daemon` gate.
-- Re-run the live repro with `FAE_MODEL_ID=google/gemma-4-E4B-it` and real TTS if/when local model weights are available; current proof uses mock engine/TTS.
+- Linux ALSA cross-build proof is deferred to P4's Ubuntu CI job.
 - `audio.play` is intentionally blocking v1 and uses WAV payloads only.
 - No daemon-side VAD/AEC/barge-in streaming was added (out of scope for P1).
 

--- a/docs/reports/skills-first-cross-platform-p1-2026-06-13.md
+++ b/docs/reports/skills-first-cross-platform-p1-2026-06-13.md
@@ -1,0 +1,321 @@
+# PHASE P1 REPORT — cpal capture + playback in fae-daemon
+
+## 1. What changed
+
+`git add -N ... && git diff --stat`:
+
+```text
+ crates/Cargo.lock                                  | 295 ++++++++-
+ crates/Cargo.toml                                  |   1 +
+ crates/README.md                                   |   3 +-
+ crates/fae-audio/Cargo.toml                        |  14 +
+ crates/fae-audio/src/lib.rs                        | 689 +++++++++++++++++++++
+ crates/fae-control-plane/src/lib.rs                |  58 +-
+ crates/fae-daemon/Cargo.toml                       |   1 +
+ crates/fae-daemon/scripts/fae_audio_repro.py       | 122 ++++
+ crates/fae-daemon/src/diagnostic.rs                |   9 +-
+ crates/fae-daemon/src/main.rs                      |   5 +-
+ crates/fae-daemon/src/session.rs                   | 156 ++++-
+ crates/fae-daemon/src/transport.rs                 |  10 +-
+ docs/CHANGELOG.md                                  |  10 +
+ .../skills-first-cross-platform-p1-2026-06-13.md   | 321 ++++++++++
+ 14 files changed, 1663 insertions(+), 31 deletions(-)
+```
+
+Summary:
+
+- Added `crates/fae-audio`, a cpal-backed portable audio crate. I chose a new crate to keep cpal/device/WAV/resampling code isolated from control-plane session dispatch.
+- Added daemon commands `audio.devices`, `audio.capture_start`, `audio.capture_stop`, and `audio.play` on the existing NDJSON control plane; kept legacy aliases `audio.start_capture`, `audio.stop_capture`, and `audio.playback_control` mapped to the same scopes/handlers.
+- Added `AudioCapture`/`AudioPlayback` command-scope wiring and explicit tests for auth/scope rejection.
+- Added unit coverage for WAV encode round-trip, 48 kHz → 16 kHz sine resampling correctness, and capture-cap reaping.
+- Added live repro script: `crates/fae-daemon/scripts/fae_audio_repro.py`.
+- Updated `docs/CHANGELOG.md`, `crates/README.md`, and matching Obsidian mirrors.
+
+## 2. Validation
+
+### `cd crates && just check && cargo check --workspace --all-targets`
+
+Command:
+
+```bash
+cd crates && just check && cargo check --workspace --all-targets
+```
+
+Tail/output:
+
+```text
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
+cargo test --all-features
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.24s
+     Running unittests src/lib.rs (target/debug/deps/fae_audio-6679fbfb2401edc2)
+
+running 4 tests
+test tests::bad_wav_is_rejected ... ok
+test tests::capture_cap_reaping_marks_then_removes_finished_sessions ... ok
+test tests::wav_encode_round_trip ... ok
+test tests::resample_48k_to_16k_preserves_sine_frequency ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running unittests src/lib.rs (target/debug/deps/fae_control_plane-603b68a25dd6ec79)
+
+running 22 tests
+...
+test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running unittests src/main.rs (target/debug/deps/fae_daemon-45d9ac8fc793d714)
+
+running 19 tests
+...
+test session::tests::audio_devices_uses_status_scope ... ok
+
+test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.28s
+
+     Running unittests src/lib.rs (target/debug/deps/fae_engine-f8ff397b585951e0)
+
+running 13 tests
+...
+test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running unittests src/lib.rs (target/debug/deps/fae_envelope_gate-cd42e0b24ef90da0)
+
+running 7 tests
+...
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+   Doc-tests fae_audio
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+   Doc-tests fae_control_plane
+...
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
+```
+
+### `just check-ui-shell`
+
+Command:
+
+```bash
+just check-ui-shell
+```
+
+Tail/output:
+
+```text
+cd native/rust/fae-ui-shell && cargo fmt --all
+cd native/rust/fae-ui-shell && cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.19s
+warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
+note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
+cd native/rust/fae-ui-shell && cargo check --workspace --all-targets
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
+warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
+note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
+```
+
+### Root Swift validation
+
+Commands:
+
+```bash
+just build
+cd native/macos/Fae && swift test --skip VocabularyHarvestTests
+just check
+```
+
+`just build` passed (xcodebuild warning only):
+
+```text
+cd native/macos/Fae && xcodebuild build -scheme Fae -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath .build/xcode -quiet
+2026-06-12 23:57:09.849 xcodebuild[82029:25723771] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
+--- xcodebuild: WARNING: Using the first of multiple matching destinations:
+{ platform:macOS, arch:arm64, id:00006050-001C08DA01F9401C, name:My Mac }
+{ platform:macOS, arch:arm64, variant:Mac Catalyst, id:00006050-001C08DA01F9401C, name:My Mac }
+{ platform:macOS, arch:arm64, variant:DriverKit, id:00006050-001C08DA01F9401C, name:My Mac }
+```
+
+`swift test --skip VocabularyHarvestTests` passed:
+
+```text
+Test Suite 'FaePackageTests.xctest' passed at 2026-06-12 23:57:01.756.
+	 Executed 3087 tests, with 0 failures (0 unexpected) in 119.082 (119.249) seconds
+Test Suite 'Selected tests' passed at 2026-06-12 23:57:01.757.
+	 Executed 3087 tests, with 0 failures (0 unexpected) in 119.082 (119.250) seconds
+...
+✔ Suite "GlobalHotkeyManager PTT" passed after 0.040 seconds.
+✔ Suite "MissedWakeStore" passed after 0.044 seconds.
+✔ Test run with 53 tests in 6 suites passed after 0.044 seconds.
+```
+
+Exact `just check` still timed out after 900 s in Swift tests while repeatedly trying to open Contacts/CoreData XPC stores. This is unrelated to the Rust daemon/audio changes and matches the plan's TCC/contact-test gotcha class.
+
+Tail:
+
+```text
+2026-06-13 00:09:10.504 xctest[82533:25727794] CoreData: XPC: Unable to load metadata: Error Domain=NSCocoaErrorDomain Code=134060 "A Core Data error occurred." UserInfo={Problem=Unable to send to server; failed after 8 attempts.}
+CoreData: error: Failed to create NSXPCConnection
+CoreData: error: addPersistentStoreWithType:configuration:URL:options:error: returned error NSCocoaErrorDomain (134060)
+CoreData: error: userInfo:
+CoreData: error: 	Problem : Unable to send to server; failed after 8 attempts.
+CoreData: error: storeType: NSXPCStore
+CoreData: error: configuration: (null)
+CoreData: error: URL: file:///Users/davidirvine/Library/Application%20Support/AddressBook/Sources/A8366A48-1C9E-4BB2-9026-821E1FD9B6D5/AddressBook-v22.abcddb
+CoreData: annotation: options:
+CoreData: annotation: 	NSReadOnlyPersistentStoreOption : 0
+CoreData: annotation: 	NSXPCStoreServerEndpointFactory : <CNCDRemotePersistentStoreEndpointFactory: 0x96e63af00>
+CoreData: annotation: 	skipModelCheck : 1
+CoreData: annotation: 	NSPersistentHistoryTrackingKey : 1
+...
+Command timed out after 900 seconds
+```
+
+### Cross-compile proof
+
+Command:
+
+```bash
+cd crates && cargo zigbuild --target x86_64-unknown-linux-gnu -p fae-daemon
+```
+
+Result: blocked locally before linking because macOS host lacks a Linux ALSA/pkg-config sysroot. The failure is from `alsa-sys` build-script discovery, not Rust typechecking or codegen.
+
+Tail:
+
+```text
+error: failed to run custom build command for `alsa-sys v0.3.1`
+
+Caused by:
+  process didn't exit successfully: `/Users/davidirvine/Desktop/Devel/projects/fae/crates/target/debug/build/alsa-sys-c6708fe4e421465b/build-script-build` (exit status: 101)
+...
+  thread 'main' ... pkg-config has not been configured to support cross-compilation.
+
+  Install a sysroot for the target platform and configure it via
+  PKG_CONFIG_SYSROOT_DIR and PKG_CONFIG_PATH, or install a
+  cross-compiling wrapper for pkg-config and set it via
+  PKG_CONFIG environment variable.
+```
+
+Retry with `PKG_CONFIG_ALLOW_CROSS=1` reached the next host issue:
+
+```text
+Could not run `... pkg-config --libs --cflags alsa`
+The pkg-config command could not be found.
+Try `brew install pkgconf` if you have Homebrew.
+```
+
+Local container fallback check:
+
+```bash
+command -v docker || command -v podman || command -v colima || true
+```
+
+Output was empty, so no local Linux container runtime was available for a native `libasound2-dev pkg-config` build.
+
+## 3. Live evidence
+
+### Daemon startup sandbox
+
+Command:
+
+```bash
+TEST_HOME=/tmp/fae-audio-p1-home
+rm -rf "$TEST_HOME"
+mkdir -p "$TEST_HOME"
+cd crates
+HOME="$TEST_HOME" FAE_NO_PARENT_WATCH=1 FAE_TTS=mock target/debug/fae-daemon > /tmp/fae-audio-p1-daemon.log 2>&1 &
+echo $! > /tmp/fae-audio-p1-daemon.pid
+```
+
+Daemon log:
+
+```text
+fae-daemon (Phase 1, chunk 2a) — protocol v2
+run dir : /tmp/fae-audio-p1-home/Library/Application Support/fae/run (0700)
+token   : /tmp/fae-audio-p1-home/Library/Application Support/fae/run/bootstrap.token (0600)
+engine  : mock (mock-echo)
+tts     : mock (mock-tts)
+audit   : /tmp/fae-audio-p1-home/Library/Application Support/fae/run/audit.jsonl (jsonl)
+client  : authenticate with {"command":"session.authenticate","payload":{"client_id":"swift-frontend-bootstrap","token":<file>}}
+
+fae-daemon: listening on /tmp/fae-audio-p1-home/Library/Application Support/fae/run/fae-daemon.sock (NDJSON)
+```
+
+### Capture → save WAV → playback → audio turn → TTS → playback
+
+Command:
+
+```bash
+HOME=/tmp/fae-audio-p1-home python3 crates/fae-daemon/scripts/fae_audio_repro.py \
+  --home /tmp/fae-audio-p1-home \
+  --out /tmp/fae-cpal-capture.wav \
+  --capture-seconds 1.5
+```
+
+Transcript:
+
+```text
+session.authenticate -> {"ok": true, "request_id": "r1", "result": {"authenticated": true, "client_id": "swift-frontend-bootstrap"}, "v": 2}
+audio.devices -> {"ok": true, "request_id": "r2", "result": {"inputs": ["David’s iPhone Microphone", "MacBook Pro Microphone", "Microsoft Teams Audio"], "outputs": ["MacBook Pro Speakers", "Microsoft Teams Audio"]}, "v": 2}
+audio.capture_start -> {"ok": true, "request_id": "r3", "result": {"capture_id": "cap-1"}, "v": 2}
+Speak now for 1.5s...
+audio.capture_stop -> {"ok": true, "request_id": "r4", "result": {"duration_ms": 1504, "sample_rate": 16000, "wav_base64": "UklGRiS8AABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQC8AAB5AHIBfAFhAS4B6ACSAC8A4P+//8D/yv/c//X/AQD2/+7/6P/Z/8j/wP+8/7v/vf/M/+b/FwA+ACUA/f8dAGcAbAD3/1z/Af/7/hr/OP91/wcAugAGAbcAGwCL/w3/ZP6e/Sj9Xf0k/hf/3v+AAB8BjwGGAQMBTgCs/yf/sP5R/kP+p/5C/7r/3v/D/5P/Rf/P/kj+7v3+/X7+Rf81AD8BQgIGA2QDUgPsAmIC0AE6AbIAYABWAHgAiwBxADEA1/9i/83+Jv6n/Yn9z/1c/hT/7f/QAJ8BKAJRAikC1QF0ARMBxgCbAJIAqgDVAPEA1ABtANr/T//w/q3+cv5d/o7+B/+d/yEAdwCeAKAAiwBsAE0AQwBNAFwAbgCIAJoAjgBaAP3/ff8F/7z+pv6s/tb+NP+k/wYATgB8AJQAmwCPAHIAXgBnAIAAkgDLALAAWQBhAEsARwA+ADcAMQArACYAIQAdABsAGwAcABwAHAAaABgAFAAPAAgAAwD+//r/9//1//T/9P/0//P/8v/w/+//7f/s/+z/7P/r/+v/6//q/+r/6v/q/+n/6f/p/+n/6f/o/+j/6P/o/+j/6P/o/+f/5//n/+f/5//n/+f/5//n/+f/5//n/+f/5//n/+f/5//o/+j/6P/o/+j/6P/o/+n/6f/p/+n/6f/p/+r/6v/q/+r/6v/r/+v/6//r/+z/7P/s/+z/7f/t/+3/7v/u/+7/7v/v/+//7//w//
+saved_wav -> channels=1 rate=16000 frames=24064 duration=1.504s
+audio.play -> {"ok": true, "request_id": "r5", "result": {"played_ms": 1504}, "v": 2}
+conversation.inject_text -> {"ok": true, "request_id": "r6", "result": {"finish_reason": "stop", "text": "echo: [audio:48172 bytes] ", "tool_calls": []}, "v": 2}
+heard_turn -> {"finish_reason": "stop", "text": "echo: [audio:48172 bytes] ", "tool_calls": []}
+tts.synthesize -> {"ok": true, "request_id": "r7", "result": {"sample_rate": 24000, "wav_base64": "UklGRgQCAABXQVZFZm10IBAAAAABAAEAwF0AAIC7AAACABAAZGF0YeABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}, "v": 2}
+audio.play -> {"ok": true, "request_id": "r8", "result": {"played_ms": 10}, "v": 2}
+```
+
+Audit log with timestamps:
+
+```text
+2026-06-12T23:34:25.215000 session.authenticate allow allow
+2026-06-12T23:34:25.216000 audio.devices allow allow
+2026-06-12T23:34:25.371000 audio.capture_start allow allow
+2026-06-12T23:34:26.970000 audio.capture_stop allow allow
+2026-06-12T23:34:27.026000 audio.play allow allow
+2026-06-12T23:34:28.603000 conversation.inject_text allow allow
+2026-06-12T23:34:28.610000 tts.synthesize allow allow
+2026-06-12T23:34:28.611000 audio.play allow allow
+```
+
+Shutdown by exact PID:
+
+```text
+PID=$(cat /tmp/fae-audio-p1-daemon.pid); kill "$PID"
+stopped 50979
+```
+
+## 4. Deviations from prompt + why
+
+- `fae-audio` is a new crate. This keeps the cpal worker, WAV parsing/encoding, and resampling out of `fae-daemon` session dispatch.
+- The live end-to-end `[heard]:` transcript was exercised with the daemon mock engine (`echo: [audio:48172 bytes]`) rather than a completed real Gemma turn. I attempted `FAE_MODEL_ID=google/gemma-4-E4B-it` with the cached HF repo, but daemon startup remained at `engine  : loading mistral.rs model google/gemma-4-E4B-it (this can take a while)…` for ~10 minutes with no control socket, so I killed the exact PID and kept the mock proof as the audio-lane evidence.
+- Cross-compilation is blocked by host sysroot tooling (`alsa-sys` requires Linux ALSA pkg-config/sysroot on this macOS machine). The code path compiles locally for macOS; `cd crates && just check` is green.
+- Exact root `just check` timed out in Swift Contacts/CoreData XPC/TCC access, outside the Rust P1 changes. `just build` and the documented local `swift test --skip VocabularyHarvestTests` path passed.
+
+## 5. Known gaps / follow-ups
+
+- Configure a Linux ALSA sysroot or run the cross-compile proof on an actual Linux builder to satisfy the `cargo zigbuild --target x86_64-unknown-linux-gnu -p fae-daemon` gate.
+- Re-run the live repro with `FAE_MODEL_ID=google/gemma-4-E4B-it` and real TTS if/when local model weights are available; current proof uses mock engine/TTS.
+- `audio.play` is intentionally blocking v1 and uses WAV payloads only.
+- No daemon-side VAD/AEC/barge-in streaming was added (out of scope for P1).
+
+## 6. Docs touched + Obsidian notes updated
+
+Repo docs touched:
+
+- `docs/CHANGELOG.md`
+- `crates/README.md`
+- `docs/reports/skills-first-cross-platform-p1-2026-06-13.md`
+
+Obsidian mirrors updated:
+
+- `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Ideas/Saorsa Labs/Projects/fae/docs/CHANGELOG.md`
+- `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Ideas/Saorsa Labs/Projects/fae/crates/README.md`
+- `~/Library/Mobile Documents/iCloud~md~obsidian/Documents/Ideas/Saorsa Labs/Projects/fae/docs/reports/skills-first-cross-platform-p1-2026-06-13.md`

--- a/docs/reports/skills-first-cross-platform-p2-2026-06-13.md
+++ b/docs/reports/skills-first-cross-platform-p2-2026-06-13.md
@@ -1,0 +1,249 @@
+# Skills-first Cross-platform P2 Report — Productivity Skills Wave
+
+**Date:** 2026-06-13
+**Status:** implementation scaffold + local validation complete; live account proof blocked on test credentials/account configuration.
+
+## Summary
+
+P2 added three portable executable productivity skills under `native/macos/Fae/Sources/Fae/Resources/Skills/`:
+
+- `mail-himalaya` — IMAP/SMTP via the `himalaya` CLI.
+- `calendar-caldav` — CalDAV list/create/update/delete via `uv run --script` Python (`caldav`, `vobject`).
+- `contacts-carddav` — CardDAV contact search via `uv run --script` Python (`vobject`).
+
+Credentials are not stored in skill files. The skills document Keychain-backed `run_skill.secret_bindings` for environment injection, matching the existing `CredentialManager`/`SkillManager.execute(... secretBindings:)` path.
+
+## Diff stat
+
+```text
+CLAUDE.md                                          |   7 +-
+docs/CHANGELOG.md                                  |  10 +
+docs/CURRENT_STATE.md                              |   2 +-
+docs/architecture/skill-and-tool-interop-2026-06-05.md           |   2 +-
+docs/reports/skills-first-cross-platform-p2-2026-06-13.md   | 249 +++++++++++++++
+native/macos/Fae/Sources/Fae/Core/ToolAugmentationManager.swift |   3 +
+native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/MANIFEST.json |  26 ++
+native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/SKILL.md  |  77 +++++
+native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/scripts/calendar_caldav.py     | 343 +++++++++++++++++++++
+native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/MANIFEST.json          |  26 ++
+native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/SKILL.md |  72 +++++
+native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/scripts/contacts_carddav.py   | 230 ++++++++++++++
+native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/MANIFEST.json   |  27 ++
+native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/SKILL.md    |  76 +++++
+native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/scripts/mail_himalaya.py  | 290 +++++++++++++++++
+native/macos/Fae/Tests/HandoffTests/SkillActivationTests.swift  |  10 +-
+native/macos/Fae/Tests/HandoffTests/SkillBypassRegressionTests.swift   |   2 +-
+native/macos/Fae/Tests/IntegrationTests/ToolAugmentationManagerTests.swift             |   7 +
+18 files changed, 1453 insertions(+), 6 deletions(-)
+```
+
+## Implementation details
+
+- Added agentskills.io-compatible `SKILL.md` frontmatter (`name`, `description`) and Hermes-style sections for all three skills.
+- Added Fae `MANIFEST.json` files with `schemaVersion: 1`, `capabilities: ["execute"]`, `allowedTools: ["run_skill"]`, and SHA-256 integrity checksums.
+- `mail-himalaya` does not install Himalaya itself; `ToolAugmentationManager.registry` now includes `himalaya` as an extended-tier brew tool.
+- `calendar-caldav` supports `status`, `list_calendars`, `list_events`, `create_event`, `update_event`, and `delete_event`.
+- `contacts-carddav` supports `status`, `search`, and compact `raw_report` diagnostics.
+- Existing AppleTools/EventKit/Contacts paths were not touched.
+
+## Local command evidence
+
+### Script syntax and status smoke
+
+```bash
+python3 -m py_compile \
+  native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/scripts/mail_himalaya.py \
+  native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/scripts/calendar_caldav.py \
+  native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/scripts/contacts_carddav.py
+```
+
+Exit: 0.
+
+```bash
+printf '{"jsonrpc":"2.0","method":"execute","params":{"action":"status"},"id":1}' | uv run --script native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/scripts/mail_himalaya.py
+```
+
+```json
+{"ok":true,"installed":false,"binary":null,"secrets_env_present":{"HIMALAYA_PASSWORD":false,"HIMALAYA_OAUTH_TOKEN":false},"state":"missing_binary","next_step":"Install himalaya through Fae tool augmentation or brew; do not install from this skill."}
+```
+
+```bash
+printf '{"jsonrpc":"2.0","method":"execute","params":{"action":"status"},"id":1}' | uv run --script native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/scripts/calendar_caldav.py
+```
+
+```json
+{"ok":true,"ready":false,"state":"missing_env","required_env_present":{"CALDAV_URL":false,"CALDAV_USERNAME":false,"CALDAV_PASSWORD":false},"missing_env":["CALDAV_URL","CALDAV_USERNAME","CALDAV_PASSWORD"],"optional_env_present":{"CALDAV_CALENDAR":false,"CALDAV_DEFAULT_TZ":false}}
+```
+
+```bash
+printf '{"jsonrpc":"2.0","method":"execute","params":{"action":"status"},"id":1}' | uv run --script native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/scripts/contacts_carddav.py
+```
+
+```json
+{"ok":true,"ready":false,"state":"missing_env","required_env_present":{"CARDDAV_URL":false,"CARDDAV_USERNAME":false,"CARDDAV_PASSWORD":false},"missing_env":["CARDDAV_URL","CARDDAV_USERNAME","CARDDAV_PASSWORD"]}
+```
+
+### Integrity check
+
+```bash
+python3 - <<'PY'
+import json,hashlib,pathlib,sys
+base=pathlib.Path('native/macos/Fae/Sources/Fae/Resources/Skills')
+for name in ['mail-himalaya','calendar-caldav','contacts-carddav']:
+    d=base/name
+    m=json.loads((d/'MANIFEST.json').read_text())
+    for rel, expected in m['integrity']['checksums'].items():
+        actual=hashlib.sha256((d/rel).read_bytes()).hexdigest()
+        if actual != expected:
+            print(f'MISMATCH {name} {rel} {actual} != {expected}')
+            sys.exit(1)
+    print(f'{name}: integrity ok')
+PY
+```
+
+Tail:
+
+```text
+mail-himalaya: integrity ok
+calendar-caldav: integrity ok
+contacts-carddav: integrity ok
+```
+
+### Targeted Swift skill/tool tests
+
+```bash
+cd native/macos/Fae && swift test \
+  --filter SkillActivationTests/testNewSkillsDiscovered \
+  --filter SkillBypassRegressionTests/testBuiltInExecutableSkillsHaveValidManifests \
+  --filter ToolAugmentationManagerTests/testRegistryIncludesHimalayaAsExtendedTool
+```
+
+Tail:
+
+```text
+Test Suite 'SkillActivationTests' passed ... Executed 1 test, with 0 failures
+Test Suite 'SkillBypassRegressionTests' passed ... Executed 1 test, with 0 failures
+Test Suite 'ToolAugmentationManagerTests' passed ... Executed 1 test, with 0 failures
+Test Suite 'Selected tests' passed ... Executed 3 tests, with 0 failures (0 unexpected)
+```
+
+```bash
+cd native/macos/Fae && swift test --filter SkillActivationTests
+```
+
+Tail:
+
+```text
+Test Suite 'SkillActivationTests' passed at 2026-06-13 10:22:14.446.
+	 Executed 10 tests, with 0 failures (0 unexpected) in 0.108 (0.109) seconds
+```
+
+### Required validation
+
+```bash
+just build
+```
+
+Tail:
+
+```text
+cd native/macos/Fae && xcodebuild build -scheme Fae -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath .build/xcode -quiet
+2026-06-13 10:41:06.254 xcodebuild[35966:26883659] [MT] IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
+--- xcodebuild: WARNING: Using the first of multiple matching destinations:
+{ platform:macOS, arch:arm64, id:00006050-001C08DA01F9401C, name:My Mac }
+{ platform:macOS, arch:arm64, variant:Mac Catalyst, id:00006050-001C08DA01F9401C, name:My Mac }
+{ platform:macOS, arch:arm64, variant:DriverKit, id:00006050-001C08DA01F9401C, name:My Mac }
+```
+
+Exit: 0.
+
+```bash
+just check
+```
+
+Result: timed out after 900s in the same local Contacts/CoreData XPC/TCC path documented in P1. Tail:
+
+```text
+2026-06-13 10:34:55.932 xctest[18126:26848354] CoreData: XPC: Unable to load metadata: Error Domain=NSCocoaErrorDomain Code=134060 "A Core Data error occurred." UserInfo={Problem=Unable to send to server; failed after 8 attempts.}
+CoreData: error: storeType: NSXPCStore
+CoreData: error: URL: file:///Users/davidirvine/Library/Application%20Support/AddressBook/AddressBook-v22.abcddb
+Command timed out after 900 seconds
+```
+
+Fallback accepted by the plan's gotchas:
+
+```bash
+cd native/macos/Fae && swift test --skip VocabularyHarvestTests
+```
+
+Tail:
+
+```text
+Test Suite 'FaePackageTests.xctest' passed at 2026-06-13 10:40:33.044.
+	 Executed 3088 tests, with 0 failures (0 unexpected) in 116.715 (116.888) seconds
+Test Suite 'Selected tests' passed at 2026-06-13 10:40:33.044.
+	 Executed 3088 tests, with 0 failures (0 unexpected) in 116.715 (116.889) seconds
+✔ Test run with 53 tests in 6 suites passed after 0.049 seconds.
+```
+
+```bash
+cd crates && just check
+```
+
+Tail:
+
+```text
+Doc-tests fae_engine
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+Doc-tests fae_envelope_gate
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+```bash
+just check-ui-shell
+```
+
+Tail:
+
+```text
+cd native/rust/fae-ui-shell && cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
+warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
+cd native/rust/fae-ui-shell && cargo check --workspace --all-targets
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
+warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
+```
+
+## Live account proof status
+
+Blocked pending reviewer-provided test account credentials/configuration. I did not fabricate account transcripts.
+
+Local environment evidence:
+
+```text
+missing: /Users/davidirvine/.config/himalaya
+missing: /Users/davidirvine/Library/Application Support/himalaya
+```
+
+Needed to close the P2 live gate:
+
+1. Install/configure `himalaya` for a test account or permit Fae's tool augmentation to install it, then provide/confirm account config.
+2. Store CalDAV credentials in Keychain and bind them as `CALDAV_URL`, `CALDAV_USERNAME`, `CALDAV_PASSWORD`.
+3. Store CardDAV credentials in Keychain and bind them as `CARDDAV_URL`, `CARDDAV_USERNAME`, `CARDDAV_PASSWORD`.
+4. Run live proofs:
+   - mail: list 5 inbox subjects; send a test email to self.
+   - calendar: list next 7 days; create/delete `fae-skill-test`.
+   - contacts: search a known contact and return phone/email.
+   - voice path: typed dev-app turn routes to the calendar skill and answers.
+
+## Cleanup
+
+- Removed Python `__pycache__/` directories after smoke checks.
+- No `xctest`, `swift test`, `xcodebuild`, or `fae-daemon` processes left running after validation.

--- a/docs/reports/skills-first-cross-platform-p3-2026-06-13.md
+++ b/docs/reports/skills-first-cross-platform-p3-2026-06-13.md
@@ -1,0 +1,180 @@
+# Skills-first cross-platform P3 report — Orb-owned Settings panel
+
+Date: 2026-06-13
+
+## Summary
+
+P3 moves the adjustable Settings surface into the Rust orb host as an opaque `wry` panel while keeping the SwiftUI Settings window available as **Settings (legacy)…**. Swift remains authoritative for persistence and policy; the Rust panel receives `settings_snapshot` bridge messages and sends `settings_set { key, value }` events back to `FaeCore.patchConfig`.
+
+Implemented keys include tool access mode, thinking depth, LLM temperature, TTS speed, awareness intervals/pause toggles, and privacy posture. Always-on capability summaries render as informational cards, not authority toggles.
+
+## Changed files
+
+```text
+native/macos/Fae/Sources/Fae/Core/FaeCore.swift
+native/macos/Fae/Sources/Fae/FaeApp.swift
+native/macos/Fae/Sources/Fae/RustUiShellController.swift
+native/rust/fae-ui-shell/src/main.rs
+native/rust/fae-ui-shell/src/menu.rs
+native/rust/fae-ui-shell/src/protocol.rs
+```
+
+`git diff --stat` at validation time:
+
+```text
+ native/macos/Fae/Sources/Fae/Core/FaeCore.swift    | 217 ++++++++++++++++++
+ native/macos/Fae/Sources/Fae/FaeApp.swift          |   5 +-
+ .../Fae/Sources/Fae/RustUiShellController.swift    |  80 ++++++-
+ native/rust/fae-ui-shell/src/main.rs               | 248 ++++++++++++++++++++-
+ native/rust/fae-ui-shell/src/menu.rs               |   5 +
+ native/rust/fae-ui-shell/src/protocol.rs           |  66 ++++++
+ 6 files changed, 617 insertions(+), 4 deletions(-)
+```
+
+## Live verification
+
+Launch command:
+
+```bash
+source ~/.secrets 2>/dev/null || true; just run-dev
+```
+
+Launch tail:
+
+```text
+✓ Bundle assembled: native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app (v0.8.189)
+  → Embedded fae-ui-shell
+  → Embedded fae-daemon
+✓ Signed: native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app
+✓ Fae (DEV) launched — logs: tail -f /tmp/fae-dev.log
+  Data: ~/Library/Application Support/fae-dev/
+  Vault: ~/.fae-vault-dev/
+```
+
+Panel opened from the orb right-click menu. Window enumeration after opening:
+
+```text
+id=16660 owner=Fae name= bounds={ Height = 48; Width = 380; X = 823; Y = "-823"; }
+id=16671 owner=Fae name= bounds={ Height = 712; Width = 880; X = 573; Y = "-1248"; }
+id=16659 owner=Fae name= bounds={ Height = 420; Width = 420; X = 803; Y = "-1175"; }
+```
+
+`id=16671` is the Rust-owned Settings panel. `screencapture` was attempted but the local macOS session denied capture:
+
+```text
+could not create image from window
+screencapture_exit=1
+could not create image from display
+full_screencapture_exit=1
+```
+
+Accessibility inspection verified rendered controls inside the real panel:
+
+```text
+role=AXHeading title=Playback speed value=3 pos=(1040,-881) size=(162,17)
+role=AXButton title=− value= pos=(1216,-876) size=(34,31)
+role=AXTextField title= value=1.10 pos=(1256,-878) size=(110,35)
+role=AXButton title=+ value= pos=(1372,-876) size=(34,31)
+```
+
+Panel → Swift two-way bridge proof (`tts.speed` stepped from 1.10 to 1.15, then back to 1.10):
+
+```text
+$ grep -n "speed" "$HOME/Library/Application Support/fae-dev/config.toml"
+44:speed = 1.1
+
+# clicked the Settings panel + stepper
+$ grep -n "speed" "$HOME/Library/Application Support/fae-dev/config.toml"
+44:speed = 1.15
+
+# clicked the Settings panel − stepper
+$ grep -n "speed" "$HOME/Library/Application Support/fae-dev/config.toml"
+44:speed = 1.1
+```
+
+Log excerpt:
+
+```text
+2026-06-13 12:02:44.129 Fae[61510:27114991] RustUiShellController: settings_set received key=tts.speed
+2026-06-13 12:02:44.132 Fae[61510:27114991] FaeCore: config persisted (config.patch.tts.speed)
+2026-06-13 12:02:44.132 Fae[61510:27114991] RustUiShellController: settings_set applied key=tts.speed
+2026-06-13 12:02:44.132 Fae[61510:27114991] RustUiShellController: settings_snapshot sent sections=4 cards=4
+2026-06-13 12:04:05.150 Fae[61510:27114991] RustUiShellController: settings_set received key=tts.speed
+2026-06-13 12:04:05.151 Fae[61510:27114991] FaeCore: config persisted (config.patch.tts.speed)
+2026-06-13 12:04:05.151 Fae[61510:27114991] RustUiShellController: settings_set applied key=tts.speed
+2026-06-13 12:04:05.152 Fae[61510:27114991] RustUiShellController: settings_snapshot sent sections=4 cards=4
+```
+
+Panel reflection after reverting:
+
+```text
+role=AXTextField title= value=1.10 pos=(1256,-878) size=(110,35)
+```
+
+Orb gesture regression proof:
+
+```text
+2026-06-13 12:06:09.514 Fae[61510:27114991] GlobalHotkeyManager: PTT press (keyCode 61)
+2026-06-13 12:06:09.514 Fae[61510:27115469] PipelineCoordinator: PTT capture started (holdMode=1)
+2026-06-13 12:06:10.303 Fae[61510:27114991] GlobalHotkeyManager: PTT release (keyCode 61)
+2026-06-13 12:06:10.303 Fae[61510:27115464] PipelineCoordinator: PTT capture finished (stop): 11200 samples, speech=0
+2026-06-13 12:06:33.657 Fae[61510:27115477] RustUiShell stderr: [gesture] long-press hold fired → talk_start
+2026-06-13 12:06:33.657 Fae[61510:27114991] RustUiShellController: talk_start received
+2026-06-13 12:06:33.657 Fae[61510:27115477] PipelineCoordinator: PTT capture started (holdMode=1)
+2026-06-13 12:06:34.114 Fae[61510:27115476] RustUiShell stderr: [gesture] long-press release → talk_stop
+2026-06-13 12:06:34.114 Fae[61510:27114991] RustUiShellController: talk_stop received
+2026-06-13 12:06:34.114 Fae[61510:27115476] PipelineCoordinator: PTT capture finished (stop): 6400 samples, speech=0
+```
+
+## Validation
+
+### `just check-ui-shell`
+
+```text
+cd native/rust/fae-ui-shell && cargo fmt --all
+cd native/rust/fae-ui-shell && cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.67s
+cd native/rust/fae-ui-shell && cargo check --workspace --all-targets
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
+```
+
+Known upstream warning remains from `block v0.1.6` future-incompatibility.
+
+### `cd native/macos/Fae && swift test --skip VocabularyHarvestTests`
+
+```text
+Test Suite 'FaePackageTests.xctest' passed at 2026-06-13 12:09:12.346.
+	 Executed 3088 tests, with 0 failures (0 unexpected) in 116.803 (116.972) seconds
+✔ Test run with 53 tests in 6 suites passed after 0.050 seconds.
+```
+
+### `cd crates && just check`
+
+```text
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+...
+test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+...
+```
+
+### `just check`
+
+Attempted after quitting the dev app. It still hit the known local Contacts/CoreData XPC/TCC failure and timed out at 1200s:
+
+```text
+CoreData: error: Failed to create NSXPCConnection
+CoreData: error: addPersistentStoreWithType:configuration:URL:options:error: returned error NSCocoaErrorDomain (134060)
+CoreData: error: URL: file:///Users/davidirvine/Library/Application%20Support/AddressBook/AddressBook-v22.abcddb
+Command timed out after 1200 seconds
+```
+
+The Swift suite itself passed with `swift test --skip VocabularyHarvestTests`, which is the documented local workaround for the TCC/Contacts hang.
+
+## Notes / residual risk
+
+- The legacy SwiftUI Settings window remains available via **Settings (legacy)…**.
+- The Rust panel intentionally renders opaque; it does not depend on transparent webview composition.
+- The panel originally re-requested snapshots after every refresh; that caused a bridge loop during live testing. The auto-request was removed, leaving explicit Swift menu snapshot pushes and a manual Refresh button.
+- The requested self-config typed-turn revert was not used; the value was reverted through the same Rust Settings panel after proving panel → config → panel sync. Local OpenAI-compatible runtime auth does not expose the random bearer token in logs, and `GET /v1/models` correctly returned 401 without it.

--- a/docs/reports/skills-first-cross-platform-p4-2026-06-13.md
+++ b/docs/reports/skills-first-cross-platform-p4-2026-06-13.md
@@ -1,0 +1,80 @@
+# Skills-first cross-platform P4 report — Linux render spike
+
+Date: 2026-06-13  
+Status: accepted locally; CI proof passed  
+Branch/PR: `p4-linux-render-spike`, <https://github.com/saorsa-labs/fae/pull/10>
+
+## Gate result
+
+P4's CI gate passed on Ubuntu. Because final documentation-only commits can retrigger the workflow, the authoritative current status is PR #10's check rollup:
+
+- PR: <https://github.com/saorsa-labs/fae/pull/10>
+- Job: `Ubuntu WebKitGTK + ALSA build proof`
+- Required outcome: success on the branch head
+
+Representative proof run captured during P4 finalization:
+
+- Run: <https://github.com/saorsa-labs/fae/actions/runs/27472229069>
+- Commit at the time of capture: `5b549cdfa8389c5cd424964f480fb509564db724`
+- Result: success, 2026-06-13T16:20:28Z → 2026-06-13T16:32:38Z
+
+## What changed
+
+- Added `.github/workflows/linux-render-spike.yml` for an explicit non-default Ubuntu product-shell proof.
+- Added `fae-ui-shell --smoke-settings-panel`, which opens the real opaque Settings panel with deterministic sample settings/cards and exits after screenshot capture.
+- On Linux, changed `wry` panel construction to use `WebViewBuilderExtUnix::build_gtk` with tao's GTK container. The initial `build(&window)` path compiled but produced a blank white WebKitGTK capture in Xvfb.
+- Added screenshot color-count validation so blank/white captures fail the workflow.
+- Added the P1-deferred Linux daemon ALSA/native/zigbuild proof to the same job.
+
+## WebKitGTK Settings proof
+
+The passing CI artifact rendered the Settings header, voice controls, select control, refresh button, and always-on capability card under Xvfb/WebKitGTK.
+
+Representative artifact: <https://github.com/saorsa-labs/fae/actions/runs/27472229069/artifacts/7612434592>
+
+Local downloaded artifact metadata:
+
+```text
+/tmp/fae-linux-render-spike/linux-settings-panel.png: PNG image data, 1280 x 900, 8-bit/color RGB, non-interlaced
+PNG 1280x900 colors=2380 size=79003B
+```
+
+CI smoke tail:
+
+```text
+/home/runner/work/fae/fae/linux-settings-panel.png: PNG image data, 1280 x 900, 8-bit/color RGB, non-interlaced
+settings panel screenshot colors=2380
+```
+
+## Linux build proof
+
+```text
+Run cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 46.96s
+
+Run cargo clippy -p fae-daemon --bin fae-daemon --all-features -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 55s
+
+Run cargo build -p fae-daemon --all-features
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 45s
+
+Run cargo zigbuild --target x86_64-unknown-linux-gnu -p fae-daemon --all-features
+Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 37s
+```
+
+## Local validation before push
+
+```text
+just check-ui-shell
+./scripts/ci/guard-no-rust-reintro.sh
+cd crates && cargo clippy -p fae-daemon --bin fae-daemon --all-features -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+```
+
+All passed locally before the final CI run.
+
+## Exceptions / follow-up
+
+- The smoke proof is X11/Xvfb CI, not a physical Linux desktop pass.
+- Wayland and real compositor behavior remain follow-up.
+- Transparent pill artifacts are expected and deliberately not treated as a blocker for opaque Settings panels; a Linux-specific wgpu caption or opaque mini-panel remains likely.
+- P2 live mail/CalDAV/CardDAV account proofs remain unresolved and separate from P4.

--- a/native/macos/Fae/Sources/Fae/Core/FaeCore.swift
+++ b/native/macos/Fae/Sources/Fae/Core/FaeCore.swift
@@ -946,6 +946,214 @@ final class FaeCore: ObservableObject, HostCommandSender {
         }
     }
 
+    // MARK: - Orb Settings Snapshot
+
+    func settingsSnapshot() -> [String: Any] {
+        [
+            "sections": [
+                Self.settingsSection(
+                    id: "conversation",
+                    title: "Conversation",
+                    description: "Access and reasoning controls for future turns.",
+                    settings: [
+                        Self.setting(
+                            key: "tool_mode",
+                            title: "Tool access",
+                            description: "Assistant mode is read-mostly. Full mode enables Fae's normal owner-gated tool surface.",
+                            kind: "select",
+                            value: config.toolMode,
+                            options: [
+                                Self.option("assistant", "Assistant"),
+                                Self.option("full", "Full"),
+                            ]
+                        ),
+                        Self.setting(
+                            key: "llm.thinking_level",
+                            title: "Thinking depth",
+                            description: "Fast minimizes deliberate reasoning; deep gives Fae more room for hard work.",
+                            kind: "select",
+                            value: config.llm.resolvedThinkingLevel.rawValue,
+                            options: [
+                                Self.option(FaeThinkingLevel.fast.rawValue, "Fast"),
+                                Self.option(FaeThinkingLevel.balanced.rawValue, "Balanced"),
+                                Self.option(FaeThinkingLevel.deep.rawValue, "Deep"),
+                            ]
+                        ),
+                        Self.setting(
+                            key: "llm.temperature",
+                            title: "Temperature",
+                            description: "Higher values make wording more varied; lower values are steadier.",
+                            kind: "number",
+                            value: Self.decimal(config.llm.temperature),
+                            min: "0.3",
+                            max: "1.0",
+                            step: "0.05"
+                        ),
+                    ]
+                ),
+                Self.settingsSection(
+                    id: "voice",
+                    title: "Voice",
+                    description: "Speech playback controls for Kokoro/Fae voice output.",
+                    settings: [
+                        Self.setting(
+                            key: "tts.speed",
+                            title: "Playback speed",
+                            description: "Adjust how quickly Fae speaks.",
+                            kind: "number",
+                            value: Self.decimal(config.tts.speed),
+                            min: "0.7",
+                            max: "1.4",
+                            step: "0.05",
+                            unit: "×"
+                        ),
+                        Self.setting(
+                            key: "tts.voice",
+                            title: "Voice",
+                            description: "Current named voice profile.",
+                            kind: "readonly",
+                            value: config.tts.voice,
+                            readOnly: true
+                        ),
+                    ]
+                ),
+                Self.settingsSection(
+                    id: "awareness",
+                    title: "Awareness cadence",
+                    description: "Intensity controls for proactive camera and screen observation.",
+                    settings: [
+                        Self.setting(
+                            key: "awareness.camera_interval_seconds",
+                            title: "Camera interval",
+                            description: "How often Fae checks presence when awareness is active.",
+                            kind: "select",
+                            value: String(config.awareness.cameraIntervalSeconds),
+                            options: [Self.option("10", "10s"), Self.option("30", "30s"), Self.option("60", "60s"), Self.option("120", "120s")]
+                        ),
+                        Self.setting(
+                            key: "awareness.screen_interval_seconds",
+                            title: "Screen interval",
+                            description: "How often Fae refreshes silent screen context.",
+                            kind: "select",
+                            value: String(config.awareness.screenIntervalSeconds),
+                            options: [Self.option("10", "10s"), Self.option("19", "19s"), Self.option("30", "30s"), Self.option("60", "60s")]
+                        ),
+                        Self.setting(
+                            key: "awareness.pause_on_battery",
+                            title: "Pause on battery",
+                            description: "Reduce background observation while unplugged.",
+                            kind: "bool",
+                            value: config.awareness.pauseOnBattery ? "true" : "false"
+                        ),
+                        Self.setting(
+                            key: "awareness.pause_on_thermal_pressure",
+                            title: "Pause when Mac is hot",
+                            description: "Pause lower-priority observations during thermal pressure.",
+                            kind: "bool",
+                            value: config.awareness.pauseOnThermalPressure ? "true" : "false"
+                        ),
+                    ]
+                ),
+                Self.settingsSection(
+                    id: "privacy",
+                    title: "Privacy posture",
+                    description: "Local-first network policy for future tasks.",
+                    settings: [
+                        Self.setting(
+                            key: "privacy.mode",
+                            title: "Mode",
+                            description: "Strict local avoids remote services; connected allows approved network tools.",
+                            kind: "select",
+                            value: config.privacy.mode,
+                            options: [
+                                Self.option("strict_local", "Strict local"),
+                                Self.option("local_preferred", "Local preferred"),
+                                Self.option("connected", "Connected"),
+                            ]
+                        ),
+                    ]
+                ),
+            ],
+            "cards": [
+                Self.settingsCard(
+                    title: "Local voice spine",
+                    body: "Push-to-talk capture, Gemma audio turns, and Kokoro playback run through the local daemon path.",
+                    detail: "The Swift audio lane remains available while the portable lane matures."
+                ),
+                Self.settingsCard(
+                    title: "Owner-gated tools",
+                    body: "Fae's tools remain governed by existing approval, audit, and reversal systems.",
+                    detail: "This panel does not expose per-tool authority toggles."
+                ),
+                Self.settingsCard(
+                    title: "Portable skills",
+                    body: "Mail, CalDAV, and CardDAV skills extend Fae without replacing Apple-local integrations.",
+                    detail: "Secrets stay in Keychain and are injected only at execution time."
+                ),
+                Self.settingsCard(
+                    title: "Memory and receipts",
+                    body: "Memory, action receipts, and backups continue to be handled by the Swift runtime.",
+                    detail: "Use the legacy Settings window for surfaces not yet represented here."
+                ),
+            ],
+        ]
+    }
+
+    private static func settingsSection(
+        id: String,
+        title: String,
+        description: String,
+        settings: [[String: Any]]
+    ) -> [String: Any] {
+        [
+            "id": id,
+            "title": title,
+            "description": description,
+            "settings": settings,
+        ]
+    }
+
+    private static func setting(
+        key: String,
+        title: String,
+        description: String,
+        kind: String,
+        value: String,
+        options: [[String: String]]? = nil,
+        min: String? = nil,
+        max: String? = nil,
+        step: String? = nil,
+        unit: String? = nil,
+        readOnly: Bool = false
+    ) -> [String: Any] {
+        var object: [String: Any] = [
+            "key": key,
+            "title": title,
+            "description": description,
+            "kind": kind,
+            "value": value,
+            "read_only": readOnly,
+        ]
+        if let options { object["options"] = options }
+        if let min { object["min"] = min }
+        if let max { object["max"] = max }
+        if let step { object["step"] = step }
+        if let unit { object["unit"] = unit }
+        return object
+    }
+
+    private static func option(_ value: String, _ label: String) -> [String: String] {
+        ["value": value, "label": label]
+    }
+
+    private static func settingsCard(title: String, body: String, detail: String) -> [String: Any] {
+        ["title": title, "body": body, "detail": detail]
+    }
+
+    private static func decimal(_ value: Float) -> String {
+        String(format: "%.2f", Double(value))
+    }
+
     // MARK: - HostCommandSender Conformance
 
     /// Handles commands from `HostCommandBridge`, Settings tabs, and relay server.
@@ -2779,6 +2987,11 @@ final class FaeCore: ObservableObject, HostCommandSender {
         do {
             try config.save()
             NSLog("FaeCore: config persisted (%@)", reason)
+            NotificationCenter.default.post(
+                name: .faeSettingsChanged,
+                object: nil,
+                userInfo: ["reason": reason]
+            )
             // Fast config-only vault backup.
             if let vault = vaultManager {
                 Task.detached(priority: .utility) {
@@ -3143,4 +3356,8 @@ final class FaeCore: ObservableObject, HostCommandSender {
             return ["payload": [:] as [String: Any]]
         }
     }
+}
+
+extension Notification.Name {
+    static let faeSettingsChanged = Notification.Name("faeSettingsChanged")
 }

--- a/native/macos/Fae/Sources/Fae/Core/ToolAugmentationManager.swift
+++ b/native/macos/Fae/Sources/Fae/Core/ToolAugmentationManager.swift
@@ -61,6 +61,8 @@ enum ToolAugmentationManager {
                 brewFormula: "pandoc", category: .media, tier: .extended),
         CLITool(name: "yq", binary: "yq", description: "YAML processor",
                 brewFormula: "yq", category: .data, tier: .extended),
+        CLITool(name: "himalaya", binary: "himalaya", description: "IMAP/SMTP email CLI for portable mail skills",
+                brewFormula: "himalaya", category: .data, tier: .extended),
         CLITool(name: "delta", binary: "delta", description: "Better git diffs",
                 brewFormula: "git-delta", category: .git, tier: .extended),
         CLITool(name: "ImageMagick", binary: "magick", description: "Image processing",
@@ -152,6 +154,7 @@ enum ToolAugmentationManager {
         if installed["tree"] != nil { hints.append("tree") }
         if installed["tokei"] != nil { hints.append("tokei (code stats)") }
         if installed["ffmpeg"] != nil { hints.append("ffmpeg") }
+        if installed["himalaya"] != nil { hints.append("himalaya (mail)") }
 
         guard !hints.isEmpty else { return nil }
 

--- a/native/macos/Fae/Sources/Fae/FaeApp.swift
+++ b/native/macos/Fae/Sources/Fae/FaeApp.swift
@@ -204,7 +204,10 @@ class FaeAppDelegate: NSObject, NSApplicationDelegate {
         rustUiShell.conversation = conversation
         rustUiShell.faeCore = faeCore
         rustUiShell.onSettings = { [weak self] in
-            self?.openSettingsWindow(reason: "rust-ui-shell")
+            self?.rustUiShell.refreshWorkspaceSnapshot()
+        }
+        rustUiShell.onSettingsLegacy = { [weak self] in
+            self?.openSettingsWindow(reason: "rust-ui-shell-legacy")
         }
         rustUiShell.onTalkToggle = { [weak self] in
             guard let faeCore = self?.faeCore else { return }

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/MANIFEST.json
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/MANIFEST.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "capabilities": [
+    "execute"
+  ],
+  "allowedTools": [
+    "run_skill"
+  ],
+  "allowedDomains": [],
+  "dataClasses": [
+    "calendar",
+    "personal_data"
+  ],
+  "riskTier": "high",
+  "timeoutSeconds": 180,
+  "allowNetwork": true,
+  "allowSubprocess": false,
+  "integrity": {
+    "algorithm": "sha256",
+    "checksums": {
+      "SKILL.md": "b44cdad6db7a0cb827b626450bbe3df6dd16a7d29364760b9b5bc9dae78574f2",
+      "scripts/calendar_caldav.py": "f74cf06584c703b455f0d7eb1bc57e29d9a7309e14f0eb3e8a752816a4d455ed"
+    },
+    "signature": null
+  }
+}

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/SKILL.md
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: calendar-caldav
+description: List, create, update, and delete CalDAV events when the user asks for a portable calendar workflow.
+tags: [calendar, caldav, productivity]
+metadata:
+  author: fae
+  version: "1.0.0"
+---
+
+# Calendar CalDAV
+
+Calendar CalDAV lets Fae work with cross-platform calendar servers, including iCloud and Google CalDAV, through a Python executable skill. It is additive to the privileged macOS EventKit path in `AppleTools.swift`.
+
+## When to Use
+
+- The user asks about calendars in a cross-platform or non-Apple context.
+- The user wants to list upcoming events from iCloud/Google CalDAV using app-specific credentials.
+- The user asks to create, update, or delete a simple event on a configured CalDAV calendar.
+- Prefer the built-in `calendar` tool for macOS-local EventKit workflows unless portability is the point.
+
+## Prerequisites
+
+- Credentials must be stored in Keychain and injected with `run_skill.secret_bindings`; never store passwords in files or prompts.
+- Required environment variables: `CALDAV_URL`, `CALDAV_USERNAME`, and `CALDAV_PASSWORD`.
+- Optional environment variables: `CALDAV_CALENDAR` for the display name to prefer, `CALDAV_DEFAULT_TZ` for floating times.
+- iCloud users need an app-specific password. Google users need the correct CalDAV URL and app/OAuth credential flow for their account.
+- The script uses `uv run --script` with inline Python dependencies (`caldav`, `vobject`); Fae's Python runtime handles installation.
+
+## How to Run
+
+Use `run_skill` with skill `calendar-caldav` and script `calendar_caldav`.
+
+```json
+{
+  "name":"calendar-caldav",
+  "script":"calendar_caldav",
+  "params":{"action":"list_events","days":7},
+  "secret_bindings":{
+    "CALDAV_URL":"productivity.calendar.url",
+    "CALDAV_USERNAME":"productivity.calendar.username",
+    "CALDAV_PASSWORD":"productivity.calendar.password"
+  }
+}
+```
+
+## Quick Reference
+
+| Action | Required params | Purpose |
+|---|---|---|
+| `status` | none | Check environment readiness without revealing secrets |
+| `list_calendars` | none | List visible calendars for the principal |
+| `list_events` | optional `days`, `calendar`, `start`, `end` | List events in a date range |
+| `create_event` | `summary`, `start`, `end` | Create a simple VEVENT |
+| `update_event` | `uid` or `href`; plus changed fields | Update summary/start/end/description/location |
+| `delete_event` | `uid` or `href` | Delete a matching event |
+
+## Procedure
+
+1. Run `status` if setup is uncertain. If anything is missing, ask only for the missing setup item.
+2. For read-only questions, call `list_events` with the smallest range that answers the user.
+3. Before creating/updating/deleting events, restate the exact calendar, date/time, title, and attendees/details if any; ask for confirmation.
+4. Use ISO 8601 times. Include a timezone offset when possible.
+5. After mutation, run `list_events` for the affected window or return the server `href`/`uid` as proof.
+
+## Pitfalls
+
+- CalDAV URLs differ by provider and account. Ask for the provider setup page or test credentials rather than guessing.
+- Floating datetimes can land in the wrong timezone. Prefer offset timestamps such as `2026-06-13T09:30:00+01:00`.
+- Recurring event edits are provider-sensitive. This v1 skill handles simple events; ask before touching recurrence.
+- Do not reveal `CALDAV_PASSWORD` or raw Authorization headers in user-visible output.
+
+## Verification
+
+- `list_calendars` shows the expected iCloud or Google calendar.
+- `list_events` over the next seven days returns real event titles and times.
+- Create an event named `fae-skill-test`, then delete it by `uid` or `href`.
+- AppleTools calendar tests still pass; this skill does not replace EventKit.

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/scripts/calendar_caldav.py
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/calendar-caldav/scripts/calendar_caldav.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["caldav>=1.4.0", "vobject>=0.9.8"]
+# ///
+"""Fae executable skill for CalDAV calendar operations."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Any
+
+import caldav
+import vobject
+
+
+REQUIRED_ENV = ["CALDAV_URL", "CALDAV_USERNAME", "CALDAV_PASSWORD"]
+
+
+def emit(result: dict[str, Any], status: int = 0) -> int:
+    print(json.dumps(result, ensure_ascii=False, separators=(",", ":"), default=str))
+    return status
+
+
+def read_request() -> dict[str, Any]:
+    payload = sys.stdin.read().strip()
+    if not payload:
+        raise ValueError("empty request")
+    request = json.loads(payload)
+    params = request.get("params") or {}
+    if not isinstance(params, dict):
+        raise ValueError("params must be an object")
+    return params
+
+
+def env_status() -> dict[str, bool]:
+    return {name: bool(os.environ.get(name)) for name in REQUIRED_ENV}
+
+
+def missing_env() -> list[str]:
+    return [name for name in REQUIRED_ENV if not os.environ.get(name)]
+
+
+def status() -> dict[str, Any]:
+    missing = missing_env()
+    return {
+        "ok": True,
+        "ready": not missing,
+        "state": "ready" if not missing else "missing_env",
+        "required_env_present": env_status(),
+        "missing_env": missing,
+        "optional_env_present": {
+            "CALDAV_CALENDAR": bool(os.environ.get("CALDAV_CALENDAR")),
+            "CALDAV_DEFAULT_TZ": bool(os.environ.get("CALDAV_DEFAULT_TZ")),
+        },
+    }
+
+
+def require_env() -> tuple[str, str, str]:
+    missing = missing_env()
+    if missing:
+        raise ValueError("missing required environment variables: " + ", ".join(missing))
+    return (
+        os.environ["CALDAV_URL"],
+        os.environ["CALDAV_USERNAME"],
+        os.environ["CALDAV_PASSWORD"],
+    )
+
+
+def client() -> caldav.DAVClient:
+    url, username, password = require_env()
+    return caldav.DAVClient(url=url, username=username, password=password)
+
+
+def principal() -> Any:
+    return client().principal()
+
+
+def calendar_name(calendar: Any) -> str:
+    for attr in ("name", "id"):
+        try:
+            value = getattr(calendar, attr)
+            if callable(value):
+                value = value()
+            if value:
+                return str(value)
+        except Exception:  # noqa: BLE001 - provider metadata can be quirky.
+            continue
+    return str(getattr(calendar, "url", "calendar"))
+
+
+def calendars() -> list[Any]:
+    found = principal().calendars()
+    if not isinstance(found, list):
+        return list(found)
+    return found
+
+
+def select_calendar(params: dict[str, Any]) -> Any:
+    wanted = str(params.get("calendar") or os.environ.get("CALDAV_CALENDAR") or "").strip().lower()
+    found = calendars()
+    if not found:
+        raise ValueError("no CalDAV calendars found")
+    if not wanted:
+        return found[0]
+    for calendar in found:
+        name = calendar_name(calendar).lower()
+        url = str(getattr(calendar, "url", "")).lower()
+        if wanted == name or wanted in name or wanted in url:
+            return calendar
+    names = [calendar_name(calendar) for calendar in found]
+    raise ValueError(f"calendar not found: {wanted}; available: {names}")
+
+
+def list_calendars(_: dict[str, Any]) -> dict[str, Any]:
+    items = []
+    for calendar in calendars():
+        items.append({"name": calendar_name(calendar), "url": str(getattr(calendar, "url", ""))})
+    return {"ok": True, "calendars": items}
+
+
+def parse_datetime(value: Any, *, default: datetime | None = None) -> datetime:
+    if value is None or str(value).strip() == "":
+        if default is None:
+            raise ValueError("datetime value is required")
+        return default
+    text = str(value).strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    return parsed
+
+
+def range_from_params(params: dict[str, Any]) -> tuple[datetime, datetime]:
+    now = datetime.now(UTC)
+    days_value = params.get("days", 7)
+    try:
+        days = int(days_value)
+    except (TypeError, ValueError):
+        days = 7
+    days = max(1, min(366, days))
+    start = parse_datetime(params.get("start"), default=now)
+    end = parse_datetime(params.get("end"), default=start + timedelta(days=days))
+    return start, end
+
+
+def iso_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return str(value)
+
+
+def parse_event(event: Any) -> dict[str, Any]:
+    data = getattr(event, "data", None)
+    if not data and hasattr(event, "load"):
+        event.load()
+        data = getattr(event, "data", None)
+    if not data:
+        return {"href": str(getattr(event, "url", "")), "summary": "(no data)"}
+
+    component = vobject.readOne(data)
+    vevent = component.vevent
+    summary = getattr(getattr(vevent, "summary", None), "value", "")
+    uid = getattr(getattr(vevent, "uid", None), "value", "")
+    location = getattr(getattr(vevent, "location", None), "value", None)
+    description = getattr(getattr(vevent, "description", None), "value", None)
+    dtstart = getattr(getattr(vevent, "dtstart", None), "value", None)
+    dtend = getattr(getattr(vevent, "dtend", None), "value", None)
+    return {
+        "uid": str(uid),
+        "summary": str(summary),
+        "start": iso_value(dtstart),
+        "end": iso_value(dtend),
+        "location": str(location) if location else None,
+        "description": str(description) if description else None,
+        "href": str(getattr(event, "url", "")),
+    }
+
+
+def list_events(params: dict[str, Any]) -> dict[str, Any]:
+    calendar = select_calendar(params)
+    start, end = range_from_params(params)
+    events = calendar.events(start=start, end=end)
+    parsed = [parse_event(event) for event in events]
+    parsed.sort(key=lambda item: item.get("start") or "")
+    limit = int(params.get("limit") or 50)
+    return {
+        "ok": True,
+        "calendar": calendar_name(calendar),
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "events": parsed[: max(1, min(200, limit))],
+    }
+
+
+def escape_ical_text(value: Any) -> str:
+    text = str(value or "")
+    return (
+        text.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\r\n", "\\n")
+        .replace("\n", "\\n")
+    )
+
+
+def ical_datetime(value: datetime) -> str:
+    if value.tzinfo is not None:
+        return value.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return value.strftime("%Y%m%dT%H%M%S")
+
+
+def build_ical(params: dict[str, Any], *, uid: str | None = None) -> tuple[str, str]:
+    summary = str(params.get("summary") or "").strip()
+    if not summary:
+        raise ValueError("summary is required")
+    start = parse_datetime(params.get("start"))
+    end = parse_datetime(params.get("end"))
+    if end <= start:
+        raise ValueError("end must be after start")
+    event_uid = uid or str(params.get("uid") or uuid.uuid4())
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Fae//calendar-caldav//EN",
+        "BEGIN:VEVENT",
+        f"UID:{event_uid}",
+        f"DTSTAMP:{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}",
+        f"DTSTART:{ical_datetime(start)}",
+        f"DTEND:{ical_datetime(end)}",
+        f"SUMMARY:{escape_ical_text(summary)}",
+    ]
+    if params.get("description"):
+        lines.append(f"DESCRIPTION:{escape_ical_text(params.get('description'))}")
+    if params.get("location"):
+        lines.append(f"LOCATION:{escape_ical_text(params.get('location'))}")
+    lines.extend(["END:VEVENT", "END:VCALENDAR", ""])
+    return "\r\n".join(lines), event_uid
+
+
+def create_event(params: dict[str, Any]) -> dict[str, Any]:
+    calendar = select_calendar(params)
+    data, uid = build_ical(params)
+    event = calendar.add_event(data)
+    return {
+        "ok": True,
+        "action": "create_event",
+        "calendar": calendar_name(calendar),
+        "uid": uid,
+        "href": str(getattr(event, "url", "")),
+    }
+
+
+def find_event(params: dict[str, Any]) -> Any:
+    href = str(params.get("href") or "").strip()
+    uid = str(params.get("uid") or "").strip()
+    if not href and not uid:
+        raise ValueError("uid or href is required")
+    calendar = select_calendar(params)
+    start = datetime.now(UTC) - timedelta(days=366)
+    end = datetime.now(UTC) + timedelta(days=366 * 2)
+    for event in calendar.events(start=start, end=end):
+        if href and str(getattr(event, "url", "")) == href:
+            return event
+        parsed = parse_event(event)
+        if uid and parsed.get("uid") == uid:
+            return event
+    raise ValueError("matching event not found")
+
+
+def delete_event(params: dict[str, Any]) -> dict[str, Any]:
+    event = find_event(params)
+    parsed = parse_event(event)
+    event.delete()
+    return {"ok": True, "action": "delete_event", "deleted": parsed}
+
+
+def ensure_child(component: Any, name: str, value: Any) -> None:
+    if hasattr(component, name):
+        getattr(component, name).value = value
+    else:
+        component.add(name).value = value
+
+
+def update_event(params: dict[str, Any]) -> dict[str, Any]:
+    event = find_event(params)
+    parsed_before = parse_event(event)
+    data = getattr(event, "data", None)
+    if not data and hasattr(event, "load"):
+        event.load()
+        data = getattr(event, "data", None)
+    component = vobject.readOne(data)
+    vevent = component.vevent
+    if params.get("summary") is not None:
+        ensure_child(vevent, "summary", str(params.get("summary")))
+    if params.get("description") is not None:
+        ensure_child(vevent, "description", str(params.get("description")))
+    if params.get("location") is not None:
+        ensure_child(vevent, "location", str(params.get("location")))
+    if params.get("start") is not None:
+        ensure_child(vevent, "dtstart", parse_datetime(params.get("start")))
+    if params.get("end") is not None:
+        ensure_child(vevent, "dtend", parse_datetime(params.get("end")))
+    event.data = component.serialize()
+    event.save()
+    return {"ok": True, "action": "update_event", "before": parsed_before, "after": parse_event(event)}
+
+
+def dispatch(params: dict[str, Any]) -> dict[str, Any]:
+    action = str(params.get("action") or "status").strip()
+    if action == "status":
+        return status()
+    if action == "list_calendars":
+        return list_calendars(params)
+    if action == "list_events":
+        return list_events(params)
+    if action == "create_event":
+        return create_event(params)
+    if action == "update_event":
+        return update_event(params)
+    if action == "delete_event":
+        return delete_event(params)
+    return {"ok": False, "error": f"unsupported action: {action}"}
+
+
+def main() -> int:
+    try:
+        result = dispatch(read_request())
+        return emit(result, status=0 if result.get("ok") else 1)
+    except Exception as exc:  # noqa: BLE001 - skill boundary returns structured JSON.
+        return emit({"ok": False, "error": str(exc), "required_env_present": env_status()}, status=1)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/MANIFEST.json
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/MANIFEST.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "capabilities": [
+    "execute"
+  ],
+  "allowedTools": [
+    "run_skill"
+  ],
+  "allowedDomains": [],
+  "dataClasses": [
+    "contacts",
+    "personal_data"
+  ],
+  "riskTier": "high",
+  "timeoutSeconds": 120,
+  "allowNetwork": true,
+  "allowSubprocess": false,
+  "integrity": {
+    "algorithm": "sha256",
+    "checksums": {
+      "SKILL.md": "af4b44d213798d39a7c256f07772ace2ff01ce0813744ff0fa7f1622ebf6f192",
+      "scripts/contacts_carddav.py": "3f0d05d8d693d403011ffe286262839a9f6a352be1b2f42c22257b9101b16626"
+    },
+    "signature": null
+  }
+}

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/SKILL.md
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: contacts-carddav
+description: Search CardDAV contacts when the user asks for portable address-book lookup across providers.
+tags: [contacts, carddav, address-book, productivity]
+metadata:
+  author: fae
+  version: "1.0.0"
+---
+
+# Contacts CardDAV
+
+Contacts CardDAV lets Fae search a cross-platform address book, including iCloud and Google CardDAV-compatible endpoints. It is additive to the privileged macOS Contacts path in `AppleTools.swift`.
+
+## When to Use
+
+- The user asks for contact lookup that should work outside macOS.
+- The user wants to search iCloud/Google contacts via CardDAV credentials.
+- The user asks for a known contact's email or phone number and has configured a CardDAV address book.
+- Prefer the built-in `contacts` tool for macOS-local Contacts access unless portability is required.
+
+## Prerequisites
+
+- Credentials must be stored in Keychain and injected with `run_skill.secret_bindings`; never store passwords in SKILL.md, scripts, or config files.
+- Required environment variables: `CARDDAV_URL`, `CARDDAV_USERNAME`, and `CARDDAV_PASSWORD`.
+- `CARDDAV_URL` should point at an address-book collection URL when possible. Provider discovery can be added later.
+- iCloud users need an app-specific password. Google users need an app/OAuth-compatible credential and CardDAV endpoint.
+- The script uses `uv run --script` with inline Python dependency `vobject` for vCard parsing.
+
+## How to Run
+
+Use `run_skill` with skill `contacts-carddav` and script `contacts_carddav`.
+
+```json
+{
+  "name":"contacts-carddav",
+  "script":"contacts_carddav",
+  "params":{"action":"search","query":"Alice","limit":5},
+  "secret_bindings":{
+    "CARDDAV_URL":"productivity.contacts.url",
+    "CARDDAV_USERNAME":"productivity.contacts.username",
+    "CARDDAV_PASSWORD":"productivity.contacts.password"
+  }
+}
+```
+
+## Quick Reference
+
+| Action | Required params | Purpose |
+|---|---|---|
+| `status` | none | Check environment readiness without revealing secrets |
+| `search` | `query`; optional `limit` | Search names, emails, and phone numbers |
+| `raw_report` | `query`; optional `limit` | Return compact diagnostics for provider troubleshooting |
+
+## Procedure
+
+1. Run `status` if setup is uncertain. Ask only for the missing URL, username, or stored secret.
+2. Call `search` with the person's name, email fragment, or phone fragment.
+3. Return only the contact fields needed for the task. Avoid dumping full vCards.
+4. If the provider returns authorization or XML errors, explain the next setup step and do not ask the user to paste the password in chat.
+
+## Pitfalls
+
+- CardDAV collection URLs are provider-specific. A principal URL may not accept address-book queries.
+- Contact names can differ from how the user says them; search by email or phone fragment if name search fails.
+- Some servers limit broad searches. Keep limits small and ask for a narrower query if needed.
+- Never echo Authorization headers or raw vCards containing more data than the user requested.
+
+## Verification
+
+- `status` reports all required environment variables present.
+- Searching a known contact returns the expected name plus at least one email or phone field.
+- AppleTools Contacts tests still pass; this skill does not replace local Contacts integration.

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/scripts/contacts_carddav.py
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/contacts-carddav/scripts/contacts_carddav.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["vobject>=0.9.8"]
+# ///
+"""Fae executable skill for CardDAV contact lookup."""
+
+from __future__ import annotations
+
+import base64
+import html
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from typing import Any
+
+import vobject
+
+
+REQUIRED_ENV = ["CARDDAV_URL", "CARDDAV_USERNAME", "CARDDAV_PASSWORD"]
+DAV_NS = "DAV:"
+CARD_NS = "urn:ietf:params:xml:ns:carddav"
+
+
+def emit(result: dict[str, Any], status: int = 0) -> int:
+    print(json.dumps(result, ensure_ascii=False, separators=(",", ":"), default=str))
+    return status
+
+
+def read_request() -> dict[str, Any]:
+    payload = sys.stdin.read().strip()
+    if not payload:
+        raise ValueError("empty request")
+    request = json.loads(payload)
+    params = request.get("params") or {}
+    if not isinstance(params, dict):
+        raise ValueError("params must be an object")
+    return params
+
+
+def env_status() -> dict[str, bool]:
+    return {name: bool(os.environ.get(name)) for name in REQUIRED_ENV}
+
+
+def missing_env() -> list[str]:
+    return [name for name in REQUIRED_ENV if not os.environ.get(name)]
+
+
+def status() -> dict[str, Any]:
+    missing = missing_env()
+    return {
+        "ok": True,
+        "ready": not missing,
+        "state": "ready" if not missing else "missing_env",
+        "required_env_present": env_status(),
+        "missing_env": missing,
+    }
+
+
+def require_env() -> tuple[str, str, str]:
+    missing = missing_env()
+    if missing:
+        raise ValueError("missing required environment variables: " + ", ".join(missing))
+    return (
+        os.environ["CARDDAV_URL"],
+        os.environ["CARDDAV_USERNAME"],
+        os.environ["CARDDAV_PASSWORD"],
+    )
+
+
+def auth_header(username: str, password: str) -> str:
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def request_xml(url: str, method: str, body: str, *, depth: str = "1") -> bytes:
+    _, username, password = require_env()
+    data = body.encode("utf-8")
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Authorization", auth_header(username, password))
+    request.add_header("Content-Type", "application/xml; charset=utf-8")
+    request.add_header("Depth", depth)
+    request.add_header("User-Agent", "Fae contacts-carddav skill")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        details = exc.read().decode("utf-8", errors="replace")[:1000]
+        raise RuntimeError(f"CardDAV HTTP {exc.code}: {details}") from exc
+
+
+def addressbook_url(params: dict[str, Any]) -> str:
+    env_url, _, _ = require_env()
+    url = str(params.get("url") or env_url).strip()
+    if not url:
+        raise ValueError("CARDDAV_URL is required")
+    return url
+
+
+def report_body(query: str) -> str:
+    escaped = html.escape(query, quote=True)
+    if escaped:
+        filter_xml = f"""
+      <card:filter test="anyof">
+        <card:prop-filter name="FN"><card:text-match collation="i;unicode-casemap" match-type="contains">{escaped}</card:text-match></card:prop-filter>
+        <card:prop-filter name="N"><card:text-match collation="i;unicode-casemap" match-type="contains">{escaped}</card:text-match></card:prop-filter>
+        <card:prop-filter name="EMAIL"><card:text-match collation="i;unicode-casemap" match-type="contains">{escaped}</card:text-match></card:prop-filter>
+        <card:prop-filter name="TEL"><card:text-match collation="i;unicode-casemap" match-type="contains">{escaped}</card:text-match></card:prop-filter>
+      </card:filter>"""
+    else:
+        filter_xml = ""
+    return f"""<?xml version="1.0" encoding="utf-8" ?>
+<card:addressbook-query xmlns:d="DAV:" xmlns:card="urn:ietf:params:xml:ns:carddav">
+  <d:prop>
+    <d:getetag />
+    <card:address-data />
+  </d:prop>
+{filter_xml}
+</card:addressbook-query>"""
+
+
+def find_text(element: ET.Element, namespace: str, local: str) -> str | None:
+    found = element.find(f".//{{{namespace}}}{local}")
+    if found is not None and found.text:
+        return found.text
+    for child in element.iter():
+        if child.tag.endswith("}" + local) and child.text:
+            return child.text
+    return None
+
+
+def parse_multistatus(payload: bytes) -> list[dict[str, str]]:
+    root = ET.fromstring(payload)
+    responses = []
+    for response in root.findall(f".//{{{DAV_NS}}}response"):
+        href = find_text(response, DAV_NS, "href") or ""
+        etag = find_text(response, DAV_NS, "getetag") or ""
+        card = find_text(response, CARD_NS, "address-data") or ""
+        if card:
+            responses.append({"href": href, "etag": etag, "vcard": card})
+    if not responses:
+        for response in root.iter():
+            if response.tag.endswith("}response"):
+                href = find_text(response, DAV_NS, "href") or ""
+                card = find_text(response, CARD_NS, "address-data") or ""
+                if card:
+                    responses.append({"href": href, "etag": "", "vcard": card})
+    return responses
+
+
+def first_values(card: Any, name: str) -> list[str]:
+    values = []
+    for item in card.contents.get(name, []):
+        value = getattr(item, "value", None)
+        if value:
+            values.append(str(value))
+    return values
+
+
+def contact_summary(item: dict[str, str]) -> dict[str, Any]:
+    card = vobject.readOne(item["vcard"])
+    full_name = first_values(card, "fn")
+    emails = first_values(card, "email")
+    phones = first_values(card, "tel")
+    org_values = first_values(card, "org")
+    org = org_values[0] if org_values else None
+    if isinstance(org, list):
+        org = " ".join(str(part) for part in org)
+    return {
+        "href": item.get("href"),
+        "etag": item.get("etag"),
+        "name": full_name[0] if full_name else "",
+        "emails": emails,
+        "phones": phones,
+        "organization": org,
+    }
+
+
+def search(params: dict[str, Any]) -> dict[str, Any]:
+    query = str(params.get("query") or "").strip()
+    if not query:
+        raise ValueError("query is required")
+    try:
+        limit = int(params.get("limit") or 10)
+    except (TypeError, ValueError):
+        limit = 10
+    limit = max(1, min(50, limit))
+    payload = request_xml(addressbook_url(params), "REPORT", report_body(query), depth="1")
+    contacts = [contact_summary(item) for item in parse_multistatus(payload)]
+    return {"ok": True, "query": query, "count": len(contacts[:limit]), "contacts": contacts[:limit]}
+
+
+def raw_report(params: dict[str, Any]) -> dict[str, Any]:
+    query = str(params.get("query") or "").strip()
+    if not query:
+        raise ValueError("query is required")
+    payload = request_xml(addressbook_url(params), "REPORT", report_body(query), depth="1")
+    entries = parse_multistatus(payload)
+    return {
+        "ok": True,
+        "query": query,
+        "entries": [{"href": item.get("href"), "etag": item.get("etag"), "vcard_bytes": len(item.get("vcard", ""))} for item in entries[:20]],
+        "total_entries": len(entries),
+    }
+
+
+def dispatch(params: dict[str, Any]) -> dict[str, Any]:
+    action = str(params.get("action") or "status").strip()
+    if action == "status":
+        return status()
+    if action == "search":
+        return search(params)
+    if action == "raw_report":
+        return raw_report(params)
+    return {"ok": False, "error": f"unsupported action: {action}"}
+
+
+def main() -> int:
+    try:
+        result = dispatch(read_request())
+        return emit(result, status=0 if result.get("ok") else 1)
+    except Exception as exc:  # noqa: BLE001 - skill boundary returns structured JSON.
+        return emit({"ok": False, "error": str(exc), "required_env_present": env_status()}, status=1)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/MANIFEST.json
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/MANIFEST.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "capabilities": [
+    "execute"
+  ],
+  "allowedTools": [
+    "run_skill"
+  ],
+  "allowedDomains": [],
+  "dataClasses": [
+    "email",
+    "contacts",
+    "personal_data"
+  ],
+  "riskTier": "high",
+  "timeoutSeconds": 120,
+  "allowNetwork": true,
+  "allowSubprocess": true,
+  "integrity": {
+    "algorithm": "sha256",
+    "checksums": {
+      "SKILL.md": "51e75de3d05ab6bc2bf0e934848a09f05c6e13241d92b79d1254c0e31ddab097",
+      "scripts/mail_himalaya.py": "639518c887d91e448a6001c08f4050de33d0ff28300d81170171b7dd12010c5a"
+    },
+    "signature": null
+  }
+}

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/SKILL.md
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: mail-himalaya
+description: Read, search, and send IMAP/SMTP email with himalaya when the user asks about mail or wants a portable email action.
+tags: [mail, email, imap, smtp, himalaya]
+metadata:
+  author: fae
+  version: "1.0.0"
+---
+
+# Mail Himalaya
+
+Mail Himalaya lets Fae use the cross-platform `himalaya` CLI for IMAP/SMTP email. It is additive to the macOS Apple tools path; use it when a user asks for portable mail access, inbox triage, message search, or sending mail through a configured account.
+
+## When to Use
+
+- The user asks to list recent inbox mail, search mail, or summarize subjects.
+- The user asks Fae to draft or send a message through IMAP/SMTP.
+- The task should work outside macOS or without Apple Mail/EventKit APIs.
+- Prefer the built-in `mail` tool for privileged macOS-local mail workflows if that is explicitly requested.
+
+## Prerequisites
+
+- `himalaya` must be installed by Fae's tool augmentation flow (`brew install himalaya` or equivalent). This skill never installs tools itself.
+- The user must configure `himalaya` with their account (`himalaya account configure <name>`), or provide a profile already present in Himalaya's config.
+- Passwords and tokens must stay outside prompts and files. If the runtime needs secrets, store them in Keychain with `input_request`/`CredentialManager` and call `run_skill` with `secret_bindings` so values arrive only as environment variables.
+- For iCloud/Gmail, use provider app-specific passwords or OAuth material supported by Himalaya; never paste credentials into SKILL.md or scripts.
+
+## How to Run
+
+Use the `run_skill` tool with skill `mail-himalaya` and script `mail_himalaya`.
+
+```json
+{"name":"mail-himalaya","script":"mail_himalaya","params":{"action":"status"}}
+```
+
+If a secret is needed at execution time, bind it from Keychain:
+
+```json
+{
+  "name": "mail-himalaya",
+  "script": "mail_himalaya",
+  "params": {"action":"list_recent","account":"personal","folder":"INBOX","count":5},
+  "secret_bindings": {"HIMALAYA_PASSWORD":"productivity.mail.personal.password"}
+}
+```
+
+## Quick Reference
+
+| Action | Required params | Purpose |
+|---|---|---|
+| `status` | none | Check whether `himalaya` is installed and report configuration guidance |
+| `list_recent` | optional `account`, `folder`, `count` | List recent envelopes, newest first |
+| `search` | `query`; optional `account`, `folder`, `count` | Search envelopes with Himalaya's query DSL |
+| `send` | `to`, `subject`, `body`; optional `from`, `cc`, `account`, `save`, `dry_run` | Send an RFC 5322 message through Himalaya |
+
+## Procedure
+
+1. Confirm setup with `status`; if missing, explain that Fae can install `himalaya` through normal tool augmentation, not from this skill.
+2. For read-only requests, call `list_recent` or `search` with `count` capped to the minimum useful number.
+3. For sending, prepare the exact recipient, subject, and body. Ask for confirmation before setting `dry_run` to `false`.
+4. Return a concise summary. Do not include raw headers unless the user asks.
+5. If Himalaya returns an authentication or provider error, explain the provider-specific next step (app password, OAuth refresh, account configure) without asking the user to reveal the secret in chat.
+
+## Pitfalls
+
+- Himalaya message IDs are mailbox-scoped. Do not treat an ID from one folder as stable in another folder.
+- `message read` should not mark mail as seen, but flag operations do mutate state. Ask before mutating flags.
+- Some providers require app-specific passwords or OAuth setup; normal account passwords may fail.
+- Bcc is intentionally unsupported in v1 because raw `.eml` submission can leak a `Bcc:` header if the provider does not strip it.
+- Never echo environment variables, config files, or secrets from stderr back to the user.
+
+## Verification
+
+- `status` returns `installed: true` and a version string.
+- `list_recent` returns five real inbox subjects for the configured account.
+- `send` with `dry_run: true` returns the generated envelope summary without sending.
+- A confirmed `send` to the user's own address appears in the inbox/sent folder.

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/scripts/mail_himalaya.py
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/mail-himalaya/scripts/mail_himalaya.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Fae executable skill wrapper for the Himalaya mail CLI."""
+
+import email.utils
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+MAX_COUNT = 25
+TIMEOUT_SECONDS = 90
+
+
+def read_request() -> dict[str, Any]:
+    payload = sys.stdin.read().strip()
+    if not payload:
+        raise ValueError("empty request")
+    request = json.loads(payload)
+    params = request.get("params") or {}
+    if not isinstance(params, dict):
+        raise ValueError("params must be an object")
+    return params
+
+
+def emit(result: dict[str, Any], status: int = 0) -> int:
+    print(json.dumps(result, ensure_ascii=False, separators=(",", ":")))
+    return status
+
+
+def safe_count(value: Any, default: int = 5) -> int:
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        count = default
+    return max(1, min(MAX_COUNT, count))
+
+
+def himalaya_binary() -> str | None:
+    return shutil.which("himalaya")
+
+
+def run_himalaya(args: list[str], *, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    binary = himalaya_binary()
+    if binary is None:
+        raise FileNotFoundError("himalaya binary not found")
+    return subprocess.run(
+        [binary, *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT_SECONDS,
+        check=False,
+        env=os.environ.copy(),
+    )
+
+
+def run_with_account_variants(account: Any, args: list[str]) -> subprocess.CompletedProcess[str]:
+    account_name = str(account or "").strip()
+    variants: list[list[str]] = []
+    if account_name:
+        variants.append(["--account", account_name, *args])
+        variants.append(["-a", account_name, *args])
+    variants.append(args)
+
+    last: subprocess.CompletedProcess[str] | None = None
+    for variant in variants:
+        result = run_himalaya(variant)
+        if result.returncode == 0:
+            return result
+        last = result
+    if last is None:
+        raise RuntimeError("no himalaya command variant was attempted")
+    return last
+
+
+def parse_json_or_text(raw: str) -> Any:
+    text = raw.strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def redacted_stderr(text: str) -> str:
+    lowered = text.lower()
+    sensitive_markers = ["password", "token", "secret", "authorization"]
+    if any(marker in lowered for marker in sensitive_markers):
+        return "[redacted: command mentioned sensitive material]"
+    return text.strip()[:4000]
+
+
+def status() -> dict[str, Any]:
+    binary = himalaya_binary()
+    result: dict[str, Any] = {
+        "ok": True,
+        "installed": binary is not None,
+        "binary": binary,
+        "secrets_env_present": {
+            "HIMALAYA_PASSWORD": bool(os.environ.get("HIMALAYA_PASSWORD")),
+            "HIMALAYA_OAUTH_TOKEN": bool(os.environ.get("HIMALAYA_OAUTH_TOKEN")),
+        },
+    }
+    if binary is None:
+        result["state"] = "missing_binary"
+        result["next_step"] = "Install himalaya through Fae tool augmentation or brew; do not install from this skill."
+        return result
+
+    version = run_himalaya(["--version"])
+    result["version"] = (version.stdout or version.stderr).strip().splitlines()[:3]
+    result["state"] = "ready"
+    return result
+
+
+def list_recent(params: dict[str, Any]) -> dict[str, Any]:
+    folder = str(params.get("folder") or "INBOX").strip() or "INBOX"
+    count = safe_count(params.get("count"), default=5)
+    account = params.get("account")
+    args = ["--json", "envelope", "list", "-m", folder]
+    result = run_with_account_variants(account, args)
+    payload = parse_json_or_text(result.stdout)
+    ok = result.returncode == 0
+    return {
+        "ok": ok,
+        "action": "list_recent",
+        "folder": folder,
+        "count_requested": count,
+        "result": trim_envelopes(payload, count),
+        "stderr": redacted_stderr(result.stderr) if not ok else "",
+        "exit_code": result.returncode,
+    }
+
+
+def search(params: dict[str, Any]) -> dict[str, Any]:
+    query = str(params.get("query") or "").strip()
+    if not query:
+        return {"ok": False, "error": "query is required"}
+    folder = str(params.get("folder") or "INBOX").strip() or "INBOX"
+    count = safe_count(params.get("count"), default=10)
+    account = params.get("account")
+    args = ["--json", "envelope", "search", "-m", folder, *query.split()]
+    result = run_with_account_variants(account, args)
+    payload = parse_json_or_text(result.stdout)
+    ok = result.returncode == 0
+    return {
+        "ok": ok,
+        "action": "search",
+        "folder": folder,
+        "query": query,
+        "count_requested": count,
+        "result": trim_envelopes(payload, count),
+        "stderr": redacted_stderr(result.stderr) if not ok else "",
+        "exit_code": result.returncode,
+    }
+
+
+def trim_envelopes(payload: Any, count: int) -> Any:
+    if isinstance(payload, dict) and isinstance(payload.get("envelopes"), list):
+        trimmed = []
+        for item in payload["envelopes"][:count]:
+            if isinstance(item, dict):
+                trimmed.append({
+                    "id": item.get("id"),
+                    "message_id": item.get("message-id") or item.get("message_id"),
+                    "subject": item.get("subject"),
+                    "from": item.get("from"),
+                    "date": item.get("date"),
+                    "flags": item.get("flags"),
+                    "has_attachment": item.get("has-attachment") or item.get("has_attachment"),
+                })
+            else:
+                trimmed.append(item)
+        return {"envelopes": trimmed, "total_returned": len(trimmed)}
+    if isinstance(payload, list):
+        return payload[:count]
+    return payload
+
+
+def address_header(values: Any) -> str:
+    if values is None:
+        return ""
+    if isinstance(values, str):
+        return values.strip()
+    if isinstance(values, list):
+        return ", ".join(str(value).strip() for value in values if str(value).strip())
+    return str(values).strip()
+
+
+def build_message(params: dict[str, Any]) -> str:
+    to_header = address_header(params.get("to"))
+    subject = str(params.get("subject") or "").strip()
+    body = str(params.get("body") or "")
+    if not to_header:
+        raise ValueError("to is required")
+    if not subject:
+        raise ValueError("subject is required")
+
+    lines = []
+    from_header = address_header(params.get("from"))
+    if from_header:
+        lines.append(("From", from_header))
+    lines.append(("To", to_header))
+    cc_header = address_header(params.get("cc"))
+    if cc_header:
+        lines.append(("Cc", cc_header))
+    if address_header(params.get("bcc")):
+        raise ValueError("bcc is not supported by this v1 raw-message sender; use to/cc or provider UI")
+    lines.append(("Subject", subject))
+    lines.append(("Date", email.utils.formatdate(localtime=True)))
+    lines.append(("Content-Type", "text/plain; charset=utf-8"))
+    headers = "\n".join(f"{name}: {value}" for name, value in lines)
+    return f"{headers}\n\n{body}\n"
+
+
+def send(params: dict[str, Any]) -> dict[str, Any]:
+    message = build_message(params)
+    dry_run = params.get("dry_run", True)
+    if isinstance(dry_run, str):
+        dry_run = dry_run.lower() not in {"false", "0", "no"}
+    if dry_run:
+        return {
+            "ok": True,
+            "dry_run": True,
+            "to": address_header(params.get("to")),
+            "subject": str(params.get("subject") or ""),
+            "bytes": len(message.encode("utf-8")),
+            "message": "Dry run only; call with dry_run=false after user confirmation to send.",
+        }
+
+    args = ["message", "send"]
+    if params.get("save", True):
+        args.extend(["--save", str(params.get("sent_folder") or "sent")])
+
+    account = params.get("account")
+    account_name = str(account or "").strip()
+    variants: list[list[str]] = []
+    if account_name:
+        variants.append(["--account", account_name, *args])
+        variants.append(["-a", account_name, *args])
+    variants.append(args)
+
+    result: subprocess.CompletedProcess[str] | None = None
+    for variant in variants:
+        candidate = run_himalaya(variant, stdin=message)
+        result = candidate
+        if candidate.returncode == 0:
+            break
+    if result is None:
+        raise RuntimeError("no himalaya send command variant was attempted")
+
+    ok = result.returncode == 0
+    return {
+        "ok": ok,
+        "dry_run": False,
+        "to": address_header(params.get("to")),
+        "subject": str(params.get("subject") or ""),
+        "stdout": result.stdout.strip()[:4000],
+        "stderr": redacted_stderr(result.stderr) if not ok else "",
+        "exit_code": result.returncode,
+    }
+
+
+def main() -> int:
+    try:
+        params = read_request()
+        action = str(params.get("action") or "status").strip()
+        if action == "status":
+            return emit(status())
+        if action == "list_recent":
+            return emit(list_recent(params))
+        if action == "search":
+            return emit(search(params))
+        if action == "send":
+            return emit(send(params))
+        return emit({"ok": False, "error": f"unsupported action: {action}"}, status=1)
+    except FileNotFoundError as exc:
+        return emit({"ok": False, "state": "missing_binary", "error": str(exc)}, status=1)
+    except subprocess.TimeoutExpired:
+        return emit({"ok": False, "error": "himalaya command timed out"}, status=1)
+    except Exception as exc:  # noqa: BLE001 - skill boundary returns structured JSON.
+        return emit({"ok": False, "error": str(exc)}, status=1)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/native/macos/Fae/Sources/Fae/RustUiShellController.swift
+++ b/native/macos/Fae/Sources/Fae/RustUiShellController.swift
@@ -19,6 +19,7 @@ final class RustUiShellController {
     weak var faeCore: FaeCore?
 
     var onSettings: (() -> Void)?
+    var onSettingsLegacy: (() -> Void)?
     var onResetConversation: (() -> Void)?
     /// Plain left-click on the orb body (S18 push-to-talk toggle).
     var onTalkToggle: (() -> Void)?
@@ -151,6 +152,7 @@ final class RustUiShellController {
         sendStateForCurrentOrbMode()
         sendRuntimeStatus()
         sendControlsSnapshot()
+        sendSettingsSnapshot()
         sendConversationSnapshot()
         refreshWorkspaceSnapshot()
     }
@@ -271,6 +273,14 @@ final class RustUiShellController {
             .removeDuplicates()
             .sink { [weak self] _ in
                 self?.sendControlsSnapshot()
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .faeSettingsChanged)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.sendControlsSnapshot()
+                self?.sendSettingsSnapshot()
             }
             .store(in: &cancellables)
 
@@ -405,6 +415,20 @@ final class RustUiShellController {
         ])
     }
 
+    private func sendSettingsSnapshot() {
+        guard let faeCore else { return }
+        var snapshot = faeCore.settingsSnapshot()
+        snapshot["type"] = "settings_snapshot"
+        send(snapshot)
+        let sectionCount = (snapshot["sections"] as? [[String: Any]])?.count ?? 0
+        let cardCount = (snapshot["cards"] as? [[String: Any]])?.count ?? 0
+        NSLog(
+            "RustUiShellController: settings_snapshot sent sections=%d cards=%d",
+            sectionCount,
+            cardCount
+        )
+    }
+
     private func sendConversationSnapshot(_ messages: [ChatMessage]? = nil) {
         send(["type": "clear_conversation"])
         let snapshot = (messages ?? conversation?.messages ?? []).suffix(40)
@@ -490,8 +514,60 @@ final class RustUiShellController {
             Task { @MainActor in
                 faeCore.setThinkingLevel(level)
             }
+        case "settings_request_snapshot":
+            sendSettingsSnapshot()
+        case "settings_set":
+            guard let key = event.key, let value = event.value else {
+                NSLog("RustUiShellController: settings_set missing key/value")
+                return
+            }
+            NSLog("RustUiShellController: settings_set received key=%@", key)
+            applySettingsPanelValue(key: key, rawValue: value)
         default:
             NSLog("RustUiShellController: unknown shell event type %@", event.type)
+        }
+    }
+
+    private func applySettingsPanelValue(key: String, rawValue: String) {
+        guard let faeCore else { return }
+        guard let value = Self.coerceSettingsPanelValue(key: key, rawValue: rawValue) else {
+            NSLog("RustUiShellController: rejected settings_set key=%@ value=%@", key, rawValue)
+            sendSettingsSnapshot()
+            return
+        }
+        faeCore.patchConfig(key: key, payload: ["value": value])
+        NSLog("RustUiShellController: settings_set applied key=%@", key)
+        sendSettingsSnapshot()
+    }
+
+    private static func coerceSettingsPanelValue(key: String, rawValue: String) -> Any? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch key {
+        case "tool_mode":
+            let migrated = FaeConfig.migrateToolMode(trimmed)
+            return ["assistant", "full"].contains(migrated) ? migrated : nil
+        case "llm.thinking_level":
+            return FaeThinkingLevel(rawValue: trimmed)?.rawValue
+        case "privacy.mode":
+            return ["strict_local", "local_preferred", "connected"].contains(trimmed) ? trimmed : nil
+        case "awareness.pause_on_battery", "awareness.pause_on_thermal_pressure":
+            if trimmed == "true" { return true }
+            if trimmed == "false" { return false }
+            return nil
+        case "awareness.camera_interval_seconds":
+            guard let interval = Int(trimmed), [10, 30, 60, 120].contains(interval) else { return nil }
+            return interval
+        case "awareness.screen_interval_seconds":
+            guard let interval = Int(trimmed), [10, 19, 30, 60].contains(interval) else { return nil }
+            return interval
+        case "tts.speed":
+            guard let speed = Double(trimmed), (0.7 ... 1.4).contains(speed) else { return nil }
+            return speed
+        case "llm.temperature":
+            guard let temperature = Double(trimmed), (0.3 ... 1.0).contains(temperature) else { return nil }
+            return temperature
+        default:
+            return nil
         }
     }
 
@@ -532,7 +608,8 @@ final class RustUiShellController {
 
     private func handleMenuAction(_ action: String) {
         switch action {
-        case "settings": onSettings?()
+        case "settings": sendSettingsSnapshot()
+        case "settings_legacy": onSettingsLegacy?()
         case "talk_toggle":
             NSLog("RustUiShellController: talk_toggle received")
             onTalkToggle?()
@@ -607,5 +684,6 @@ private struct ShellEvent: Decodable {
     let enabled: Bool?
     let active: Bool?
     let text: String?
+    let key: String?
     let value: String?
 }

--- a/native/macos/Fae/Tests/HandoffTests/SkillActivationTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/SkillActivationTests.swift
@@ -16,7 +16,7 @@ final class SkillActivationTests: XCTestCase {
         let manager = SkillManager()
         let skills = await manager.discoverSkills()
 
-        XCTAssertGreaterThanOrEqual(skills.count, 26, "Expected at least 26 bundled skills (21 original + 5 new)")
+        XCTAssertGreaterThanOrEqual(skills.count, 30, "Expected at least 30 bundled skills including productivity wave")
 
         for skill in skills {
             XCTAssertFalse(skill.name.isEmpty, "Skill name must not be empty")
@@ -38,6 +38,9 @@ final class SkillActivationTests: XCTestCase {
             "file-organizer",
             "smart-home",
             "channel-hub",
+            "mail-himalaya",
+            "calendar-caldav",
+            "contacts-carddav",
         ]
 
         for expected in expectedNew {
@@ -100,6 +103,9 @@ final class SkillActivationTests: XCTestCase {
         XCTAssertTrue(names.contains("file-organizer"))
         XCTAssertTrue(names.contains("smart-home"))
         XCTAssertTrue(names.contains("channel-hub"))
+        XCTAssertTrue(names.contains("mail-himalaya"))
+        XCTAssertTrue(names.contains("calendar-caldav"))
+        XCTAssertTrue(names.contains("contacts-carddav"))
     }
 
     /// Prompt metadata descriptions are concise (under 200 chars for built-in skills).
@@ -133,6 +139,7 @@ final class SkillActivationTests: XCTestCase {
         let skillNames = [
             "document-analyst", "email-triage", "focus-defender",
             "system-health", "file-organizer", "smart-home", "channel-hub",
+            "mail-himalaya", "calendar-caldav", "contacts-carddav",
         ]
 
         for name in skillNames {
@@ -170,6 +177,7 @@ final class SkillActivationTests: XCTestCase {
         let skillNames = [
             "document-analyst", "email-triage", "focus-defender",
             "system-health", "file-organizer", "smart-home", "channel-hub",
+            "mail-himalaya", "calendar-caldav", "contacts-carddav",
         ]
 
         for name in skillNames {

--- a/native/macos/Fae/Tests/HandoffTests/SkillBypassRegressionTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/SkillBypassRegressionTests.swift
@@ -157,7 +157,7 @@ final class SkillBypassRegressionTests: XCTestCase {
         let manager = SkillManager()
         let skills = await manager.discoverSkills()
 
-        for skillName in ["forge", "toolbox"] {
+        for skillName in ["forge", "toolbox", "mail-himalaya", "calendar-caldav", "contacts-carddav"] {
             guard let skill = skills.first(where: { $0.name == skillName }) else {
                 XCTFail("Expected built-in skill \(skillName) to be discovered")
                 continue

--- a/native/macos/Fae/Tests/IntegrationTests/ToolAugmentationManagerTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/ToolAugmentationManagerTests.swift
@@ -42,6 +42,13 @@ final class ToolAugmentationManagerTests: XCTestCase {
         XCTAssertTrue(fragment!.contains("jq"))
     }
 
+    func testRegistryIncludesHimalayaAsExtendedTool() {
+        let tool = ToolAugmentationManager.registry.first { $0.binary == "himalaya" }
+        XCTAssertNotNil(tool)
+        XCTAssertEqual(tool?.brewFormula, "himalaya")
+        XCTAssertEqual(tool?.tier, .extended)
+    }
+
     // MARK: - formatProjectsForMemory
 
     func testFormatProjectsForMemoryEmpty() {

--- a/native/rust/fae-ui-shell/src/main.rs
+++ b/native/rust/fae-ui-shell/src/main.rs
@@ -5,17 +5,17 @@ use std::{
     error::Error,
     io::{self, BufRead, Write},
     thread,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use menu::{MenuAction, OrbMenu};
 use protocol::{
-    FaeUiState, SchedulerTask, SettingItem, SettingsCard, SettingsSection, ShellCommand,
-    SkillSummary,
+    FaeUiState, SchedulerTask, SettingItem, SettingOption, SettingsCard, SettingsSection,
+    ShellCommand, SkillSummary,
 };
 use tao::{
     dpi::{PhysicalPosition, PhysicalSize},
-    event::{ElementState, Event, KeyEvent, MouseButton, WindowEvent},
+    event::{ElementState, Event, KeyEvent, MouseButton, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoopBuilder},
     keyboard::KeyCode,
     window::{Window, WindowBuilder},
@@ -478,6 +478,10 @@ impl State {
 
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
+    if std::env::args().any(|arg| arg == "--smoke-settings-panel") {
+        return run_settings_panel_smoke();
+    }
+
     let mut event_loop_builder = EventLoopBuilder::<UserEvent>::with_user_event();
     #[allow(unused_mut)]
     let mut event_loop = event_loop_builder.build();
@@ -743,6 +747,109 @@ fn main() -> Result<(), Box<dyn Error>> {
     });
 }
 
+fn run_settings_panel_smoke() -> Result<(), Box<dyn Error>> {
+    let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
+    let proxy = event_loop.create_proxy();
+    let panel_proxy = proxy.clone();
+    let exit_proxy = proxy.clone();
+    thread::spawn(move || {
+        thread::sleep(Duration::from_secs(10));
+        let _ = exit_proxy.send_event(UserEvent::Bridge(ShellCommand::Quit));
+    });
+
+    let mut orb_ui = OrbUiModel::new();
+    orb_ui.set_settings(smoke_settings_sections(), smoke_settings_cards());
+    let mut web_panels = Vec::new();
+    let mut opened = false;
+
+    event_loop.run(move |event, target, control_flow| {
+        *control_flow = ControlFlow::Poll;
+        match event {
+            Event::NewEvents(StartCause::Init) if !opened => {
+                opened = true;
+                match open_settings_panel(target, &orb_ui, &panel_proxy) {
+                    Ok(panel) => {
+                        log::info!("smoke settings panel opened");
+                        web_panels.push(panel);
+                    }
+                    Err(error) => {
+                        log::error!("failed to open smoke settings panel: {error}");
+                        *control_flow = ControlFlow::Exit;
+                    }
+                }
+            }
+            Event::UserEvent(UserEvent::Bridge(ShellCommand::Quit)) => {
+                log::info!("smoke settings panel exit");
+                *control_flow = ControlFlow::Exit;
+            }
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => {
+                *control_flow = ControlFlow::Exit;
+            }
+            _ => {}
+        }
+    });
+}
+
+fn smoke_settings_sections() -> Vec<SettingsSection> {
+    vec![SettingsSection {
+        id: "voice".to_string(),
+        title: "Voice".to_string(),
+        description: Some("Opaque WebKitGTK smoke controls for Linux rendering.".to_string()),
+        settings: vec![
+            SettingItem {
+                key: "tts.speed".to_string(),
+                title: "Playback speed".to_string(),
+                description: "Adjust how quickly Fae speaks.".to_string(),
+                kind: "number".to_string(),
+                value: "1.10".to_string(),
+                options: None,
+                min: Some("0.7".to_string()),
+                max: Some("1.4".to_string()),
+                step: Some("0.05".to_string()),
+                unit: Some("multiplier".to_string()),
+                read_only: Some(false),
+            },
+            SettingItem {
+                key: "llm.thinking_level".to_string(),
+                title: "Thinking depth".to_string(),
+                description: "Reasoning budget for future turns.".to_string(),
+                kind: "select".to_string(),
+                value: "fast".to_string(),
+                options: Some(vec![
+                    SettingOption {
+                        value: "fast".to_string(),
+                        label: "Fast".to_string(),
+                    },
+                    SettingOption {
+                        value: "deep".to_string(),
+                        label: "Deep".to_string(),
+                    },
+                ]),
+                min: None,
+                max: None,
+                step: None,
+                unit: None,
+                read_only: Some(false),
+            },
+        ],
+    }]
+}
+
+fn smoke_settings_cards() -> Vec<SettingsCard> {
+    vec![SettingsCard {
+        title: "Opaque fallback".to_string(),
+        body:
+            "This card validates the Settings panel on WebKitGTK without relying on transparency."
+                .to_string(),
+        detail: Some(
+            "The pill may still show compositor-specific transparency artifacts.".to_string(),
+        ),
+    }]
+}
+
 fn spawn_stdin_bridge(proxy: tao::event_loop::EventLoopProxy<UserEvent>) {
     thread::spawn(move || {
         let stdin = io::stdin();
@@ -952,6 +1059,27 @@ const LONG_PRESS_MS: u128 = 400;
 /// Cursor travel that turns a pending press into a window drag.
 const PRESS_SLOP_PX: f64 = 8.0;
 
+fn build_webview_for_window<'a>(
+    window: &'a Window,
+    builder: WebViewBuilder<'a>,
+) -> Result<WebView, Box<dyn Error>> {
+    #[cfg(target_os = "linux")]
+    {
+        use tao::platform::unix::WindowExtUnix;
+        use wry::WebViewBuilderExtUnix;
+
+        let container = window
+            .default_vbox()
+            .ok_or_else(|| io::Error::other("tao GTK window missing default vbox"))?;
+        Ok(builder.build_gtk(container)?)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Ok(builder.build(window)?)
+    }
+}
+
 fn open_pill_panel(
     target: &tao::event_loop::EventLoop<UserEvent>,
 ) -> Result<PillPanel, Box<dyn Error>> {
@@ -967,13 +1095,15 @@ fn open_pill_panel(
     if let Err(error) = window.set_ignore_cursor_events(true) {
         log::warn!("pill window could not be made click-through: {error}");
     }
-    let webview = WebViewBuilder::new()
-        .with_transparent(true)
-        // Belt-and-braces: WKWebView paints a white canvas in light mode even
-        // with a transparent body unless the background colour is cleared too.
-        .with_background_color((0, 0, 0, 0))
-        .with_html(PILL_HTML)
-        .build(&window)?;
+    let webview = build_webview_for_window(
+        &window,
+        WebViewBuilder::new()
+            .with_transparent(true)
+            // Belt-and-braces: WKWebView paints a white canvas in light mode even
+            // with a transparent body unless the background colour is cleared too.
+            .with_background_color((0, 0, 0, 0))
+            .with_html(PILL_HTML),
+    )?;
     Ok(PillPanel { window, webview })
 }
 
@@ -1120,14 +1250,17 @@ fn open_messages_panel(
         .build(target)?;
     let html = messages_html(orb_ui);
     let proxy = panel_proxy.clone();
-    let webview = WebViewBuilder::new()
-        .with_html(html)
-        .with_ipc_handler(move |request| {
-            if let Err(error) = proxy.send_event(UserEvent::PanelAction(request.body().clone())) {
-                log::warn!("failed to forward messages panel IPC: {error}");
-            }
-        })
-        .build(&window)?;
+    let webview = build_webview_for_window(
+        &window,
+        WebViewBuilder::new()
+            .with_html(html)
+            .with_ipc_handler(move |request| {
+                if let Err(error) = proxy.send_event(UserEvent::PanelAction(request.body().clone()))
+                {
+                    log::warn!("failed to forward messages panel IPC: {error}");
+                }
+            }),
+    )?;
     Ok(WebPanel {
         kind: WebPanelKind::Messages,
         window,
@@ -1378,7 +1511,7 @@ fn open_browser_data_panel(
         .with_decorations(true)
         .build(target)?;
     let html = browser_data_html(orb_ui);
-    let webview = WebViewBuilder::new().with_html(html).build(&window)?;
+    let webview = build_webview_for_window(&window, WebViewBuilder::new().with_html(html))?;
     Ok(WebPanel {
         kind: WebPanelKind::BrowserData,
         window,
@@ -1422,14 +1555,17 @@ fn open_settings_panel(
         .build(target)?;
     window.set_focus();
     let proxy = panel_proxy.clone();
-    let webview = WebViewBuilder::new()
-        .with_html(settings_html(orb_ui))
-        .with_ipc_handler(move |request| {
-            if let Err(error) = proxy.send_event(UserEvent::PanelAction(request.body().clone())) {
-                log::warn!("failed to forward settings panel IPC: {error}");
-            }
-        })
-        .build(&window)?;
+    let webview = build_webview_for_window(
+        &window,
+        WebViewBuilder::new()
+            .with_html(settings_html(orb_ui))
+            .with_ipc_handler(move |request| {
+                if let Err(error) = proxy.send_event(UserEvent::PanelAction(request.body().clone()))
+                {
+                    log::warn!("failed to forward settings panel IPC: {error}");
+                }
+            }),
+    )?;
     window.set_focus();
     Ok(WebPanel {
         kind: WebPanelKind::Settings,
@@ -1639,14 +1775,17 @@ fn open_scheduler_panel(
         .with_always_on_top(true)
         .build(target)?;
     let proxy = panel_proxy.clone();
-    let webview = WebViewBuilder::new()
-        .with_html(scheduler_html(orb_ui))
-        .with_ipc_handler(move |request| {
-            if let Err(error) = proxy.send_event(UserEvent::PanelAction(request.body().clone())) {
-                log::warn!("failed to forward scheduler panel IPC: {error}");
-            }
-        })
-        .build(&window)?;
+    let webview = build_webview_for_window(
+        &window,
+        WebViewBuilder::new()
+            .with_html(scheduler_html(orb_ui))
+            .with_ipc_handler(move |request| {
+                if let Err(error) = proxy.send_event(UserEvent::PanelAction(request.body().clone()))
+                {
+                    log::warn!("failed to forward scheduler panel IPC: {error}");
+                }
+            }),
+    )?;
     Ok(WebPanel {
         kind: WebPanelKind::Scheduler,
         window,
@@ -1666,14 +1805,17 @@ fn open_skills_panel(
         .with_always_on_top(true)
         .build(target)?;
     let proxy = panel_proxy.clone();
-    let webview = WebViewBuilder::new()
-        .with_html(skills_html(orb_ui))
-        .with_ipc_handler(move |request| {
-            if let Err(error) = proxy.send_event(UserEvent::PanelAction(request.body().clone())) {
-                log::warn!("failed to forward skills panel IPC: {error}");
-            }
-        })
-        .build(&window)?;
+    let webview = build_webview_for_window(
+        &window,
+        WebViewBuilder::new()
+            .with_html(skills_html(orb_ui))
+            .with_ipc_handler(move |request| {
+                if let Err(error) = proxy.send_event(UserEvent::PanelAction(request.body().clone()))
+                {
+                    log::warn!("failed to forward skills panel IPC: {error}");
+                }
+            }),
+    )?;
     Ok(WebPanel {
         kind: WebPanelKind::Skills,
         window,
@@ -1759,7 +1901,7 @@ fn show_context_menu(menu: &OrbMenu, window: &Window, position: PhysicalPosition
 
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (menu, window, position);
-        log::warn!("context menu popup is only wired for macOS in this POC");
+        let _ = (&menu.menu, window, position);
+        log::warn!("context menu popup is not wired for this platform yet");
     }
 }

--- a/native/rust/fae-ui-shell/src/main.rs
+++ b/native/rust/fae-ui-shell/src/main.rs
@@ -9,7 +9,10 @@ use std::{
 };
 
 use menu::{MenuAction, OrbMenu};
-use protocol::{FaeUiState, SchedulerTask, ShellCommand, SkillSummary};
+use protocol::{
+    FaeUiState, SchedulerTask, SettingItem, SettingsCard, SettingsSection, ShellCommand,
+    SkillSummary,
+};
 use tao::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{ElementState, Event, KeyEvent, MouseButton, WindowEvent},
@@ -89,6 +92,7 @@ enum WebPanelKind {
     BrowserData,
     Messages,
     Scheduler,
+    Settings,
     Skills,
 }
 
@@ -118,6 +122,8 @@ struct OrbUiModel {
     messages: Vec<TranscriptMessage>,
     scheduler_tasks: Vec<SchedulerTask>,
     skills: Vec<SkillSummary>,
+    settings_sections: Vec<SettingsSection>,
+    settings_cards: Vec<SettingsCard>,
 }
 
 impl OrbUiModel {
@@ -132,6 +138,8 @@ impl OrbUiModel {
             messages: Vec::new(),
             scheduler_tasks: Vec::new(),
             skills: Vec::new(),
+            settings_sections: Vec::new(),
+            settings_cards: Vec::new(),
         }
     }
 
@@ -169,6 +177,11 @@ impl OrbUiModel {
 
     fn set_skills(&mut self, skills: Vec<SkillSummary>) {
         self.skills = skills;
+    }
+
+    fn set_settings(&mut self, sections: Vec<SettingsSection>, cards: Vec<SettingsCard>) {
+        self.settings_sections = sections;
+        self.settings_cards = cards;
     }
 }
 
@@ -847,6 +860,10 @@ fn apply_bridge_command(
             orb_ui.thinking = thinking;
             refresh_messages_panels(web_panels, orb_ui);
         }
+        ShellCommand::SettingsSnapshot { sections, cards } => {
+            orb_ui.set_settings(sections, cards);
+            refresh_settings_panels(web_panels, orb_ui);
+        }
         ShellCommand::ShowMessages => {
             log::info!(
                 "show_messages bridge command ignored; Messages opens from orb-owned menu/button"
@@ -880,6 +897,10 @@ fn handle_menu_action(
     panel_proxy: &tao::event_loop::EventLoopProxy<UserEvent>,
 ) {
     match action {
+        MenuAction::Settings => match open_settings_panel(target, orb_ui, panel_proxy) {
+            Ok(panel) => web_panels.push(panel),
+            Err(error) => log::error!("failed to open settings panel: {error}"),
+        },
         MenuAction::ShowMessages => match open_messages_panel(target, orb_ui, panel_proxy) {
             Ok(panel) => web_panels.push(panel),
             Err(error) => log::error!("failed to open messages panel: {error}"),
@@ -896,7 +917,7 @@ fn handle_menu_action(
             Ok(panel) => web_panels.push(panel),
             Err(error) => log::error!("failed to open skills panel: {error}"),
         },
-        MenuAction::HideFae | MenuAction::Quit | MenuAction::Stop => {}
+        MenuAction::SettingsLegacy | MenuAction::HideFae | MenuAction::Quit | MenuAction::Stop => {}
         other => {
             log::info!("stubbed Fae menu action: {other:?}");
         }
@@ -1166,6 +1187,10 @@ fn refresh_skills_panels(web_panels: &[WebPanel], orb_ui: &OrbUiModel) {
     refresh_panel_kind(web_panels, WebPanelKind::Skills, skills_html(orb_ui));
 }
 
+fn refresh_settings_panels(web_panels: &[WebPanel], orb_ui: &OrbUiModel) {
+    refresh_panel_kind(web_panels, WebPanelKind::Settings, settings_html(orb_ui));
+}
+
 fn messages_html(orb_ui: &OrbUiModel) -> String {
     // Status: a slim one-line chip. While waking it carries a progress bar;
     // once running it collapses to a quiet "● Ready · model" line; errors go
@@ -1380,6 +1405,225 @@ fn browser_data_html(orb_ui: &OrbUiModel) -> String {
         message = html_escape(&orb_ui.status_message),
         progress = html_escape(&progress),
         message_count = message_count
+    )
+}
+
+fn open_settings_panel(
+    target: &tao::event_loop::EventLoopWindowTarget<UserEvent>,
+    orb_ui: &OrbUiModel,
+    panel_proxy: &tao::event_loop::EventLoopProxy<UserEvent>,
+) -> Result<WebPanel, Box<dyn Error>> {
+    let window = WindowBuilder::new()
+        .with_title("Fae Settings")
+        .with_inner_size(PhysicalSize::new(880, 680))
+        .with_decorations(true)
+        .with_always_on_top(true)
+        .with_focused(true)
+        .build(target)?;
+    window.set_focus();
+    let proxy = panel_proxy.clone();
+    let webview = WebViewBuilder::new()
+        .with_html(settings_html(orb_ui))
+        .with_ipc_handler(move |request| {
+            if let Err(error) = proxy.send_event(UserEvent::PanelAction(request.body().clone())) {
+                log::warn!("failed to forward settings panel IPC: {error}");
+            }
+        })
+        .build(&window)?;
+    window.set_focus();
+    Ok(WebPanel {
+        kind: WebPanelKind::Settings,
+        window,
+        webview,
+    })
+}
+
+fn settings_html(orb_ui: &OrbUiModel) -> String {
+    let sections = if orb_ui.settings_sections.is_empty() {
+        "<section class='card'><h2>Waiting for settings</h2><p class='muted'>The Swift host has not sent a settings snapshot yet.</p></section>".to_string()
+    } else {
+        orb_ui
+            .settings_sections
+            .iter()
+            .map(settings_section_html)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let cards = if orb_ui.settings_cards.is_empty() {
+        String::new()
+    } else {
+        orb_ui
+            .settings_cards
+            .iter()
+            .map(settings_card_html)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!(
+        r#"<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>
+<style>
+:root{{color-scheme:dark;--bg:#0F1013;--panel:#1A1820;--panel2:#221F28;--text:#CEC4DC;--soft:#9A90A8;--cream:#E8DED2;--gold:#E6C05A;--glen:#8FB8A2;--berry:#C4788A}}
+*{{box-sizing:border-box}}
+body{{margin:0;background:linear-gradient(135deg,#0F1013 0%,#18151D 52%,#221F28 100%);color:var(--text);font:14px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}}
+main{{min-height:100vh;padding:28px;display:grid;gap:18px}}
+header{{border:1px solid rgba(180,168,196,.24);border-radius:22px;padding:24px;background:#1A1820;box-shadow:0 24px 80px rgba(0,0,0,.38)}}
+h1{{margin:0 0 8px;font:42px 'Instrument Serif',Georgia,serif;color:var(--cream);letter-spacing:.01em}}
+.lede{{margin:0;color:var(--soft);line-height:1.55;max-width:760px}}
+.grid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px;align-items:start}}
+.card{{border:1px solid rgba(180,168,196,.22);border-radius:18px;background:#1A1820;padding:18px;box-shadow:0 18px 48px rgba(0,0,0,.28)}}
+h2{{margin:0 0 6px;font:27px 'Instrument Serif',Georgia,serif;color:var(--cream)}}
+h3{{margin:0 0 5px;font-size:14px;color:var(--text)}}
+p{{margin:0;line-height:1.5}}.muted{{color:var(--soft)}}
+.setting{{display:grid;grid-template-columns:1fr minmax(120px,190px);gap:14px;align-items:center;padding:13px 0;border-top:1px solid rgba(255,255,255,.07)}}
+.setting:first-of-type{{border-top:0}}
+.desc{{font-size:12px;color:var(--soft)}}
+input,select{{width:100%;border:1px solid rgba(180,168,196,.30);border-radius:10px;background:#0F1013;color:var(--text);padding:8px 10px;font:13px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;outline:none}}
+input:focus,select:focus{{border-color:rgba(230,192,90,.68);box-shadow:0 0 0 3px rgba(230,192,90,.10)}}
+input[type='checkbox']{{width:22px;height:22px;justify-self:end;accent-color:var(--gold)}}
+.number-control{{display:grid;grid-template-columns:34px 1fr 34px;gap:6px;align-items:center}}
+.stepper{{border-radius:10px;padding:8px 0;line-height:1;color:var(--cream);background:rgba(230,192,90,.10)}}
+.unit{{font-size:11px;color:var(--soft);margin-top:4px;text-align:right}}
+.info-grid{{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px}}
+.info{{border:1px solid rgba(143,184,162,.24);border-radius:16px;padding:15px;background:#17201D}}
+.info h3{{color:#DDE8E1}}.info .detail{{margin-top:8px;font-size:12px;color:#A9BFB4}}
+button{{border:1px solid rgba(230,192,90,.48);border-radius:999px;background:rgba(230,192,90,.14);color:var(--gold);padding:8px 13px;font:12px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;cursor:pointer}}
+.toolbar{{display:flex;gap:10px;align-items:center;justify-content:flex-end}}
+@media(max-width:640px){{main{{padding:18px}}.setting{{grid-template-columns:1fr}}input[type='checkbox']{{justify-self:start}}}}
+</style></head><body><main>
+<header><h1>Fae Settings</h1><p class='lede'>Orb-owned settings for the adjustable runtime surface. Changes are sent to Swift through the bridge and persisted by FaeCore. Capability showcases below are informational cards, not authority toggles.</p></header>
+<div class='toolbar'><button onclick='requestSnapshot()'>Refresh from Swift</button></div>
+<div class='grid'>{sections}</div>
+<section class='card'><h2>Always-on capabilities</h2><div class='info-grid'>{cards}</div></section>
+<script>
+function post(obj){{window.ipc.postMessage(JSON.stringify(obj));}}
+function requestSnapshot(){{post({{type:'settings_request_snapshot'}});}}
+function sendSetting(el){{
+  const key = el.dataset.key;
+  if (!key || el.disabled) return;
+  const value = el.type === 'checkbox' ? String(el.checked) : String(el.value);
+  post({{type:'settings_set', key, value}});
+}}
+function stepSetting(button){{
+  const key = button.dataset.stepKey;
+  const input = document.querySelector(`[data-key="${{key}}"]`);
+  if (!input || input.disabled) return;
+  const step = Number.parseFloat(button.dataset.step || input.step || '1');
+  const direction = Number.parseFloat(button.dataset.direction || '0');
+  const min = input.min === '' ? Number.NEGATIVE_INFINITY : Number.parseFloat(input.min);
+  const max = input.max === '' ? Number.POSITIVE_INFINITY : Number.parseFloat(input.max);
+  const current = Number.parseFloat(input.value || '0');
+  const decimals = Math.max(0, ((input.step || '').split('.')[1] || '').length);
+  const next = Math.min(max, Math.max(min, current + step * direction));
+  input.value = next.toFixed(decimals);
+  sendSetting(input);
+}}
+document.querySelectorAll('[data-key]').forEach((el)=>{{el.addEventListener('change',()=>sendSetting(el));}});
+document.querySelectorAll('[data-step-key]').forEach((el)=>{{el.addEventListener('click',()=>stepSetting(el));}});
+</script></main></body></html>"#,
+        sections = sections,
+        cards = cards
+    )
+}
+
+fn settings_section_html(section: &SettingsSection) -> String {
+    let description = section
+        .description
+        .as_deref()
+        .map(|text| format!("<p class='muted'>{}</p>", html_escape(text)))
+        .unwrap_or_default();
+    let controls = section
+        .settings
+        .iter()
+        .map(setting_item_html)
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "<section class='card' data-section='{id}'><h2>{title}</h2>{description}{controls}</section>",
+        id = html_escape(&section.id),
+        title = html_escape(&section.title),
+        description = description,
+        controls = controls
+    )
+}
+
+fn setting_item_html(setting: &SettingItem) -> String {
+    let control = setting_control_html(setting);
+    format!(
+        "<div class='setting'><div><h3>{title}</h3><p class='desc'>{description}</p></div><div>{control}{unit}</div></div>",
+        title = html_escape(&setting.title),
+        description = html_escape(&setting.description),
+        control = control,
+        unit = setting
+            .unit
+            .as_deref()
+            .map(|unit| format!("<div class='unit'>{}</div>", html_escape(unit)))
+            .unwrap_or_default()
+    )
+}
+
+fn setting_control_html(setting: &SettingItem) -> String {
+    let key = html_escape(&setting.key);
+    let value = html_escape(&setting.value);
+    let disabled = if setting.read_only.unwrap_or(false) {
+        " disabled"
+    } else {
+        ""
+    };
+    match setting.kind.as_str() {
+        "select" => {
+            let options = setting
+                .options
+                .as_ref()
+                .map(|items| {
+                    items
+                        .iter()
+                        .map(|option| {
+                            let selected = if option.value == setting.value {
+                                " selected"
+                            } else {
+                                ""
+                            };
+                            format!(
+                                "<option value='{value}'{selected}>{label}</option>",
+                                value = html_escape(&option.value),
+                                selected = selected,
+                                label = html_escape(&option.label)
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("")
+                })
+                .unwrap_or_default();
+            format!("<select data-key='{key}'{disabled}>{options}</select>")
+        }
+        "bool" => {
+            let checked = if setting.value == "true" { " checked" } else { "" };
+            format!("<input data-key='{key}' type='checkbox'{checked}{disabled}>")
+        }
+        "number" | "int" => format!(
+            "<div class='number-control'><button class='stepper' type='button' data-step-key='{key}' data-step='{step}' data-direction='-1'{disabled}>−</button><input data-key='{key}' type='number' value='{value}' min='{min}' max='{max}' step='{step}'{disabled}><button class='stepper' type='button' data-step-key='{key}' data-step='{step}' data-direction='1'{disabled}>+</button></div>",
+            min = html_escape(setting.min.as_deref().unwrap_or("")),
+            max = html_escape(setting.max.as_deref().unwrap_or("")),
+            step = html_escape(setting.step.as_deref().unwrap_or("1"))
+        ),
+        "readonly" => format!("<input value='{value}' disabled>"),
+        _ => format!("<input data-key='{key}' value='{value}'{disabled}>"),
+    }
+}
+
+fn settings_card_html(card: &SettingsCard) -> String {
+    let detail = card
+        .detail
+        .as_deref()
+        .map(|text| format!("<p class='detail'>{}</p>", html_escape(text)))
+        .unwrap_or_default();
+    format!(
+        "<article class='info'><h3>{title}</h3><p>{body}</p>{detail}</article>",
+        title = html_escape(&card.title),
+        body = html_escape(&card.body),
+        detail = detail
     )
 }
 

--- a/native/rust/fae-ui-shell/src/menu.rs
+++ b/native/rust/fae-ui-shell/src/menu.rs
@@ -3,6 +3,7 @@ use muda::{Menu, MenuEvent, MenuId, MenuItem, PredefinedMenuItem};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MenuAction {
     Settings,
+    SettingsLegacy,
     OpenBrowserDataPanel,
     ShowMessages,
     ResetConversation,
@@ -40,6 +41,7 @@ impl MenuAction {
     pub fn as_str(self) -> &'static str {
         match self {
             MenuAction::Settings => "settings",
+            MenuAction::SettingsLegacy => "settings_legacy",
             MenuAction::OpenBrowserDataPanel => "open_browser_data_panel",
             MenuAction::ShowMessages => "show_messages",
             MenuAction::ResetConversation => "reset_conversation",
@@ -81,6 +83,7 @@ impl OrbMenu {
         // discoverable mouse fallback (capture ends on pause or via Stop).
         append_item(&menu, MenuAction::TalkToggle, "Talk to Fae")?;
         append_item(&menu, MenuAction::Settings, "Settings…")?;
+        append_item(&menu, MenuAction::SettingsLegacy, "Settings (legacy)…")?;
         append_item(&menu, MenuAction::ShowMessages, "Messages…")?;
         append_item(
             &menu,
@@ -160,6 +163,7 @@ fn append_separator(menu: &Menu) -> Result<(), muda::Error> {
 fn id(action: MenuAction) -> MenuId {
     MenuId::new(match action {
         MenuAction::Settings => "settings",
+        MenuAction::SettingsLegacy => "settings_legacy",
         MenuAction::OpenBrowserDataPanel => "open_browser_data_panel",
         MenuAction::ShowMessages => "show_messages",
         MenuAction::ResetConversation => "reset_conversation",
@@ -192,6 +196,7 @@ fn id(action: MenuAction) -> MenuId {
 fn action_from_id(id: &MenuId) -> Option<MenuAction> {
     match id.as_ref() {
         "settings" => Some(MenuAction::Settings),
+        "settings_legacy" => Some(MenuAction::SettingsLegacy),
         "open_browser_data_panel" => Some(MenuAction::OpenBrowserDataPanel),
         "show_messages" => Some(MenuAction::ShowMessages),
         "reset_conversation" => Some(MenuAction::ResetConversation),

--- a/native/rust/fae-ui-shell/src/protocol.rs
+++ b/native/rust/fae-ui-shell/src/protocol.rs
@@ -47,6 +47,10 @@ pub enum ShellCommand {
         access: String,
         thinking: String,
     },
+    SettingsSnapshot {
+        sections: Vec<SettingsSection>,
+        cards: Vec<SettingsCard>,
+    },
     ClearConversation,
     ShowMessages,
     Show,
@@ -73,6 +77,42 @@ pub struct SkillSummary {
     pub tier: String,
     pub enabled: bool,
     pub active: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettingsSection {
+    pub id: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub settings: Vec<SettingItem>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettingItem {
+    pub key: String,
+    pub title: String,
+    pub description: String,
+    pub kind: String,
+    pub value: String,
+    pub options: Option<Vec<SettingOption>>,
+    pub min: Option<String>,
+    pub max: Option<String>,
+    pub step: Option<String>,
+    pub unit: Option<String>,
+    pub read_only: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettingOption {
+    pub value: String,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettingsCard {
+    pub title: String,
+    pub body: String,
+    pub detail: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -166,6 +206,32 @@ mod tests {
         // S18: plain left-click on the orb body emits this to the Swift host.
         let encoded = encode_menu_action(MenuAction::TalkToggle)?;
         assert_eq!(encoded, r#"{"type":"menu","action":"talk_toggle"}"#);
+        Ok(())
+    }
+
+    #[test]
+    fn encodes_legacy_settings_event() -> Result<(), serde_json::Error> {
+        let encoded = encode_menu_action(MenuAction::SettingsLegacy)?;
+        assert_eq!(encoded, r#"{"type":"menu","action":"settings_legacy"}"#);
+        Ok(())
+    }
+
+    #[test]
+    fn decodes_settings_snapshot() -> Result<(), serde_json::Error> {
+        let command: ShellCommand = serde_json::from_str(
+            r#"{"type":"settings_snapshot","sections":[{"id":"voice","title":"Voice","description":"Speech","settings":[{"key":"tts.speed","title":"Speed","description":"Playback speed","kind":"number","value":"1.1","options":null,"min":"0.7","max":"1.4","step":"0.05","unit":"×","read_only":false}]}],"cards":[{"title":"Local first","body":"Everything stays on this Mac","detail":null}]}"#,
+        )?;
+        let decoded = match command {
+            ShellCommand::SettingsSnapshot { sections, cards } => {
+                sections.len() == 1
+                    && sections[0].settings.len() == 1
+                    && sections[0].settings[0].key == "tts.speed"
+                    && cards.len() == 1
+                    && cards[0].title == "Local first"
+            }
+            _ => false,
+        };
+        assert!(decoded);
         Ok(())
     }
 }

--- a/scripts/ci/guard-no-rust-reintro.sh
+++ b/scripts/ci/guard-no-rust-reintro.sh
@@ -9,6 +9,12 @@ fail=0
 echo "[guard-no-rust] checking active CI workflows for rust/cargo reintroduction..."
 for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
   [ -e "$wf" ] || continue
+  case "$(basename "$wf")" in
+    linux-render-spike.yml|linux-render-spike.yaml)
+      echo "[guard-no-rust] allowing explicit Linux render-spike Rust workflow: $wf"
+      continue
+      ;;
+  esac
   if grep -nEi '\b(cargo|rustup|actions-rs|dtolnay/rust-toolchain|Swatinem/rust-cache)\b' "$wf"; then
     echo "[guard-no-rust] ERROR: forbidden rust/cargo references found in active workflow: $wf" >&2
     fail=1


### PR DESCRIPTION
Draft PR to run the P4 linux-render-spike workflow and validate the Ubuntu WebKitGTK/ALSA build proof.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the Linux render spike: a new `linux-render-spike.yml` CI workflow that validates an Ubuntu WebKitGTK/wgpu orb shell and ALSA-backed daemon build, a new `fae-audio` crate with cpal-based capture and playback, and wire-up of `audio.*` commands in the daemon session dispatcher and control-plane scope table.

- **`fae-audio` crate** — cpal worker thread, WAV encode/decode, linear resampling, RMS normalization, and capture-session reaping are well-implemented and unit-tested. `AudioManager::play_wav()` returns synchronously after full playback, which becomes a problem at the call site.
- **Daemon audio dispatch** — `audio.devices`, `audio.capture_start/stop`, and `audio.play` are correctly scope-gated. However, `audio_play()` is a sync function called directly inside the `async fn dispatch`, so the tokio executor thread blocks for the entire playback duration. `synthesize_tts` (the equivalent TTS path) is `async fn` — audio playback should follow the same pattern via `spawn_blocking`.
- **CI workflow** — Xvfb smoke test with a 7 s render window and 10 s self-exit timer, plus a guard-script allowlist for the new workflow file.

<h3>Confidence Score: 3/5</h3>

The daemon correctly wires up the new audio commands and scope gating, but calling play_wav synchronously from the async handler will stall a tokio executor thread for the full playback duration on every audio.play invocation.

The audio worker design is sound and all the other changes (CI workflow, scope table, capture/device commands) are clean. The problem is that audio_play calls AudioManager::play_wav() — which blocks on mpsc::recv() until cpal finishes playing — directly inside an async dispatch function, monopolizing a tokio worker thread for as long as the audio plays. synthesize_tts follows the correct async pattern; audio playback should do the same. Until that is addressed, the daemon's responsiveness degrades whenever a TTS response is being played back.

crates/fae-audio/src/lib.rs (play_wav_impl spin-wait) and crates/fae-daemon/src/session.rs (audio_play called sync from async dispatch)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/linux-render-spike.yml | New workflow: Ubuntu build proof with Xvfb smoke test for the Settings panel WebView. Zig 0.13.0 is pinned by exact download URL, CI steps are well-structured. The smoke test gives the app 7 seconds to render before screenshotting and 10 s total before the self-Quit timer fires — thin margin on slow runners but appears reliable in practice. |
| crates/fae-audio/src/lib.rs | New cpal-backed audio crate. WAV encode/decode, linear resampling, RMS normalization, and capture-session management are solid. The audio worker correctly runs cpal streams on a dedicated thread. However, `play_wav_impl` blocks the worker thread via a 10 ms spin-wait for the full playback duration, and `AudioManager::play_wav()` exposes that block to callers via a synchronous `mpsc::recv()`, which is called from async tokio handlers. |
| crates/fae-daemon/src/session.rs | Audio dispatch commands added (`audio.devices`, `audio.capture_start/stop`, `audio.play`). Capture and device queries are acceptably short. `audio_play` is sync but called directly inside the async `dispatch`, blocking a tokio executor thread for the entire playback duration — unlike `synthesize_tts` which is async. |
| crates/fae-control-plane/src/lib.rs | Adds `audio.capture_start`, `audio.capture_stop`, `audio.devices`, and `audio.play` to the scope-routing table; grants `AudioCapture` to the `SwiftFrontend` default scopes; updates tests accordingly. All changes are correct and consistent with existing patterns. |
| native/rust/fae-ui-shell/src/main.rs | Adds `--smoke-settings-panel` mode with a 10 s self-exit timer, a Settings panel WebView renderer backed by inline HTML/CSS, and a `run_settings_panel_smoke()` entry point for CI. Emotion easing parameters and gesture state machine are unchanged. |
| scripts/ci/guard-no-rust-reintro.sh | Adds a `case` allowlist for `linux-render-spike.yml` before the Rust/Cargo grep check. Logic is correct but the exemption is hardcoded by filename. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant TokioTask as Tokio Task (handle_frame)
    participant Dispatch as dispatch()
    participant AudioMgr as AudioManager
    participant Worker as AudioWorker thread
    participant CPAL as cpal stream

    Client->>TokioTask: "audio.play {wav_base64}"
    TokioTask->>Dispatch: audio_play() [sync, no .await]
    Dispatch->>AudioMgr: "play_wav(&wav) — mpsc::send"
    Note over TokioTask,AudioMgr: Tokio thread now BLOCKED on mpsc::recv()
    AudioMgr->>Worker: AudioRequest::Play
    Worker->>CPAL: build_output_stream + play()
    loop every 10 ms until done
        Worker->>Worker: thread::sleep(10ms) — worker BLOCKED
    end
    Worker->>Worker: thread::sleep(25ms) tail
    CPAL-->>Worker: "done = true"
    Worker-->>AudioMgr: Ok(played_ms)
    AudioMgr-->>Dispatch: Ok(played_ms)
    Note over TokioTask,AudioMgr: Tokio thread unblocked only here
    Dispatch-->>TokioTask: "Response {played_ms}"
    TokioTask-->>Client: JSON response
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
crates/fae-audio/src/lib.rs:375-421
**`audio.play` blocks the tokio executor thread for the full playback duration**

`play_wav_impl` spins on `done.load()` every 10 ms plus an extra 25 ms tail, which keeps the audio worker thread fully occupied for the entire playback duration. `AudioManager::play_wav()` then blocks its caller on `mpsc::Receiver::recv()` until the worker finishes — meaning the tokio executor thread that handles `"audio.play"` is stalled for that same duration. Unlike `tts.synthesize` (which is `async fn`), `audio_play` is a plain sync function called directly in `dispatch`, so no yield point exists. A TTS response that takes 4–8 seconds to play back monopolizes one tokio thread for the whole period; under concurrent load this starves other sessions. The fix is to wrap the blocking call in `tokio::task::spawn_blocking` so the runtime thread is released while audio plays.

### Issue 2 of 3
crates/fae-daemon/src/session.rs:331-345
**`audio_play`, `audio_capture_start`, and `audio_capture_stop` are sync in an async handler**

All three audio dispatch helpers call `AudioManager` methods (`play_wav`, `capture_start`, `capture_stop`) that block on `mpsc::Receiver::recv()` internally, but they are called directly — without `spawn_blocking` — from the `async fn dispatch`. For capture start/stop this is a short (sub-millisecond) stall, but for `play_wav` the block equals the full playback duration. Compare with `synthesize_tts`, which is correctly `async fn`. The right fix is to wrap `audio.play_wav(&wav)` (and ideally the other audio calls) inside `tokio::task::spawn_blocking(move || …).await?` so the executor thread is freed during the wait.

### Issue 3 of 3
scripts/ci/guard-no-rust-reintro.sh:12-17
**Allowlist is hardcoded by filename**

The exemption pattern matches only `linux-render-spike.yml`/`.yaml` by literal name. If the workflow file is ever renamed, the guard will start rejecting it, and whoever renames it will need to remember to update this script in the same commit. A comment here noting that coupling would help future contributors avoid a confusing CI failure.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(linux): add render spike guard"](https://github.com/saorsa-labs/fae/commit/725f453579f98faba8240fe976b3e9b3778dc7ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37416035)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->