### PR TITLE
fix(pipeline): keep silent awareness from stranding thinking

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Detailed version history moved from CLAUDE.md. For current architecture, see `CLAUDE.md`.
 
+## Unreleased — Task #10 Thinking liveness
+
+### Fixed
+- Silent awareness/proactive generations are now tracked for token-stream isolation without driving the orb's user-visible `assistantGenerating` / "Thinking" indicator.
+- Stale or superseded generations can no longer strand the Thinking pill: ending an old generation only removes that generation, while the indicator is forced idle once no visible generation or approval pause remains.
+- Added regression coverage for overlapping silent proactive generations, visible-generation guard semantics, and approval pauses.
+
 ## Unreleased — Skills-first cross-platform P5
 
 ### CI / Build

--- a/docs/architecture/s18-kill-list-3of3-plan.md
+++ b/docs/architecture/s18-kill-list-3of3-plan.md
@@ -4,6 +4,12 @@ Status: EXECUTED 2026-06-12. Predecessors landed: 1/3 SmartTurn (384f39d7),
 2/3 keyword spotter (13480bb8), both CI green. Companion context:
 docs/spikes/S18-pure-gemma-asr-ptt.md ("Post-S18 consolidation queue").
 
+Task #10 follow-up: EXECUTED 2026-06-14. Scope clarified to the orb
+Thinking-liveness bug: silent awareness/proactive generations are tracked for
+stale-token isolation but no longer drive the user-visible `assistantGenerating`
+indicator; overlapping/stale generations now force the indicator back to idle
+when no visible generation or approval pause remains.
+
 Execution notes (deviations from the delete/keep lists below):
 - `ParakeetStreamingEngine` went with the `StreamingSTTEngine` protocol (its
   only conformer); `KeywordBiasConfig` moved into `KeywordSpotter.swift`.
@@ -103,6 +109,7 @@ Execution notes (deviations from the delete/keep lists below):
    `llm.useDaemonEngine`/`tts.useDaemonEngine` defaults true, models.lock
    distribution — THEN delete FaeTTSAdapter + MLXLLMEngine (note: MLX LLM is
    the LoRA training substrate; decide training story first).
