### PR TITLE
fix(daemon): move audio commands off tokio workers

### DIFF
--- a/crates/fae-audio/src/lib.rs
+++ b/crates/fae-audio/src/lib.rs
@@ -80,6 +80,7 @@ struct CaptureSession {
 /// Shared daemon audio manager. Public methods are thread-safe; all cpal
 /// streams live on a dedicated worker thread because CoreAudio streams are not
 /// `Send` on macOS.
+#[derive(Clone)]
 pub struct AudioManager {
     tx: mpsc::Sender<AudioRequest>,
 }

--- a/crates/fae-daemon/src/session.rs
+++ b/crates/fae-daemon/src/session.rs
@@ -296,25 +296,43 @@ async fn dispatch(
         }
         "conversation.inject_text" => inject_text(backends.engine, cmd).await,
         "tts.synthesize" => synthesize_tts(backends.tts, cmd).await,
-        "audio.devices" => {
-            serde_json::to_value(backends.audio.devices()).map_err(|_| "internal_error")
+        "audio.devices" => audio_devices(backends.audio).await,
+        "audio.capture_start" | "audio.start_capture" => audio_capture_start(backends.audio).await,
+        "audio.capture_stop" | "audio.stop_capture" => {
+            audio_capture_stop(backends.audio, cmd).await
         }
-        "audio.capture_start" | "audio.start_capture" => audio_capture_start(backends.audio),
-        "audio.capture_stop" | "audio.stop_capture" => audio_capture_stop(backends.audio, cmd),
-        "audio.play" | "audio.playback_control" => audio_play(backends.audio, cmd),
+        "audio.play" | "audio.playback_control" => audio_play(backends.audio, cmd).await,
         _ => Err("not_implemented"),
     }
 }
 
-fn audio_capture_start(audio: &AudioManager) -> Result<serde_json::Value, &'static str> {
-    let capture_id = audio.capture_start().map_err(|error| {
-        eprintln!("fae-daemon: audio.capture_start failed: {error}");
-        "audio_error"
-    })?;
+async fn audio_devices(audio: &AudioManager) -> Result<serde_json::Value, &'static str> {
+    let audio = (*audio).clone();
+    let devices = tokio::task::spawn_blocking(move || audio.devices())
+        .await
+        .map_err(|error| {
+            eprintln!("fae-daemon: audio.devices worker join failed: {error}");
+            "internal_error"
+        })?;
+    serde_json::to_value(devices).map_err(|_| "internal_error")
+}
+
+async fn audio_capture_start(audio: &AudioManager) -> Result<serde_json::Value, &'static str> {
+    let audio = (*audio).clone();
+    let capture_id = tokio::task::spawn_blocking(move || audio.capture_start())
+        .await
+        .map_err(|error| {
+            eprintln!("fae-daemon: audio.capture_start worker join failed: {error}");
+            "internal_error"
+        })?
+        .map_err(|error| {
+            eprintln!("fae-daemon: audio.capture_start failed: {error}");
+            "audio_error"
+        })?;
     Ok(serde_json::json!({ "capture_id": capture_id }))
 }
 
