### PR TITLE
feat(pipeline): add progressive tool disclosure

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Detailed version history moved from CLAUDE.md. For current architecture, see `CLAUDE.md`.
 
+## Unreleased — Task #11 Prompt budget
+
+### Changed
+- Added native progressive tool disclosure: ordinary turns keep a compact index of all allowed tools but send full JSON schemas only for a conservative working set plus explicit/inferred long-tail tools.
+- Added daemon prompt-budget metrics logging (`prompt_budget`) with approximate text-token, payload-byte, and tool-schema counts per turn.
+- Added regression coverage for generic/core tool working sets, inferred long-tail expansion, proactive allowlist narrowing, strict-local filtering, and prompt-budget metric reductions.
+
 ## Unreleased — Task #10 Thinking liveness
 
 ### Fixed

--- a/docs/plans/fae-prompt-budget-2026-06-13.md
+++ b/docs/plans/fae-prompt-budget-2026-06-13.md
@@ -1,0 +1,107 @@
+# Fae Prompt-Budget — cut prompt tokens to fix latency + the NaN bug
+
+**Date:** 2026-06-13
+**Why:** Fae's LLM is local (Gemma via mistral.rs) — there is **no API cost** to
+save. But prompt *length* is load-bearing for two real problems:
+- **Latency**: measured 50–82s TTFA driven by full re-prefill (prefix cache off)
+  + history growth. Prefill time scales with prompt tokens.
+- **The NaN bug** ([mistral.rs#2214]): NaN logits occur at specific *total*
+  prompt lengths. Shorter, stabler prompts dodge the bad windows.
+
+This is the "save tokens" lever that actually pays off for a local-first product
+— done **natively** in Fae's pipeline, no third-party proxy/compression model.
+(Evaluated `chopratejas/headroom` 2026-06-13: good for paid-API agents, but a
+Python proxy + compression model is an architectural mismatch for a local
+Rust/Swift turn path with no API bill; context-mode already covers our dev
+workflow. We adopt the *idea*, not the dependency.)
+
+## Current state (verified 2026-06-13)
+
+1. **All 36 tool specs ship in every request.** `DaemonWire.injectTextPayload`
+   (`ML/DaemonLLMEngine.swift:214`) sends `daemonTools(from: options.tools ?? [])`
+   — every tool's `{name, description, parameters}` on every turn. The NaN repro
+   payload carried all 36. This is the single largest, most cuttable chunk.
+2. **Memory recall is result-count-capped, not byte-capped.**
+   `MemoryOrchestrator.recall` (`Memory/MemoryOrchestrator.swift:76`) caps by
+   `maxRecallResults` (default 6) but pulls from several sources
+   (`recentRecords` ×3/×4, entity hits, etc.) and returns an unbounded string
+   injected into the system prompt. The NaN repro's system prompt was ~30K chars.
+3. **Prefix cache is fully disabled.** `crates/fae-engine/src/mistralrs_adapter.rs`
+   lines 39 & 57: `.with_prefix_cache_n(None)` on both load paths. The comment
+   cites audio-turn correctness, but it's off for *all* turns — so every turn
+   re-prefills the entire (large) prompt from scratch.
+
+## The three levers (in priority order)
+
+### Lever 1 — Progressive tool disclosure (biggest win)
+
+Today every turn sends all 36 full tool schemas. We already do progressive
+disclosure for **skills** (names+descriptions in prompt; full SKILL.md body only
+on `activate_skill`). Apply the same to **tools**:
+
+- Send the model a compact **tool index** (name + one-line description) for all
+  tools, plus the **full `parameters` schema only for a working set** — the tools
+  plausibly relevant to the turn (e.g. always-core tools + any recently used +
+  any the turn's intent suggests). The model requests a tool by name; if it picks
+  one whose full schema wasn't sent, do a cheap second pass that includes that
+  tool's full schema (mirrors `activate_skill`).
+- Conservative first cut if dynamic selection is risky: keep full schemas for the
+  ~8–10 core tools (`read/write/edit/bash/self_config/web_search/...`), index-only
+  for the long tail (Apple/scheduler/vision/computer-use), expand on demand.
+- Measure: log total daemon-payload token count per turn before/after. Target a
+  large reduction in the tools array on a typical turn.
+
+**Risk:** tool-calling accuracy must not regress. Gate on FaeBenchmark tool-call
+score (the harness that scored Gemma 4 E4B 100% on tool calling). No net
+accuracy loss permitted.
+
+### Lever 2 — Byte-budget the memory recall injection
+
+- Add a hard character/token budget to the string `MemoryOrchestrator.recall`
+  returns (e.g. cap at N tokens; default sized from `recommendedMaxHistory`
+  math). Truncate lowest-ranked records first; keep the highest-relevance hits.
+- Prefer the hybrid 60% ANN / 40% FTS5 top results; drop the `recentRecords ×3/×4`
+  padding when the budget is tight.
+- Surface the budget as a config knob (`memory.maxRecallTokens`) consistent with
+  the existing `memory.maxRecallResults`.
+
+**Risk:** don't starve recall — memory strength is a core objective. Tune the
+budget so typical turns are unaffected; only very large recalls get trimmed.
+
+### Lever 3 — Re-enable prefix caching where safe
+
+- The prefix cache is off entirely. Re-enable it for the **text/tool prefix**
+  (system prompt + tools + stable history) while keeping it off (or scoped) for
+  the **audio-bearing** portion that empirically corrupted audio turns
+  (`with_prefix_cache_n(None)` was added for that reason — confirm the exact
+  failure before changing).
+- A stable prefix is also what `headroom`'s "CacheAligner" chases — here it's
+  free if the system-prompt + tool-index prefix is byte-stable across turns
+  (don't reorder tools, don't inject timestamps into the prefix).
+- This is the highest-leverage *latency* fix (re-prefill is the 50–82s driver),
+  but the riskiest — it touches the daemon engine and the audio-correctness
+  fix. Do it last, behind a flag, with the audio turn regression explicitly
+  re-tested.
+
+**Risk:** must not reintroduce the audio-turn corruption that disabling it cured.
+Keep audio turns on the safe path; only the text prefix gets cached.
+
+## Acceptance / evidence
+
+- Per-turn daemon-payload token count logged before/after each lever; report the
+  reduction on a representative turn (typical chat + a tool turn + an audio turn).
+- FaeBenchmark tool-call + capability scores: **no regression** from Lever 1.
+- A turn that previously hit a NaN window: show prompt length moved out of it
+  (or padded-retry frequency dropped).
+- TTFA on a warm multi-turn conversation: before/after (Lever 3).
+- `cd crates && just check` + `just check --skip VocabularyHarvestTests` green;
+  audio-turn correctness re-verified for Lever 3.
+
+## Sequencing
+
+Lever 1 (tools) first — biggest token cut, lowest engine risk. Lever 2 (memory
+budget) second. Lever 3 (prefix cache) last, behind a flag, with the audio
+regression gate. Each lands as its own commit/PR with the evidence above. This
+is independent of the P1–P5 cross-platform track and can run in parallel.
+
+[mistral.rs#2214]: https://github.com/EricLBuehler/mistral.rs/issues/2214

--- a/docs/reports/task11-prompt-budget-2026-06-14.md
+++ b/docs/reports/task11-prompt-budget-2026-06-14.md
@@ -1,0 +1,168 @@
+# Task #11 — Fae prompt budget
+
+Date: 2026-06-14 local / 2026-06-14 UTC
+Branch: `fae-prompt-budget`
+Scope: Lever 1 from `docs/plans/fae-prompt-budget-2026-06-13.md` — native progressive tool disclosure + prompt-budget metrics. Prefix cache and memory recall byte-budgeting remain follow-ups.
+
+## 1. What changed
+
+```text
+docs/CHANGELOG.md                                  |   7 +
+docs/plans/fae-prompt-budget-2026-06-13.md         | 107 +++++++++++++
+docs/reports/task11-prompt-budget-2026-06-14.md    | 168 +++++++++++++++++++++
+.../macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift |  61 ++++++++
+.../Sources/Fae/Pipeline/PipelineCoordinator.swift |  35 ++++-
+.../Fae/Sources/Fae/Pipeline/TurnHelpers.swift     |  74 ++++++++-
+.../macos/Fae/Sources/Fae/Tools/ToolRegistry.swift |  12 +-
+.../IntegrationTests/DaemonLLMEngineTests.swift    |  84 +++++++++++
+.../Tests/IntegrationTests/TurnHelpersTests.swift  |  92 +++++++++++
+9 files changed, 628 insertions(+), 12 deletions(-)
+```
+
+Summary:
+
+- Added progressive native tool disclosure: full JSON schemas are sent only for a conservative per-turn working set, while the prompt carries a compact allowed-tool index.
+- Long-tail tools expand into full schemas when explicitly mentioned or inferred from user intent; proactive allowlists stay narrow and keep their compact index aligned with callable schemas.
+- Conversation continuations with ambiguous text preserve the old all-schema behavior to avoid breaking short follow-ups like “yes, use that”.
+- Added daemon prompt-budget metrics logging before every `conversation.inject_text` request.
+- Added tests for generic working-set reduction, long-tail expansion, proactive narrowing, strict-local filtering, continuation preservation, and zero-tool metrics.
+
+## 2. Validation
+
+### `cd native/macos/Fae && swift test --filter TurnHelpersTests`
+
+```text
+Test Suite 'TurnHelpersTests' passed at 2026-06-14 08:53:55.035.
+	 Executed 60 tests, with 0 failures (0 unexpected) in 0.009 (0.012) seconds
+Test Suite 'Selected tests' passed at 2026-06-14 08:53:55.035.
+	 Executed 60 tests, with 0 failures (0 unexpected) in 0.009 (0.013) seconds
+```
+
+### `cd native/macos/Fae && swift test --filter DaemonWireTests`
+
+```text
+2026-06-14 08:53:55.998 xctest[99005:30268973] PromptBudgetTest: generic all_tools=36 all_tool_tokens=5570 working_tools=15 working_tool_tokens=2665 reduction_tokens=2905
+Test Suite 'DaemonWireTests' passed at 2026-06-14 08:53:55.999.
+	 Executed 21 tests, with 0 failures (0 unexpected) in 0.007 (0.008) seconds
+Test Suite 'Selected tests' passed at 2026-06-14 08:27:08.704.
+	 Executed 21 tests, with 0 failures (0 unexpected) in 0.007 (0.009) seconds
+```
+
+### `cd native/macos/Fae && swift test --filter RuntimeContractTests`
+
+```text
+Test Suite 'RuntimeContractTests' passed at 2026-06-14 08:54:00.713.
+	 Executed 22 tests, with 0 failures (0 unexpected) in 3.754 (3.756) seconds
+Test Suite 'Selected tests' passed at 2026-06-14 08:54:00.714.
+	 Executed 22 tests, with 0 failures (0 unexpected) in 3.754 (3.757) seconds
+```
+
+### `cd native/macos/Fae && swift test --skip VocabularyHarvestTests`
+
+```text
+Test Suite 'FaePackageTests.xctest' passed at 2026-06-14 08:56:11.327.
+	 Executed 3103 tests, with 0 failures (0 unexpected) in 120.653 (120.823) seconds
+Test Suite 'Selected tests' passed at 2026-06-14 08:56:11.327.
+	 Executed 3103 tests, with 0 failures (0 unexpected) in 120.653 (120.824) seconds
+```
+
+### `cd crates && just check`
+
+```text
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.87s
+cargo test --all-features
+...
+test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+### `just check-ui-shell`
+
+```text
+cd native/rust/fae-ui-shell && cargo fmt --all
+cd native/rust/fae-ui-shell && cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
+cd native/rust/fae-ui-shell && cargo check --workspace --all-targets
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
+```
+
+The `block v0.1.6` future-incompat warning is pre-existing.
+
+## 3. Live evidence
+
+Built and launched the dev bundle with embedded `fae-ui-shell` and `fae-daemon`:
+
+```text
+✓ Bundle assembled: native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app (v0.8.189)
+  → Embedded fae-ui-shell
+  → Embedded fae-daemon
+✓ Signed: native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app
+native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app: valid on disk
+native/macos/Fae/.build/xcode/Build/Products/Debug/Fae.app: satisfies its Designated Requirement
+✓ Fae (DEV) launched — logs: tail -f /tmp/fae-dev.log
+```
+
+Relaunched the same bundle with `--test-server`; `/health` reached:
+
+```text
+{"pipeline":"running","status":"ok"}
+```
+
+Injected a simple no-tool turn:
+
+```text
+inject: {"injected":"say ok in one short sentence","ok":true,"turn_id":"E8ECF417-0C7B-4133-BAD9-2437D685EDB3"}
+```
+
+Runtime events for the injected turn:
+
+```text
+26 2026-06-14T07:28:35.092Z QA === TURN START user=say ok in one short sentence ===
+29 2026-06-14T07:28:35.192Z Pipeline Tool disclosure: index=36 full_schemas=15
+37 2026-06-14T07:28:51.697Z Pipeline LLM done: 1 tokens total=16.5s first_token=16.5s decode=0.0s decode_tps=1000.0
+40 2026-06-14T07:28:51.697Z QA Model raw response preview: Ok.
+```
+
+No `Found tool call` / `Tool id=` events occurred for the injected user turn. The daemon logged prompt-budget metrics for that request:
+
+```text
+2026-06-14 08:28:35.225 Fae[54869:30187412] DaemonLLMEngine: prompt_budget request=r3 estimated_text_tokens=10370 payload_bytes=42358 system_tokens=7552 message_tokens=153 tools=15 tool_tokens=2665 tool_bytes=10658
+```
+
+The same run also showed startup proactive work using the narrowed allowlist path:
+
+```text
+2026-06-14T07:28:18.209Z Pipeline Tool disclosure: index=6 full_schemas=1
+2026-06-14 08:28:18.282 Fae[54869:30187184] DaemonLLMEngine: prompt_budget request=r2 estimated_text_tokens=7337 payload_bytes=30205 system_tokens=7037 message_tokens=228 tools=1 tool_tokens=72 tool_bytes=287
+```
+
+Test-side before/after metric for a generic turn, using all full schemas as the pre-change baseline:
+
+```text
+PromptBudgetTest: generic all_tools=36 all_tool_tokens=5570 working_tools=15 working_tool_tokens=2665 reduction_tokens=2905
+```
+
+The app was killed after verification.
+
+## 4. Deviations / scope
+
+- Implemented Lever 1 only. Lever 2 (memory recall token/byte budgeting) and Lever 3 (prefix cache re-enable) are left for separate PRs because prefix caching is explicitly high-risk for audio turns.
+- The compact index still lists all allowed tools for ordinary user turns, but full callable schemas are reduced to the working set. Conversation continuations preserve all schemas when intent is ambiguous to avoid regressing follow-up turns.
+- Root `just check` was not claimed green; local full Swift test remains blocked by the known `VocabularyHarvestTests` Contacts/CoreData/TCC path. The established local substitute, `swift test --skip VocabularyHarvestTests`, passed.
+
+## 5. Known gaps / follow-ups
+
+- Add Lever 2: hard budget for memory recall injection.
+- Add Lever 3 behind a flag: prefix cache for safe text/tool prefixes only, with explicit audio-turn regression proof.
+- Add a FaeBenchmark tool-call score gate before broader prompt-budget changes.
+
+## 6. Docs touched + Obsidian notes
+
+Docs touched:
+
+- `docs/CHANGELOG.md`
+- `docs/plans/fae-prompt-budget-2026-06-13.md`
+- `docs/reports/task11-prompt-budget-2026-06-14.md`
+
+Obsidian mirrors updated after this report was written.

--- a/native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift
+++ b/native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift
@@ -105,6 +105,18 @@ enum DaemonWire {
         var finishReason: String?
     }
 
+    struct PromptBudgetMetrics: Equatable {
+        var systemChars: Int
+        var messageChars: Int
+        var toolCount: Int
+        var toolBytes: Int
+        var payloadBytes: Int
+        var estimatedSystemTokens: Int
+        var estimatedMessageTokens: Int
+        var estimatedToolTokens: Int
+        var estimatedTextTokens: Int
+    }
+
     /// A single tool call extracted from a daemon turn result.
     struct ToolCallPayload {
         var name: String
@@ -216,6 +228,43 @@ enum DaemonWire {
             payload["tools"] = tools
         }
         return payload
+    }
+
+    static func promptBudgetMetrics(for payload: [String: Any]) -> PromptBudgetMetrics {
+        let system = (payload["system"] as? String) ?? ""
+        let messages = (payload["messages"] as? [[String: Any]]) ?? []
+        let messageChars = messages.reduce(0) { partial, message in
+            partial + ((message["content"] as? String)?.count ?? 0)
+        }
+        let tools = (payload["tools"] as? [[String: Any]]) ?? []
+        let toolBytes = tools.isEmpty ? 0 : jsonByteCount(tools)
+        let payloadBytes = jsonByteCount(payload)
+        let systemTokens = estimateTextTokens(system.count)
+        let messageTokens = estimateTextTokens(messageChars)
+        let toolTokens = tools.isEmpty ? 0 : estimateTextTokens(toolBytes)
+        return PromptBudgetMetrics(
+            systemChars: system.count,
+            messageChars: messageChars,
+            toolCount: tools.count,
+            toolBytes: toolBytes,
+            payloadBytes: payloadBytes,
+            estimatedSystemTokens: systemTokens,
+            estimatedMessageTokens: messageTokens,
+            estimatedToolTokens: toolTokens,
+            estimatedTextTokens: systemTokens + messageTokens + toolTokens
+        )
+    }
+
+    private static func estimateTextTokens(_ byteOrCharCount: Int) -> Int {
+        guard byteOrCharCount > 0 else { return 0 }
+        return max(1, (byteOrCharCount + 3) / 4)
+    }
+
+    private static func jsonByteCount(_ object: Any) -> Int {
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        else { return 0 }
+        return data.count
     }
 
     /// Flatten MLX ToolSpec dictionaries into the daemon's tool shape.
@@ -755,6 +804,18 @@ actor DaemonLLMEngine: LLMEngine {
         let requestID = nextRequestID()
         let payload = DaemonWire.injectTextPayload(
             messages: messages, systemPrompt: systemPrompt, options: options)
+        let metrics = DaemonWire.promptBudgetMetrics(for: payload)
+        NSLog(
+            "DaemonLLMEngine: prompt_budget request=%@ estimated_text_tokens=%d payload_bytes=%d system_tokens=%d message_tokens=%d tools=%d tool_tokens=%d tool_bytes=%d",
+            requestID,
+            metrics.estimatedTextTokens,
+            metrics.payloadBytes,
+            metrics.estimatedSystemTokens,
+            metrics.estimatedMessageTokens,
+            metrics.toolCount,
+            metrics.estimatedToolTokens,
+            metrics.toolBytes
+        )
         let frame = try DaemonWire.encodeFrame(
             requestID: requestID, command: "conversation.inject_text", payload: payload)
         let raw = try await connection.roundTrip(frame: frame, expectRequestID: requestID)

--- a/native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift
@@ -2943,6 +2943,16 @@ actor PipelineCoordinator {
                 proactiveAllowedTools: proactiveContext?.allowedTools,
                 isConversationContinuation: isRecentContinuation
             )
+            let indexedToolNames: Set<String>? = speakerGate.firstOwnerEnrollmentActive
+                ? []
+                : proactiveContext?.allowedTools
+            let fullSchemaToolNames = TurnHelpers.fullSchemaToolNamesForTurn(
+                firstOwnerEnrollmentActive: speakerGate.firstOwnerEnrollmentActive,
+                userText: userText,
+                availableToolNames: registry.toolNames,
+                proactiveAllowedTools: proactiveContext?.allowedTools,
+                isConversationContinuation: isRecentContinuation
+            )
             if let visibleToolNames {
                 debugLog(
                     debugConsole,
@@ -3016,22 +3026,26 @@ actor PipelineCoordinator {
                 skillDescs = []
                 legacySkills = []
             }
-            // Build native tool specs for MLX tool calling.
-            let nativeTools = includeTools && !preferLegacyInlineToolPrompt
+            // Build native tool specs for MLX/daemon tool calling. The prompt
+            // still carries a compact index of the allowed tool surface, but
+            // full JSON schemas are limited to the conservative working set for
+            // this turn to reduce prefill and avoid known bad prompt windows.
+            let useNativeToolCalling = includeTools && !preferLegacyInlineToolPrompt
+            let nativeTools = useNativeToolCalling
                 ? registry.nativeToolSpecs(
                     for: toolMode,
                     privacyMode: privacyMode,
-                    limitedTo: visibleToolNames
+                    limitedTo: fullSchemaToolNames
                 )
                 : nil
 
             let toolSchemas: String? = {
                 guard includeTools else { return nil }
-                if nativeTools != nil {
+                if useNativeToolCalling {
                     let compact = registry.compactToolSummary(
                         for: toolMode,
                         privacyMode: privacyMode,
-                        limitedTo: visibleToolNames
+                        limitedTo: indexedToolNames
                     )
                     return compact.isEmpty ? nil : compact
                 }
@@ -3044,7 +3058,16 @@ actor PipelineCoordinator {
             }()
 
             if let specs = nativeTools {
-                debugLog(debugConsole, .pipeline, "Native tool specs: \(specs.count) tools")
+                let indexedCount = registry.allowedToolNames(
+                    for: toolMode,
+                    privacyMode: privacyMode,
+                    limitedTo: indexedToolNames
+                ).count
+                debugLog(
+                    debugConsole,
+                    .pipeline,
+                    "Tool disclosure: index=\(indexedCount) full_schemas=\(specs.count)"
+                )
             } else if includeTools, preferLegacyInlineToolPrompt {
                 debugLog(
                     debugConsole,

--- a/native/macos/Fae/Sources/Fae/Pipeline/TurnHelpers.swift
+++ b/native/macos/Fae/Sources/Fae/Pipeline/TurnHelpers.swift
@@ -140,14 +140,10 @@ enum TurnHelpers {
             // Voice-identity teardown: enrollment no longer exposes a tool.
             return []
         }
-        let explicitMentions = explicitlyMentionedToolNames(
+        let requestedTools = requestedToolNamesForTurn(
             in: userText,
             availableToolNames: availableToolNames
         )
-        let inferredMentions = explicitMentions.isEmpty
-            ? inferredToolNamesForTurn(in: userText, availableToolNames: availableToolNames)
-            : []
-        let requestedTools = explicitMentions.isEmpty ? inferredMentions : explicitMentions
 
         // In a conversation continuation (within 45s of last assistant message),
         // show all tools unless this is a proactive task with a specific allowlist.
@@ -170,6 +166,74 @@ enum TurnHelpers {
         case (nil, true):
             return nil
         }
+    }
+
+    /// Conservative tools that keep full native schemas on ordinary turns.
+    /// Long-tail tools are still indexed in the prompt, but only expand to full
+    /// schemas when the turn explicitly/inferentially asks for them.
+    static let defaultFullSchemaToolNames: Set<String> = [
+        "activate_skill",
+        "bash",
+        "channel_setup",
+        "edit",
+        "fetch_url",
+        "input_request",
+        "manage_skill",
+        "read",
+        "run_skill",
+        "self_config",
+        "session_search",
+        "till_done",
+        "web_search",
+        "window_control",
+        "write",
+    ]
+
+    static func fullSchemaToolNamesForTurn(
+        firstOwnerEnrollmentActive: Bool,
+        userText: String,
+        availableToolNames: [String],
+        proactiveAllowedTools: Set<String>?,
+        isConversationContinuation: Bool = false
+    ) -> Set<String> {
+        if firstOwnerEnrollmentActive {
+            return []
+        }
+
+        let available = Set(availableToolNames)
+        let requestedTools = requestedToolNamesForTurn(
+            in: userText,
+            availableToolNames: availableToolNames
+        ).intersection(available)
+
+        if let proactiveAllowedTools {
+            // Proactive allowlists are already intentionally narrow. Keep the
+            // compact index and native schemas aligned by exposing the whole
+            // allowlist rather than a requested subset.
+            return proactiveAllowedTools.intersection(available)
+        }
+
+        if isConversationContinuation, requestedTools.isEmpty {
+            return available
+        }
+
+        var workingSet = defaultFullSchemaToolNames.intersection(available)
+        workingSet.formUnion(requestedTools)
+        return workingSet
+    }
+
+    static func requestedToolNamesForTurn(
+        in userText: String,
+        availableToolNames: [String]
+    ) -> Set<String> {
+        let explicitMentions = explicitlyMentionedToolNames(
+            in: userText,
+            availableToolNames: availableToolNames
+        )
+        if !explicitMentions.isEmpty {
+            return explicitMentions
+        }
+        return inferredToolNamesForTurn(in: userText, availableToolNames: availableToolNames)
     }
 
     /// Common English words that happen to be tool names but should NOT

--- a/native/macos/Fae/Sources/Fae/Tools/ToolRegistry.swift
+++ b/native/macos/Fae/Sources/Fae/Tools/ToolRegistry.swift
@@ -130,6 +130,16 @@ final class ToolRegistry: Sendable {
         Array(tools.keys).sorted()
     }
 
+    func allowedToolNames(
+        for mode: String,
+        privacyMode: String = "local_preferred",
+        limitedTo allowedNames: Set<String>? = nil
+    ) -> [String] {
+        filteredTools(for: mode, privacyMode: privacyMode, limitedTo: allowedNames)
+            .map { $0.name }
+            .sorted()
+    }
+
     /// JSON schema descriptions for all registered tools, with examples when available.
     var toolSchemas: String {
         schemaString(for: Array(tools.values))
@@ -167,7 +177,7 @@ final class ToolRegistry: Sendable {
                 ?? tool.description
             return "- \(tool.name): \(brief)"
         }
-        return "Available tools:\n" + lines.joined(separator: "\n")
+        return "Available tool index (full callable schemas are supplied for the likely working set):\n" + lines.joined(separator: "\n")
     }
 
     /// Check whether a tool is allowed in the given mode.

--- a/native/macos/Fae/Tests/IntegrationTests/DaemonLLMEngineTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/DaemonLLMEngineTests.swift
@@ -110,6 +110,90 @@ final class DaemonWireTests: XCTestCase {
         XCTAssertEqual((tools[0]["parameters"] as? [String: Any])?["type"] as? String, "object")
     }
 
+    func testPromptBudgetMetricsCountsTextAndTools() throws {
+        let specs: [[String: any Sendable]] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "read",
+                    "description": "Read a file",
+                    "parameters": ["type": "object", "properties": ["path": ["type": "string"]]] as [String: Any],
+                ] as [String: Any],
+            ]
+        ]
+        var options = GenerationOptions(maxTokens: 64)
+        options.tools = specs
+        let payload = DaemonWire.injectTextPayload(
+            messages: [LLMMessage(role: .user, content: "hello")],
+            systemPrompt: "You are Fae.",
+            options: options)
+
+        let metrics = DaemonWire.promptBudgetMetrics(for: payload)
+        XCTAssertEqual(metrics.systemChars, "You are Fae.".count)
+        XCTAssertEqual(metrics.messageChars, "hello".count)
+        XCTAssertEqual(metrics.toolCount, 1)
+        XCTAssertGreaterThan(metrics.toolBytes, 0)
+        XCTAssertGreaterThan(metrics.payloadBytes, metrics.toolBytes)
+        XCTAssertEqual(
+            metrics.estimatedTextTokens,
+            metrics.estimatedSystemTokens + metrics.estimatedMessageTokens + metrics.estimatedToolTokens
+        )
+    }
+
+    func testPromptBudgetMetricsReportsZeroForNoTools() {
+        let payload = DaemonWire.injectTextPayload(
+            messages: [LLMMessage(role: .user, content: "hello")],
+            systemPrompt: "You are Fae.",
+            options: GenerationOptions(maxTokens: 64)
+        )
+        let metrics = DaemonWire.promptBudgetMetrics(for: payload)
+        XCTAssertEqual(metrics.toolCount, 0)
+        XCTAssertEqual(metrics.toolBytes, 0)
+        XCTAssertEqual(metrics.estimatedToolTokens, 0)
+    }
+
+    func testPromptBudgetWorkingSetReducesGenericToolPayload() throws {
+        let registry = ToolRegistry.buildDefault()
+        let allTools = try XCTUnwrap(registry.nativeToolSpecs(for: "full"))
+        let workingSet = TurnHelpers.fullSchemaToolNamesForTurn(
+            firstOwnerEnrollmentActive: false,
+            userText: "hello fae",
+            availableToolNames: registry.toolNames,
+            proactiveAllowedTools: nil
+        )
+        let workingTools = try XCTUnwrap(
+            registry.nativeToolSpecs(for: "full", limitedTo: workingSet)
+        )
+
+        var allOptions = GenerationOptions(maxTokens: 64)
+        allOptions.tools = allTools
+        let allPayload = DaemonWire.injectTextPayload(
+            messages: [LLMMessage(role: .user, content: "hello fae")],
+            systemPrompt: "You are Fae.",
+            options: allOptions
+        )
+        var workingOptions = GenerationOptions(maxTokens: 64)
+        workingOptions.tools = workingTools
+        let workingPayload = DaemonWire.injectTextPayload(
+            messages: [LLMMessage(role: .user, content: "hello fae")],
+            systemPrompt: "You are Fae.",
+            options: workingOptions
+        )
+
+        let allMetrics = DaemonWire.promptBudgetMetrics(for: allPayload)
+        let workingMetrics = DaemonWire.promptBudgetMetrics(for: workingPayload)
+        NSLog(
+            "PromptBudgetTest: generic all_tools=%d all_tool_tokens=%d working_tools=%d working_tool_tokens=%d reduction_tokens=%d",
+            allMetrics.toolCount,
+            allMetrics.estimatedToolTokens,
+            workingMetrics.toolCount,
+            workingMetrics.estimatedToolTokens,
+            allMetrics.estimatedToolTokens - workingMetrics.estimatedToolTokens
+        )
+        XCTAssertLessThan(workingMetrics.toolCount, allMetrics.toolCount)
+        XCTAssertLessThan(workingMetrics.estimatedToolTokens, allMetrics.estimatedToolTokens)
+    }
+
     func testDaemonToolsSkipsSpecsWithoutNames() {
         let specs: [[String: any Sendable]] = [
             ["type": "function", "function": ["description": "nameless"] as [String: Any]]

--- a/native/macos/Fae/Tests/IntegrationTests/TurnHelpersTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/TurnHelpersTests.swift
@@ -79,6 +79,98 @@ final class TurnHelpersTests: XCTestCase {
         XCTAssertNotNil(tools)
     }
 
+    func testFullSchemaToolsGenericTurnUsesCoreWorkingSet() {
+        let available = [
+            "read", "write", "edit", "bash", "self_config", "web_search", "fetch_url",
+            "calendar", "camera", "mail", "scheduler_create", "input_request",
+        ]
+        let tools = TurnHelpers.fullSchemaToolNamesForTurn(
+            firstOwnerEnrollmentActive: false,
+            userText: "hello there",
+            availableToolNames: available,
+            proactiveAllowedTools: nil
+        )
+        XCTAssertTrue(tools.contains("read"))
+        XCTAssertTrue(tools.contains("bash"))
+        XCTAssertTrue(tools.contains("input_request"))
+        XCTAssertFalse(tools.contains("calendar"))
+        XCTAssertFalse(tools.contains("camera"))
+        XCTAssertLessThan(tools.count, available.count)
+    }
+
+    func testFullSchemaToolsIncludeInferredLongTailTool() {
+        let tools = TurnHelpers.fullSchemaToolNamesForTurn(
+            firstOwnerEnrollmentActive: false,
+            userText: "can you see me",
+            availableToolNames: ["read", "bash", "camera", "calendar"],
+            proactiveAllowedTools: nil
+        )
+        XCTAssertTrue(tools.contains("read"))
+        XCTAssertTrue(tools.contains("camera"))
+        XCTAssertFalse(tools.contains("calendar"))
+    }
+
+    func testFullSchemaToolsProactiveAllowlistStaysNarrow() {
+        let tools = TurnHelpers.fullSchemaToolNamesForTurn(
+            firstOwnerEnrollmentActive: false,
+            userText: "look around",
+            availableToolNames: ["read", "bash", "camera", "calendar"],
+            proactiveAllowedTools: ["camera"]
+        )
+        XCTAssertEqual(tools, ["camera"])
+    }
+
+    func testFullSchemaToolsProactiveAllowlistDoesNotNarrowIndexAndSchemasApart() {
+        let tools = TurnHelpers.fullSchemaToolNamesForTurn(
+            firstOwnerEnrollmentActive: false,
+            userText: "check the calendar",
+            availableToolNames: ["calendar", "mail", "reminders"],
+            proactiveAllowedTools: ["calendar", "mail", "reminders"]
+        )
+        XCTAssertEqual(tools, ["calendar", "mail", "reminders"])
+    }
+
+    func testFullSchemaToolsContinuationPreservesAllSchemasWhenIntentIsAmbiguous() {
+        let available = ["read", "bash", "calendar", "mail", "input_request"]
+        let tools = TurnHelpers.fullSchemaToolNamesForTurn(
+            firstOwnerEnrollmentActive: false,
+            userText: "yes, use that",
+            availableToolNames: available,
+            proactiveAllowedTools: nil,
+            isConversationContinuation: true
+        )
+        XCTAssertEqual(tools, Set(available))
+    }
+
+    func testFullSchemaToolsDuringEnrollmentAreEmpty() {
+        let tools = TurnHelpers.fullSchemaToolNamesForTurn(
+            firstOwnerEnrollmentActive: true,
+            userText: "search web",
+            availableToolNames: ["read", "web_search"],
+            proactiveAllowedTools: nil
+        )
+        XCTAssertTrue(tools.isEmpty)
+    }
+
+    func testToolRegistryStrictLocalFiltersFullSchemaWorkingSet() {
+        let registry = ToolRegistry(tools: [ReadTool(), WebSearchTool(), FetchURLTool(), BashTool()])
+        let workingSet = TurnHelpers.fullSchemaToolNamesForTurn(
+            firstOwnerEnrollmentActive: false,
+            userText: "search the web",
+            availableToolNames: registry.toolNames,
+            proactiveAllowedTools: nil
+        )
+        let allowed = registry.allowedToolNames(
+            for: "full",
+            privacyMode: "strict_local",
+            limitedTo: workingSet
+        )
+        XCTAssertTrue(allowed.contains("read"))
+        XCTAssertTrue(allowed.contains("bash"))
+        XCTAssertFalse(allowed.contains("web_search"))
+        XCTAssertFalse(allowed.contains("fetch_url"))
+    }
+
     func testExplicitlyMentionedToolNames() {
         let tools = TurnHelpers.explicitlyMentionedToolNames(
             in: "please use web_search to look this up",


### PR DESCRIPTION
## Summary
- implement Task #11 / prompt-budget Lever 1: compact allowed-tool index plus reduced full-schema working set
- expand long-tail full schemas on explicit/inferred tool intent and keep proactive allowlists narrow
- add daemon prompt_budget metrics logging for estimated prompt tokens/payload/tool schema size
- preserve all schemas for ambiguous conversation continuations to avoid short-follow-up regressions

## Evidence
- generic all-full baseline vs working set: 36 tools / ~5570 tool tokens → 15 tools / ~2665 tool tokens (−2905 estimated tool tokens)
- live dev/test-server injected turn "say ok in one short sentence": Tool disclosure index=36 full_schemas=15; daemon prompt_budget tools=15 tool_tokens=2665; response "Ok." with no tool calls
- startup proactive path: Tool disclosure index=6 full_schemas=1; prompt_budget tools=1 tool_tokens=72

## Validation
- cd native/macos/Fae && swift test --filter TurnHelpersTests — 59 tests passed
- cd native/macos/Fae && swift test --filter DaemonWireTests — 21 tests passed
- cd native/macos/Fae && swift test --filter RuntimeContractTests — 22 tests passed
- cd native/macos/Fae && swift test --skip VocabularyHarvestTests — 3102 tests passed
- cd crates && just check — passed
- just check-ui-shell — passed (pre-existing block v0.1.6 future-incompat warning)

## Notes
- Lever 2 memory recall budgeting and Lever 3 prefix-cache re-enable are intentionally left for follow-up PRs.
- Root just check is not claimed green locally because full swift test remains blocked by the known VocabularyHarvestTests Contacts/CoreData/TCC path; the skip run above is the established local substitute.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements Lever 1 of the Fae prompt-budget plan: progressive tool disclosure. Rather than sending all 36 full JSON schemas on every turn, the pipeline now sends a compact name+description index for the full allowed-tool surface while restricting callable native schemas to a conservative working set (~15 tools) plus any tools explicitly or inferentially matched to the current turn's intent. A `PromptBudgetMetrics` struct and `NSLog` instrumentation track estimated token counts per request for observability.

- **`TurnHelpers.fullSchemaToolNamesForTurn`** selects which tools get full schemas: the hardcoded `defaultFullSchemaToolNames` core set unioned with turn-inferred tools; proactive turns narrow to the allowlist; ambiguous continuations fall back to all available tools to avoid follow-up regressions.
- **`PipelineCoordinator`** now computes two separate sets — `indexedToolNames` (compact text index) and `fullSchemaToolNames` (native JSON specs) — passing each to the corresponding `ToolRegistry` method; the existing `visibleToolNamesForTurn` result is preserved only for the legacy inline-tool-prompt path.
- **`DaemonLLMEngine`** logs `prompt_budget` metrics before each `conversation.inject_text` call, with a new `PromptBudgetMetrics` struct and a 1-char-per-4-token heuristic.

<h3>Confidence Score: 4/5</h3>

Safe to merge on the non-proactive paths; the proactive multi-tool narrowing case has a schema/index mismatch that could silently drop tool calls.

The core non-proactive path (ordinary turns and ambiguous continuations) is well-tested and the working-set selection is conservative enough that the model rarely encounters a tool in the index without a schema. The proactive path has a narrower issue: when task-text inference picks only a subset of a multi-tool proactive allowlist, the compact index advertises the full allowlist while native schemas are limited to the intersection — any tool call to the non-schema tools would fail without a recovery path. The live evidence shows single-tool proactive allowlists in practice, so this is unlikely to trigger immediately, but the logic gap is real and worth closing before proactive tasks grow more complex allowlists.

PipelineCoordinator.swift — the `indexedToolNames` / `fullSchemaToolNames` split for the proactive branch

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift | Splits tool visibility into two independent sets — indexedToolNames (compact index) and fullSchemaToolNames (callable schemas) — but for proactive contexts indexedToolNames is the raw allowlist while fullSchemaToolNames may be narrowed by intent, creating a mismatch. |
| native/macos/Fae/Sources/Fae/Pipeline/TurnHelpers.swift | Adds fullSchemaToolNamesForTurn and requestedToolNamesForTurn helpers; extracts explicit+inferred selection logic into a shared function; adds defaultFullSchemaToolNames working set constant. |
| native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift | Adds PromptBudgetMetrics struct, promptBudgetMetrics(for:) factory, and NSLog instrumentation before every conversation.inject_text call; token estimation mixes byte-count for tools with char-count for text. |
| native/macos/Fae/Sources/Fae/Tools/ToolRegistry.swift | Adds allowedToolNames(for:privacyMode:limitedTo:) helper and updates the compact summary header string; both changes are straightforward. |
| native/macos/Fae/Tests/IntegrationTests/TurnHelpersTests.swift | Adds six new tests covering enrollment, proactive allowlist, continuation, inferred long-tail, strict-local filtering, and core working set; proactive multi-tool narrowing case is not covered. |
| native/macos/Fae/Tests/IntegrationTests/DaemonLLMEngineTests.swift | Adds three prompt-budget tests (non-zero tools, zero tools, working-set reduction ratio); all assertions are sensible and self-contained. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PC as PipelineCoordinator
    participant TH as TurnHelpers
    participant TR as ToolRegistry
    participant DE as DaemonLLMEngine

    PC->>TH: visibleToolNamesForTurn(...)
    TH-->>PC: visibleToolNames (legacy path only)

    PC->>PC: "indexedToolNames = nil or proactiveAllowedTools"
    PC->>TH: fullSchemaToolNamesForTurn(...)
    note over TH: enrollment -> []<br/>proactive -> allowed intersect requestedTools<br/>continuation+ambiguous -> all available<br/>ordinary -> defaultWorkingSet union requestedTools
    TH-->>PC: fullSchemaToolNames (Set)

    PC->>TR: nativeToolSpecs(limitedTo: fullSchemaToolNames)
    TR-->>PC: full JSON schemas (working set only)

    PC->>TR: compactToolSummary(limitedTo: indexedToolNames)
    TR-->>PC: compact text index (name + one-liner per tool)

    PC->>DE: "injectTextPayload(messages, systemPrompt, options with tools=fullSchemas)"
    DE->>DE: promptBudgetMetrics(payload) then NSLog
    DE-->>PC: LLM response
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift`, line 336-343 ([link](https://github.com/saorsa-labs/fae/blob/227956324332faac3092c451e55b6a919d2dafe8/native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift#L336-L343)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`messageChars` undercounts when content is not a plain string**

   `message["content"] as? String` returns `nil` for any message whose `content` field is an array (tool-result turns, structured multimodal turns). Those messages contribute 0 to `messageChars`, so `estimatedMessageTokens` will be significantly lower than the real prefill cost on turns that carry tool results. Since this metric is used to track prompt-budget health and spot the NaN windows, a systematic undercount here could hide the real prompt length.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift
   Line: 336-343

   Comment:
   **`messageChars` undercounts when content is not a plain string**

   `message["content"] as? String` returns `nil` for any message whose `content` field is an array (tool-result turns, structured multimodal turns). Those messages contribute 0 to `messageChars`, so `estimatedMessageTokens` will be significantly lower than the real prefill cost on turns that carry tool results. Since this metric is used to track prompt-budget health and spot the NaN windows, a systematic undercount here could hide the real prompt length.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift`, line 358-361 ([link](https://github.com/saorsa-labs/fae/blob/227956324332faac3092c451e55b6a919d2dafe8/native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift#L358-L361)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Token estimation conflates byte count with character count**

   `estimateTextTokens` divides by 4 to approximate tokens, but is called with `toolBytes` (UTF-8 JSON bytes) for the tools array and with `.count` (Swift `String.count` = Unicode scalar count) for system and message text. For typical ASCII tool schemas the difference is small, but any Unicode in tool descriptions (e.g. emoji, curly quotes) will inflate `toolBytes` relative to chars, producing a slightly higher tool-token estimate than the text fields. A brief doc-comment on `estimateTextTokens` noting the mixed input would prevent future callers from misinterpreting the parameter.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift
   Line: 358-361

   Comment:
   **Token estimation conflates byte count with character count**

   `estimateTextTokens` divides by 4 to approximate tokens, but is called with `toolBytes` (UTF-8 JSON bytes) for the tools array and with `.count` (Swift `String.count` = Unicode scalar count) for system and message text. For typical ASCII tool schemas the difference is small, but any Unicode in tool descriptions (e.g. emoji, curly quotes) will inflate `toolBytes` relative to chars, producing a slightly higher tool-token estimate than the text fields. A brief doc-comment on `estimateTextTokens` noting the mixed input would prevent future callers from misinterpreting the parameter.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift:2946-2955
**Proactive multi-tool schema/index mismatch**

For proactive turns where `requestedTools` is non-empty and intersects only a subset of the allowlist, `indexedToolNames` carries the full `proactiveContext.allowedTools` while `fullSchemaToolNamesForTurn` returns the narrowed intersection. The compact index therefore advertises tools that have no callable native schema on that turn. If the model picks any of those index-only tools, the daemon receives a call for an unregistered schema and the tool call silently fails or errors.

Before this PR, both the compact text and the native specs used the same `visibleToolNames`, so they were always consistent. The split is correct for the non-proactive path (where `indexedToolNames = nil` → all tools indexed, and the working set is a reasonable subset to have schemas for), but for the proactive path the index should be bounded by what actually has schemas. Concretely: intersect `indexedToolNames` with `fullSchemaToolNames` for the proactive branch, or expand `fullSchemaToolNamesForTurn` to always return the full `allowed` set (not `narrowed`) when a proactive context is active — the proactive allowlist is already narrow by design.

### Issue 2 of 3
native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift:336-343
**`messageChars` undercounts when content is not a plain string**

`message["content"] as? String` returns `nil` for any message whose `content` field is an array (tool-result turns, structured multimodal turns). Those messages contribute 0 to `messageChars`, so `estimatedMessageTokens` will be significantly lower than the real prefill cost on turns that carry tool results. Since this metric is used to track prompt-budget health and spot the NaN windows, a systematic undercount here could hide the real prompt length.

### Issue 3 of 3
native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift:358-361
**Token estimation conflates byte count with character count**

`estimateTextTokens` divides by 4 to approximate tokens, but is called with `toolBytes` (UTF-8 JSON bytes) for the tools array and with `.count` (Swift `String.count` = Unicode scalar count) for system and message text. For typical ASCII tool schemas the difference is small, but any Unicode in tool descriptions (e.g. emoji, curly quotes) will inflate `toolBytes` relative to chars, producing a slightly higher tool-token estimate than the text fields. A brief doc-comment on `estimateTextTokens` noting the mixed input would prevent future callers from misinterpreting the parameter.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(pipeline): add progressive tool dis..."](https://github.com/saorsa-labs/fae/commit/227956324332faac3092c451e55b6a919d2dafe8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37468105)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->