-2. Test isolation (Task #10).
+2. Test isolation (Task #10) — superseded by the clarified Task #10
+   Thinking-liveness fix above; test isolation remains future CI debt.
 3. Daemon streaming + cancel; candle voice-tts backend.
 4. MTP wiring (Task #1, recipe in memory project_mtp_daemon_speedup.md).

--- a/docs/reports/task10-thinking-liveness-2026-06-14.md
+++ b/docs/reports/task10-thinking-liveness-2026-06-14.md
@@ -1,0 +1,167 @@
+# Task #10 — Orb Thinking liveness
+
+Date: 2026-06-14 local / 2026-06-13 UTC
+Branch: `task10-thinking-liveness`
+
+## 1. What changed
+
+```text
+docs/CHANGELOG.md                                  |   7 +
+docs/architecture/s18-kill-list-3of3-plan.md       |   9 +-
+.../reports/task10-thinking-liveness-2026-06-14.md | 153 +++++++++++++++++++++
+.../Fae/Pipeline/AssistantGenerationTracker.swift  |  59 ++++++++
+.../Sources/Fae/Pipeline/PipelineCoordinator.swift | 143 +++++++++++++------
+.../AssistantGenerationTrackerTests.swift          |  93 +++++++++++++
+6 files changed, 421 insertions(+), 43 deletions(-)
+```
+
+Summary:
+
+- Added `AssistantGenerationTracker` to separate token-stream liveness from the user-visible orb Thinking indicator.
+- Silent proactive/awareness generations remain tracked and can be superseded, but they do not emit `assistantGenerating(true)`.
+- Ending a stale generation now removes only that generation; it cannot clear a newer visible one, but quiescence forces the indicator idle when no visible generation or approval pause remains.
+- Proactive awareness drains now check active tracked generations, not just the UI Thinking flag, so overlapping camera/screen chores defer instead of superseding each other.
+- Deliberate user turns still supersede silent background generations.
+- Added regression tests for overlapping silent proactive generations, visible overlap guard semantics, no resurrection of superseded older generations, visible+silent quiescence, and awaiting-approval liveness.
+
+## 2. Validation
+
+### `cd native/macos/Fae && swift test --filter AssistantGenerationTrackerTests`
+
+```text
+Test Suite 'AssistantGenerationTrackerTests' passed at 2026-06-14 00:55:49.528.
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
+Test Suite 'Selected tests' passed at 2026-06-14 00:55:49.528.
+	 Executed 5 tests, with 0 failures (0 unexpected) in 0.004 (0.005) seconds
+```
+
+### `cd native/macos/Fae && swift test --filter RuntimeContractTests`
+
+```text
+Test Suite 'RuntimeContractTests' passed at 2026-06-14 00:11:03.007.
+	 Executed 22 tests, with 0 failures (0 unexpected) in 3.751 (3.754) seconds
+Test Suite 'Selected tests' passed at 2026-06-14 00:11:03.008.
+	 Executed 22 tests, with 0 failures (0 unexpected) in 3.751 (3.754) seconds
+```
+
+### `cd native/macos/Fae && swift build`
+
+```text
+Build complete! (2.04s)
+```
+
+Known warnings were unchanged SwiftPM resource/exclude warnings for missing Metal source files and unhandled `Resources/VERSION`.
+
+### `cd native/macos/Fae && swift test --skip VocabularyHarvestTests`
+
+```text
+Test Suite 'FaePackageTests.xctest' passed at 2026-06-14 00:58:06.780.
+	 Executed 3093 tests, with 0 failures (0 unexpected) in 120.960 (121.127) seconds
+Test Suite 'Selected tests' passed at 2026-06-14 00:58:06.780.
+	 Executed 3093 tests, with 0 failures (0 unexpected) in 120.960 (121.128) seconds
+```
+
+### `just check`
+
+Attempted and timed out after 30 minutes in the pre-existing Contacts/CoreData XPC/TCC path inside `VocabularyHarvestTests`:
+
+```text
+2026-06-14 00:36:15.848 xctest[15276:28981803] VocabularyHarvester: calendar permission not granted (status=0)
+Test Case '-[IntegrationTests.VocabularyHarvestTests testHarvestDeduplicates]' passed (1204.554 seconds).
+Test Case '-[IntegrationTests.VocabularyHarvestTests testHarvestIntoEmptyLexicon]' started.
+CoreData: error: Failed to create NSXPCConnection
+CoreData: XPC: Unable to load metadata: Error Domain=NSCocoaErrorDomain Code=134060 "A Core Data error occurred." UserInfo={Problem=Unable to send to server; failed after 8 attempts.}
+Command timed out after 1800 seconds
+```
+
+This is the known local TCC/AddressBook validation blocker; the skipped full Swift suite above is the established local substitute.
+
+### `cd crates && just check`
+
+```text
+Doc-tests fae_engine
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+All Rust crate unit/doc tests passed.
+
+### `just check-ui-shell`
+
+```text
+cd native/rust/fae-ui-shell && cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
+warning: the following packages contain code that will be rejected by a future version of Rust: block v0.1.6
+cd native/rust/fae-ui-shell && cargo check --workspace --all-targets
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
+```
+
+The `block v0.1.6` future-incompat warning is pre-existing.
+
+## 3. Live evidence
+
+Ran `just run-dev` after temporarily enabling dev awareness consent and short intervals in `~/Library/Application Support/fae-dev/config.toml` (restored afterwards). The app launched with the Rust orb shell and embedded daemon:
+
+```text
+✓ Bundle assembled: native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app (v0.8.189)
+  → Embedded fae-ui-shell
+  → Embedded fae-daemon
+✓ Signed: native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app
+native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app: valid on disk
+native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app: satisfies its Designated Requirement
+✓ Fae (DEV) launched — logs: tail -f /tmp/fae-dev.log
+```
+
+Then relaunched the same dev bundle with `--test-server` so the conversation/orb generation state could be polled while awareness ran. `/health` reached `{"pipeline":"running","status":"ok"}`.
+
+Awareness tasks started and camera checks ran as silent proactive work:
+
+```text
+2026-06-14 01:07:49.293 Fae[15186:29153742] FaeScheduler: awareness tasks started (camera=on, screen=on)
+2026-06-14 01:07:54.323 Fae[15186:29153746] FaeScheduler: camera_presence_check dispatching (mode=digest, silent=yes, consent=yes)
+2026-06-14 01:08:22.385 Fae[15186:29153742] PipelineCoordinator: executing tool 'camera'
+2026-06-14 01:08:29.394 Fae[15186:29153733] FaeScheduler: camera_presence_check dispatching (mode=digest, silent=yes, consent=yes)
+2026-06-14 01:08:29.394 Fae[15186:29153733] PipelineCoordinator: proactive query deferred — assistant busy
+2026-06-14 01:10:52.617Z Pipeline Proactive query: taskId=camera_presence_check silent=true
+2026-06-14 01:10:52.619Z Pipeline Generation started id=4C1DA211
+2026-06-14 01:11:17.334Z Tool id=EB279072 name=camera args={"prompt":"Observe the environment remotely"}
+2026-06-14 01:11:19.840Z Tool Tool finished: camera success=true latency=2441ms
+```
+
+While those silent awareness generations and deferred camera jobs were active, the conversation endpoint stayed idle; this is the orb/pill-facing state used by the UI bridge:
+
+```text
+polls ts isGenerating isSpeaking background pipeline
+01:08:03 False False False running
+01:08:28 False False False running
+01:09:03 False False False running
+01:09:28 False False False running
+01:09:47 False False False running
+01:10:27 False False False running
+01:11:42 False False False running
+```
+
+This proves the live behavior behind the fix: silent awareness jobs are still live/tracked (`assistant busy` defers overlapping camera jobs), camera tools complete, and the user-visible generation state returns/remains idle instead of stranding the orb/pill in Thinking. Direct screenshot capture was unavailable in this agent harness (`screencapture` failed with `could not create image from display`), so the proof uses the dev test-server conversation state plus runtime logs.
+
+## 4. Deviations
+
+- The original compacted instruction said "task 10"; an earlier pass mistakenly interpreted it as PR #10. This report covers the clarified Task #10 Thinking-liveness bug.
+- The S18 plan previously listed Task #10 as test isolation. The user clarified Task #10 as the orb Thinking liveness issue; the plan now records that clarification and leaves test isolation as future CI debt.
+- No flat liveness timeout was added. The fix is state-based and preserves token/tool activity for long real turns.
+
+## 5. Known gaps / follow-ups
+
+- Direct screenshot capture failed in this harness, but the dev test-server conversation state stayed idle during live awareness generations.
+- Root `just check` still needs the separate VocabularyHarvest/Contacts test-isolation fix to avoid the local TCC/CoreData XPC timeout.
+
+## 6. Docs touched + Obsidian notes updated
+
+Docs touched:
+
+- `docs/CHANGELOG.md`
+- `docs/architecture/s18-kill-list-3of3-plan.md`
+- `docs/reports/task10-thinking-liveness-2026-06-14.md`
+
+Obsidian mirrors updated after this report was written.

--- a/native/macos/Fae/Sources/Fae/Pipeline/AssistantGenerationTracker.swift
+++ b/native/macos/Fae/Sources/Fae/Pipeline/AssistantGenerationTracker.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Tracks in-flight assistant generations separately from the user-visible
+/// "assistant is thinking" indicator.
+///
+/// Silent background generations (for example awareness chores) remain live for
+/// stale-token isolation, but they do not light the orb's Thinking state. A
+/// stale generation ending can therefore never clear a newer visible turn, while
+/// quiescence is still forced back to idle when no visible generation remains.
+struct AssistantGenerationTracker {
+    enum Visibility: Equatable {
+        /// User-visible turn: should drive the orb Thinking indicator.
+        case visible
+        /// Silent/background turn: should not drive the orb Thinking indicator.
+        case silentBackground
+    }
+
+    private(set) var activeGenerationID: UUID?
+
+    private var generationVisibility: [UUID: Visibility] = [:]
+
+    var hasActiveGeneration: Bool {
+        !generationVisibility.isEmpty
+    }
+
+    var hasVisibleGeneration: Bool {
+        generationVisibility.values.contains(.visible)
+    }
+
+    mutating func begin(_ generationID: UUID, visibility: Visibility) {
+        // A newly-started generation owns the token stream. Older generations
+        // may still be draining, but they are superseded and must no longer
+        // keep the user-visible Thinking indicator alive.
+        generationVisibility = generationVisibility.mapValues { _ in .silentBackground }
+        generationVisibility[generationID] = visibility
+        activeGenerationID = generationID
+    }
+
+    mutating func end(_ generationID: UUID?) {
+        guard let generationID else {
+            reset()
+            return
+        }
+
+        generationVisibility.removeValue(forKey: generationID)
+        if activeGenerationID == generationID {
+            activeGenerationID = nil
+        }
+    }
+
+    mutating func reset() {
+        generationVisibility.removeAll()
+        activeGenerationID = nil
+    }
+
+    func shouldShowAssistantGenerating(awaitingApproval: Bool) -> Bool {
+        awaitingApproval || hasVisibleGeneration
+    }
+}

--- a/native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift
@@ -499,7 +499,8 @@ actor PipelineCoordinator {
     /// Exposed for the test harness to wait until speech completes.
     var isSpeaking: Bool { assistantSpeaking }
     /// Active generation scope for streaming-token isolation across interrupted turns.
-    private var activeGenerationID: UUID?
+    private var assistantGenerationTracker = AssistantGenerationTracker()
+    private var activeGenerationID: UUID? { assistantGenerationTracker.activeGenerationID }
     private var interrupted: Bool = false
     private var interruptedGenerationID: UUID?
     private var awaitingApproval: Bool = false
@@ -764,7 +765,7 @@ actor PipelineCoordinator {
             // assistantSpeaking without a matching clear (playback completed
             // during the old pipeline loop which is now dead).
             assistantSpeaking = false
-            assistantGenerating = false
+            endAssistantGeneration(scheduleDeferredDrain: false)
             interrupted = false
             interruptedGenerationID = nil
             ttsState.cancelPending()
@@ -819,10 +820,10 @@ actor PipelineCoordinator {
         debugLog(debugConsole, .qa, "Pipeline stop requested")
         markGenerationInterrupted()
         pendingGovernanceAction = nil
-        awaitingApproval = false
-        manualOnlyApprovalPending = false
+        setApprovalState(awaiting: false, manualOnly: false)
         computerUseStepCount = 0
         bargeInState.generationTakeoverCandidate = nil
+        endAssistantGeneration(scheduleDeferredDrain: false)
 
         // Ensure any in-flight TTS synthesis task fully exits before teardown.
         let activeTTSTask = ttsState.pendingTask
@@ -874,8 +875,7 @@ actor PipelineCoordinator {
     func cancelAndWait() async {
         markGenerationInterrupted()
         pendingGovernanceAction = nil
-        awaitingApproval = false
-        manualOnlyApprovalPending = false
+        setApprovalState(awaiting: false, manualOnly: false)
         computerUseStepCount = 0
         bargeInState.generationTakeoverCandidate = nil
 
@@ -893,10 +893,9 @@ actor PipelineCoordinator {
         assistantSpeaking = false
         lastAssistantStart = nil
         echoSuppressor.reset()
-        // Ensure generation flag is cleared so the pipeline accepts new injections after reset.
-        assistantGenerating = false
-        awaitingApproval = false
-        manualOnlyApprovalPending = false
+        // Ensure generation state is cleared so the pipeline accepts new injections after reset.
+        setApprovalState(awaiting: false, manualOnly: false)
+        endAssistantGeneration(scheduleDeferredDrain: false)
         await abandonAllWorkflowTraces(reason: "Generation cancelled before workflow completion.")
         NSLog("PipelineCoordinator: cancelAndWait complete")
     }
@@ -983,8 +982,9 @@ actor PipelineCoordinator {
             wake()
         }
 
-        // If assistant is active, trigger barge-in.
-        if assistantSpeaking || assistantGenerating {
+        // If assistant is active, trigger barge-in. Silent background generations
+        // do not light the orb, but typed user input still supersedes them.
+        if assistantSpeaking || assistantGenerating || assistantGenerationTracker.hasActiveGeneration {
             markGenerationInterrupted()
             await playback.stop()
         }
@@ -1281,7 +1281,7 @@ actor PipelineCoordinator {
         // This preserves GPU for responsive voice interaction.
         let recentConversation = await conversationState.lastAssistantMessageAt
             .map { Date().timeIntervalSince($0) < 30 } ?? false
-        guard !assistantGenerating, !assistantSpeaking else {
+        guard !assistantGenerationTracker.hasActiveGeneration, !assistantSpeaking else {
             enqueueDeferredProactiveRequest(request)
             NSLog("PipelineCoordinator: proactive query deferred — assistant busy")
             return
@@ -1344,12 +1344,16 @@ actor PipelineCoordinator {
     }
 
     private func scheduleDeferredProactiveDrain() {
-        guard !assistantGenerating, !assistantSpeaking, !deferredProactiveRequests.isEmpty else { return }
+        guard !assistantGenerationTracker.hasActiveGeneration,
+              !assistantSpeaking,
+              !deferredProactiveRequests.isEmpty
+        else { return }
         Task { await drainDeferredProactiveIfIdle() }
     }
 
     private func drainDeferredProactiveIfIdle() async {
-        guard !assistantGenerating, !assistantSpeaking,
+        guard !assistantGenerationTracker.hasActiveGeneration,
+              !assistantSpeaking,
               !deferredProactiveRequests.isEmpty
         else {
             return
@@ -1427,8 +1431,8 @@ actor PipelineCoordinator {
         engagedUntil = nil
         lastAssistantResponseText = ""
 
-        awaitingApproval = false
-        manualOnlyApprovalPending = false
+        setApprovalState(awaiting: false, manualOnly: false)
+        endAssistantGeneration(scheduleDeferredDrain: false)
         pendingGovernanceAction = nil
         computerUseStepCount = 0
         ttsState.cancelPending()
@@ -1470,7 +1474,7 @@ actor PipelineCoordinator {
         idleRearmTask?.cancel()
         idleRearmTask = nil
         engagedUntil = nil
-        if assistantSpeaking || assistantGenerating {
+        if assistantSpeaking || assistantGenerating || assistantGenerationTracker.hasActiveGeneration {
             markGenerationInterrupted()
             Task { await playback.stop() }
         }
@@ -1765,7 +1769,7 @@ actor PipelineCoordinator {
 
     private func resetConversationSession(trigger: String, source: String) async {
         // Stop any active speech/generation immediately.
-        if assistantSpeaking || assistantGenerating {
+        if assistantSpeaking || assistantGenerating || assistantGenerationTracker.hasActiveGeneration {
             markGenerationInterrupted()
             await playback.stop()
         }
@@ -1776,8 +1780,8 @@ actor PipelineCoordinator {
         bargeInState.generationTakeoverCandidate = nil
         bargeInState.falseInterruptionRecovery.cancel()
 
-        awaitingApproval = false
-        manualOnlyApprovalPending = false
+        setApprovalState(awaiting: false, manualOnly: false)
+        endAssistantGeneration(scheduleDeferredDrain: false)
         pendingGovernanceAction = nil
         computerUseStepCount = 0
         ttsState.cancelPending()
@@ -2215,6 +2219,13 @@ actor PipelineCoordinator {
             debugLog(debugConsole, .pipeline, "User turn takeover — interrupting in-flight generation")
             markGenerationInterrupted()
             endAssistantGeneration()
+        } else if assistantGenerationTracker.hasActiveGeneration {
+            // Silent/background generation in progress. It intentionally does
+            // not drive assistantGenerating, but deliberate user input still
+            // supersedes it and becomes the active token stream owner.
+            guard proactiveContext == nil else { return }
+            debugLog(debugConsole, .pipeline, "User turn takeover — interrupting silent background generation")
+            markGenerationInterrupted()
         }
 
         let forceFastCommandPath = shouldForceThinkingSuppression(for: queryText)
@@ -2280,8 +2291,7 @@ actor PipelineCoordinator {
             responseText = reply
         }
 
-        assistantGenerating = true
-        eventBus.send(.assistantGenerating(true))
+        let generationID = beginAssistantGeneration(visibility: .visible)
         await conversationState.addUserMessage(
             queryText,
             speakerDisplayName: speakerGate.currentSpeakerDisplayName,
@@ -2316,7 +2326,7 @@ actor PipelineCoordinator {
             await capturePendingCorrection()
         }
 
-        endAssistantGeneration()
+        endAssistantGeneration(for: generationID)
         engage()
         return true
     }
@@ -2747,8 +2757,13 @@ actor PipelineCoordinator {
                 return
             }
         } else {
-            generationID = UUID()
-            activeGenerationID = generationID
+            generationID = beginAssistantGeneration(
+                visibility: generationVisibility(
+                    proactiveContext: proactiveContext,
+                    playsThinkingTone: playsThinkingTone,
+                    allowsAudibleOutput: allowsAudibleOutput
+                )
+            )
             debugLog(debugConsole, .pipeline, "Generation started id=\(generationID.uuidString.prefix(8))")
         }
 
@@ -2794,8 +2809,6 @@ actor PipelineCoordinator {
             // Ensure no stale TTS tasks from a previous turn can block this one.
             ttsState.cancelPending()
             lastAssistantResponseText = ""
-            assistantGenerating = true
-            eventBus.send(.assistantGenerating(true))
 
             // Play thinking tone.
             if playsThinkingTone {
@@ -4873,19 +4886,60 @@ actor PipelineCoordinator {
 
     // MARK: - Speech State
 
-    /// Clear the generation-in-progress flag.
+    /// Start tracking an assistant generation.
     ///
-    /// When called with a `generationID`, only clears if that generation is still
-    /// the active one. This prevents an interrupted/stale generation from clearing
-    /// state that belongs to a newer generation (race after barge-in).
-    private func endAssistantGeneration(for generationID: UUID? = nil) {
-        if let generationID, activeGenerationID != generationID {
-            return
+    /// The latest generation ID remains the token-stream authority, but only
+    /// visible generations drive the orb's Thinking state. Silent background
+    /// chores stay tracked so a newer turn can stale them out without lighting
+    /// the UI.
+    @discardableResult
+    private func beginAssistantGeneration(
+        id generationID: UUID = UUID(),
+        visibility: AssistantGenerationTracker.Visibility
+    ) -> UUID {
+        assistantGenerationTracker.begin(generationID, visibility: visibility)
+        reconcileAssistantGenerating()
+        return generationID
+    }
+
+    /// Clear a generation-in-progress record.
+    ///
+    /// When called with a stale `generationID`, only that generation is removed;
+    /// a newer visible generation continues to own the Thinking indicator. If no
+    /// visible generation remains and no approval is pending, the indicator is
+    /// forced back to idle.
+    private func endAssistantGeneration(
+        for generationID: UUID? = nil,
+        scheduleDeferredDrain: Bool = true
+    ) {
+        assistantGenerationTracker.end(generationID)
+        if !assistantGenerationTracker.hasVisibleGeneration {
+            bargeInState.generationTakeoverCandidate = nil
         }
-        assistantGenerating = false
-        bargeInState.generationTakeoverCandidate = nil
-        eventBus.send(.assistantGenerating(false))
-        scheduleDeferredProactiveDrain()
+        reconcileAssistantGenerating()
+        if scheduleDeferredDrain {
+            scheduleDeferredProactiveDrain()
+        }
+    }
+
+    private func generationVisibility(
+        proactiveContext: ProactiveRequestContext?,
+        playsThinkingTone: Bool,
+        allowsAudibleOutput: Bool
+    ) -> AssistantGenerationTracker.Visibility {
+        if proactiveContext != nil, !playsThinkingTone, !allowsAudibleOutput {
+            return .silentBackground
+        }
+        return .visible
+    }
+
+    private func reconcileAssistantGenerating() {
+        let shouldShow = assistantGenerationTracker.shouldShowAssistantGenerating(
+            awaitingApproval: awaitingApproval
+        )
+        guard assistantGenerating != shouldShow else { return }
+        assistantGenerating = shouldShow
+        eventBus.send(.assistantGenerating(shouldShow))
     }
 
     static func shouldShowToolModeUpgradePopup(reasonCode: String) -> Bool {
@@ -5630,8 +5684,11 @@ actor PipelineCoordinator {
         }
 
         explicitUserAuthorizationForTurn = job.explicitUserAuthorization
-        assistantGenerating = true
-        eventBus.send(.assistantGenerating(true))
+        let generationID = beginAssistantGeneration(
+            visibility: job.generationContext.playsThinkingTone || job.generationContext.allowsAudibleOutput
+                ? .visible
+                : .silentBackground
+        )
         if job.generationContext.playsThinkingTone {
             await playback.playThinkingTone()
         }
@@ -5641,7 +5698,8 @@ actor PipelineCoordinator {
             isToolFollowUp: true,
             turnCount: 1,
             forceSuppressThinking: job.forceSuppressThinking,
-            generationContext: job.generationContext
+            generationContext: job.generationContext,
+            generationID: generationID
         )
     }
 
@@ -5725,6 +5783,7 @@ actor PipelineCoordinator {
     private func setApprovalState(awaiting: Bool, manualOnly: Bool) {
         awaitingApproval = awaiting
         manualOnlyApprovalPending = manualOnly
+        reconcileAssistantGenerating()
     }
 
     private func autoEnableVision() {

--- a/native/macos/Fae/Tests/HandoffTests/AssistantGenerationTrackerTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/AssistantGenerationTrackerTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import Fae
+
+final class AssistantGenerationTrackerTests: XCTestCase {
+    func testOverlappingSilentProactiveGenerationsLeaveThinkingFalseAtQuiescence() {
+        var tracker = AssistantGenerationTracker()
+        let first = UUID()
+        let second = UUID()
+
+        tracker.begin(first, visibility: .silentBackground)
+        XCTAssertEqual(tracker.activeGenerationID, first)
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+
+        tracker.begin(second, visibility: .silentBackground)
+        XCTAssertEqual(tracker.activeGenerationID, second)
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+
+        tracker.end(first)
+        XCTAssertEqual(tracker.activeGenerationID, second)
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+
+        tracker.end(second)
+        XCTAssertNil(tracker.activeGenerationID)
+        XCTAssertFalse(tracker.hasActiveGeneration)
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+    }
+
+    func testStaleVisibleGenerationDoesNotClearNewerVisibleGeneration() {
+        var tracker = AssistantGenerationTracker()
+        let older = UUID()
+        let newer = UUID()
+
+        tracker.begin(older, visibility: .visible)
+        tracker.begin(newer, visibility: .visible)
+
+        tracker.end(older)
+        XCTAssertEqual(tracker.activeGenerationID, newer)
+        XCTAssertTrue(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+
+        tracker.end(newer)
+        XCTAssertNil(tracker.activeGenerationID)
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+    }
+
+    func testVisibleEndingClearsThinkingWhenOnlySilentGenerationRemains() {
+        var tracker = AssistantGenerationTracker()
+        let visible = UUID()
+        let silent = UUID()
+
+        tracker.begin(silent, visibility: .silentBackground)
+        tracker.begin(visible, visibility: .visible)
+        XCTAssertTrue(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+
+        tracker.end(visible)
+        XCTAssertNil(tracker.activeGenerationID)
+        XCTAssertTrue(tracker.hasActiveGeneration)
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+
+        tracker.end(silent)
+        XCTAssertNil(tracker.activeGenerationID)
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+    }
+
+    func testEndingNewestGenerationDoesNotResurrectSupersededOlderGeneration() {
+        var tracker = AssistantGenerationTracker()
+        let older = UUID()
+        let newer = UUID()
+
+        tracker.begin(older, visibility: .visible)
+        tracker.begin(newer, visibility: .visible)
+        tracker.end(newer)
+
+        XCTAssertNil(tracker.activeGenerationID)
+        XCTAssertTrue(tracker.hasActiveGeneration)
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+
+        tracker.end(older)
+        XCTAssertNil(tracker.activeGenerationID)
+        XCTAssertFalse(tracker.hasActiveGeneration)
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+    }
+
+    func testAwaitingApprovalKeepsThinkingVisibleUntilApprovalClears() {
+        var tracker = AssistantGenerationTracker()
+        let visible = UUID()
+
+        tracker.begin(visible, visibility: .visible)
+        tracker.end(visible)
+
+        XCTAssertTrue(tracker.shouldShowAssistantGenerating(awaitingApproval: true))
+        XCTAssertFalse(tracker.shouldShowAssistantGenerating(awaitingApproval: false))
+    }
+}


### PR DESCRIPTION
## Summary
- add AssistantGenerationTracker to separate visible Thinking from silent proactive generation liveness
- keep stale-generation guard semantics while preventing superseded older turns from resurrecting Thinking
- route silent awareness work through tracked liveness without emitting user-visible assistantGenerating
- add regression coverage for overlapping silent work, stale visible guards, approval pauses, and no resurrection of superseded turns

## Validation
- cd native/macos/Fae && swift test --filter AssistantGenerationTrackerTests — 5 tests passed
- cd native/macos/Fae && swift test --filter RuntimeContractTests — 22 tests passed
- cd native/macos/Fae && swift build — passed (pre-existing SwiftPM resource warnings only)
- cd native/macos/Fae && swift test --skip VocabularyHarvestTests — 3093 tests passed
- cd crates && just check — passed
- just check-ui-shell — passed (pre-existing block v0.1.6 future-incompat warning)
- just check — attempted; timed out in known VocabularyHarvestTests Contacts/CoreData/TCC path

## Live proof
- launched dev bundle with embedded fae-ui-shell/fae-daemon and temporary short-interval awareness config, then restored config
- relaunched with --test-server; /health reached running
- logs showed silent camera awareness dispatch/execution/deferred overlap while /conversation stayed isGenerating=false/isSpeaking=false/background=false across polling

## Notes
- direct screencapture is unavailable in this harness (could not create image from display), so live evidence uses runtime logs plus test-server conversation state

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `AssistantGenerationTracker` to separate token-stream liveness from the user-visible orb Thinking indicator. Silent awareness/proactive generations are now tracked without emitting `assistantGenerating`, and stale or superseded generations cannot strand the Thinking pill because ending an old generation only removes that slot while `reconcileAssistantGenerating` drives the indicator from the current set of visible generations.

- Adds `AssistantGenerationTracker` with `visible`/`silentBackground` visibility, `begin()` supersession semantics, and `shouldShowAssistantGenerating(awaitingApproval:)` — backed by five targeted regression tests.
- Replaces scattered `assistantGenerating = true/false` assignments in `PipelineCoordinator` with `beginAssistantGeneration`/`endAssistantGeneration`/`reconcileAssistantGenerating`; proactive drain guards now use `hasActiveGeneration` instead of `assistantGenerating`.
- The tool follow-up visibility check (line 5687) uses `playsThinkingTone || allowsAudibleOutput` without consulting `proactiveContext`, diverging from the `generationVisibility()` helper used in the main generation path — this can misclassify user-turn tool follow-ups as silent in text-only mode.

<h3>Confidence Score: 3/5</h3>

Core tracker logic and the main generation pipeline are sound, but the tool follow-up path uses a different visibility heuristic that can suppress the Thinking indicator for text-only mode users during tool result processing.

The tool follow-up visibility check at line 5687 diverges from the `generationVisibility()` helper: it omits the `proactiveContext` discriminator, so a user-typed query with no TTS and no thinking tone will have its tool follow-up silently tracked, hiding the Thinking indicator while the user waits for a response. Additionally, when a user turn supersedes a silent background generation, only `markGenerationInterrupted()` is called and not `endAssistantGeneration`; if any drain exit path skips cleanup, the generation ID lingers and `hasActiveGeneration` stays permanently true, blocking all future proactive requests.

The tool follow-up dispatch block in `PipelineCoordinator.swift` (around line 5687) and the user-turn-supersedes-silent-background branch (around line 2222) warrant a second look before merging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| native/macos/Fae/Sources/Fae/Pipeline/AssistantGenerationTracker.swift | New struct cleanly separates visible/silent generation tracking; `begin()` correctly downgrades superseded generations; `shouldShowAssistantGenerating` and `hasActiveGeneration` semantics are well-defined and covered by tests. |
| native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift | Tool follow-up generation visibility (line 5687–5691) uses only audio flags, unlike `generateWithTools` which gates on `proactiveContext`. This misclassifies user turns in text-only mode as silentBackground during tool result processing. |
| native/macos/Fae/Tests/HandoffTests/AssistantGenerationTrackerTests.swift | Five regression tests cover overlapping silent generations, stale visible guards, approval pauses, and the no-resurrection invariant; all scenarios match the tracker implementation. |
| docs/CHANGELOG.md | Changelog entry accurately describes the fix and is placed correctly above the prior unreleased entry. |
| docs/reports/task10-thinking-liveness-2026-06-14.md | Detailed task report with validation logs, live evidence, and known gaps; no code concerns. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as "Orb/UI"
    participant PC as "PipelineCoordinator"
    participant AGT as "AssistantGenerationTracker"
    participant EB as "EventBus"

    Note over PC,AGT: User turn (visible)
    PC->>AGT: begin(genID, visible)
    PC->>PC: reconcileAssistantGenerating
    PC->>EB: assistantGenerating(true)
    EB-->>UI: Thinking ON

    Note over PC,AGT: Proactive awareness deferred while user turn active
    PC->>AGT: "hasActiveGeneration = true"
    PC-->>PC: enqueue deferred proactive request

    Note over PC,AGT: User turn ends
    PC->>AGT: end(genID)
    PC->>PC: reconcileAssistantGenerating
    PC->>EB: assistantGenerating(false)
    EB-->>UI: Thinking OFF

    Note over PC,AGT: Proactive drain now idle
    PC->>AGT: begin(silentID, silentBackground)
    PC->>PC: reconcileAssistantGenerating
    Note over PC: hasVisibleGeneration = false, no emit

    Note over PC,AGT: Silent generation ends
    PC->>AGT: end(silentID)
    PC->>PC: reconcileAssistantGenerating
    Note over PC: already false, no emit
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift:5687-5691
**Tool follow-up visibility omits `proactiveContext`, hiding Thinking for text-only user turns**

The visibility decision here uses `playsThinkingTone || allowsAudibleOutput` with no `proactiveContext` guard. The `generationVisibility()` helper used by `generateWithTools` is stricter: it only returns `.silentBackground` when `proactiveContext != nil` *and* both audio flags are false, so a user turn always gets `.visible` regardless of audio mode.

When a user query is typed (no TTS, `allowsAudibleOutput = false`) and also suppresses the thinking tone (`playsThinkingTone = false`), tool follow-up generations are classified as `.silentBackground`. Because the parent generation from `generateWithTools` is already ended by the time the follow-up job runs, the tracker contains no visible generation, so `reconcileAssistantGenerating()` emits `assistantGenerating(false)`. The result: the Thinking indicator disappears during tool result processing for text-only mode users, which is a regression from the unconditional `assistantGenerating = true` in the old code.

The fix is to make the visibility decision here consistent with `generationVisibility()`. If `GenerationContext` (or the `Job`) carries a `proactiveContext`, pass it through; otherwise, consider defaulting to `.visible` unless the job is explicitly marked as proactive, since a missing audio flag should not be enough on its own to silence a user-facing turn.

### Issue 2 of 2
native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift:2222-2230
**Silent generation interrupted without `endAssistantGeneration`, leaking its ID if the drain path skips cleanup**

When a user turn supersedes a silent background generation, `markGenerationInterrupted()` is called but `endAssistantGeneration(for: activeGenerationID)` is not. The expectation is that the background generation's own drain path will eventually call `endAssistantGeneration(for: id)` when it detects the interrupt. If any early-exit path in that drain does not call through (e.g., an error branch that returns without cleanup), the UUID stays in `generationVisibility` indefinitely. Once the map is non-empty, `hasActiveGeneration` stays true and every subsequent proactive request is deferred forever.

The visible generation case immediately above this block calls both `markGenerationInterrupted()` and `endAssistantGeneration()`, so there is precedent for doing both here. Alternatively, an explicit cleanup at the end of the background generation's interrupt path would make the guarantee explicit rather than implicit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pipeline): keep silent awareness fro..."](https://github.com/saorsa-labs/fae/commit/2cd047458bec0d346d039a832880cdef9798f9bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37446024)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->