-fn audio_capture_stop(
+async fn audio_capture_stop(
     audio: &AudioManager,
     cmd: &Command,
 ) -> Result<serde_json::Value, &'static str> {
@@ -323,14 +341,22 @@ fn audio_capture_stop(
         .payload
         .get("capture_id")
         .and_then(serde_json::Value::as_str)
-        .ok_or("bad_request")?;
-    let captured = audio.capture_stop(capture_id).map_err(|error| {
-        eprintln!("fae-daemon: audio.capture_stop failed: {error}");
-        match error {
-            fae_audio::AudioError::CaptureNotFound => "not_found",
-            _ => "audio_error",
-        }
-    })?;
+        .ok_or("bad_request")?
+        .to_owned();
+    let audio = (*audio).clone();
+    let captured = tokio::task::spawn_blocking(move || audio.capture_stop(&capture_id))
+        .await
+        .map_err(|error| {
+            eprintln!("fae-daemon: audio.capture_stop worker join failed: {error}");
+            "internal_error"
+        })?
+        .map_err(|error| {
+            eprintln!("fae-daemon: audio.capture_stop failed: {error}");
+            match error {
+                fae_audio::AudioError::CaptureNotFound => "not_found",
+                _ => "audio_error",
+            }
+        })?;
     Ok(serde_json::json!({
         "wav_base64": base64::engine::general_purpose::STANDARD.encode(captured.wav),
         "duration_ms": captured.duration_ms,
@@ -338,7 +364,10 @@ fn audio_capture_stop(
     }))
 }
 
-fn audio_play(audio: &AudioManager, cmd: &Command) -> Result<serde_json::Value, &'static str> {
+async fn audio_play(
+    audio: &AudioManager,
+    cmd: &Command,
+) -> Result<serde_json::Value, &'static str> {
     use base64::Engine as _;
     let encoded = cmd
         .payload
@@ -348,10 +377,17 @@ fn audio_play(audio: &AudioManager, cmd: &Command) -> Result<serde_json::Value, 
     let wav = base64::engine::general_purpose::STANDARD
         .decode(encoded)
         .map_err(|_| "bad_request")?;
-    let played_ms = audio.play_wav(&wav).map_err(|error| {
-        eprintln!("fae-daemon: audio.play failed: {error}");
-        "audio_error"
-    })?;
+    let audio = (*audio).clone();
+    let played_ms = tokio::task::spawn_blocking(move || audio.play_wav(&wav))
+        .await
+        .map_err(|error| {
+            eprintln!("fae-daemon: audio.play worker join failed: {error}");
+            "internal_error"
+        })?
+        .map_err(|error| {
+            eprintln!("fae-daemon: audio.play failed: {error}");
+            "audio_error"
+        })?;
     Ok(serde_json::json!({ "played_ms": played_ms }))
 }
 

--- a/scripts/ci/guard-no-rust-reintro.sh
+++ b/scripts/ci/guard-no-rust-reintro.sh
@@ -9,6 +9,8 @@ fail=0
 echo "[guard-no-rust] checking active CI workflows for rust/cargo reintroduction..."
 for wf in .github/workflows/*.yml .github/workflows/*.yaml; do
   [ -e "$wf" ] || continue
+  # Explicit Rust workflow exemptions are filename-coupled: if one of these
+  # workflows is renamed, update this allowlist in the same commit.
   case "$(basename "$wf")" in
     linux-render-spike.yml|linux-render-spike.yaml)
       echo "[guard-no-rust] allowing explicit Linux render-spike Rust workflow: $wf"


### PR DESCRIPTION
## Summary

Follow-up for Greptile comments on merged PR #10.

- Moves daemon audio command waits (`audio.devices`, `audio.capture_start`, `audio.capture_stop`, `audio.play`) into `tokio::task::spawn_blocking` so Tokio worker threads are not occupied while the cpal audio worker responds or playback completes.
- Makes `AudioManager` cheaply cloneable by cloning its `mpsc::Sender`, allowing owned handles to move into blocking closures.
- Documents the filename-coupled Rust workflow allowlist in `guard-no-rust-reintro.sh`.

## Validation

- `cargo fmt --all --manifest-path crates/Cargo.toml`
- `cd crates && cargo clippy -p fae-daemon --bin fae-daemon --all-features -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used`
- `cd crates && just check`
- `cd crates && cargo check --workspace --all-targets`
- `./scripts/ci/guard-no-rust-reintro.sh`

## Notes

PR #10 itself is already merged. This PR addresses its review findings without touching the merged P4 branch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the four blocking audio command handlers (`audio.devices`, `audio.capture_start`, `audio.capture_stop`, `audio.play`) off Tokio worker threads by wrapping them in `tokio::task::spawn_blocking`, and makes `AudioManager` cheaply cloneable by deriving `Clone` on its single `mpsc::Sender` field.

- **`fae-audio`**: `#[derive(Clone)]` is added to `AudioManager`. The only field is `mpsc::Sender<AudioRequest>`, which is already `Clone`, so the derived impl is a zero-cost sender clone — all clones share the same underlying worker thread.
- **`fae-daemon/session.rs`**: Each handler now clones the sender handle, moves it into a `spawn_blocking` closure, and chains two `.map_err` layers — one for `JoinError` (runtime/panic) and one for `AudioError` — before returning the JSON payload. Data that must cross the thread boundary (`capture_id` as `String`, `wav` as `Vec<u8>`) is correctly `.to_owned()` / moved before the closure.
- **`guard-no-rust-reintro.sh`**: Comment-only change documenting the filename coupling of the workflow allowlist.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a targeted threading fix with no behavioural side-effects — all audio command semantics are preserved, only the thread on which the blocking wait occurs has changed.

All four audio handlers correctly clone the `mpsc::Sender`-backed `AudioManager`, move owned data into the closure (`capture_id` as `String`, `wav` as `Vec<u8>`), and chain `JoinError` and `AudioError` maps cleanly. The `#[derive(Clone)]` on `AudioManager` is safe because the only field (`mpsc::Sender`) is already `Clone` and sharing the sender is the intended semantics. No logic changes elsewhere.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/fae-audio/src/lib.rs | Adds `#[derive(Clone)]` to `AudioManager`; the only field is `mpsc::Sender<AudioRequest>` which is already `Clone`, so the derived impl is correct and inexpensive. |
| crates/fae-daemon/src/session.rs | Converts all four audio handler functions to `async`, wrapping the blocking `mpsc::Sender`/`recv` calls in `tokio::task::spawn_blocking`. The owned capture_id and wav data are correctly moved into each closure; error paths (JoinError and AudioError) are properly chained. |
| scripts/ci/guard-no-rust-reintro.sh | Adds a comment documenting that the filename-coupled allowlist must be updated in the same commit when a whitelisted workflow is renamed. Comment-only change with no functional impact. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant TokioWorker as "Tokio Worker Thread"
    participant BlockingPool as "spawn_blocking Thread"
    participant AudioWorker as "AudioWorker Thread (cpal)"

    Client->>TokioWorker: "audio.play / audio.devices / etc."
    TokioWorker->>TokioWorker: "dispatch() -> audio_play() async"
    TokioWorker->>TokioWorker: "Clone AudioManager (clone Sender)"
    TokioWorker->>BlockingPool: "spawn_blocking(|| audio.play_wav(&wav))"
    Note over TokioWorker: ".await — worker thread is free"
    BlockingPool->>AudioWorker: "mpsc::Sender::send(AudioRequest::Play)"
    BlockingPool->>BlockingPool: "rx.recv() — blocking thread waits"
    Note over AudioWorker: "play_wav_impl: build stream, poll done flag"
    AudioWorker-->>BlockingPool: "mpsc reply: AudioResult"
    BlockingPool-->>TokioWorker: "JoinHandle resolves Ok(AudioResult)"
    TokioWorker->>TokioWorker: "map JoinError + AudioError, build JSON"
    TokioWorker-->>Client: "Response { played_ms }"
```

<sub>Reviews (1): Last reviewed commit: ["fix(daemon): move audio commands off tok..."](https://github.com/saorsa-labs/fae/commit/7ad239bff0f6d44dc440b643854c9f45598bda9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37440424)</sub>

<!-- /greptile_comment -->