### PR TITLE
feat(voice): Linux Piper TTS lane + offline voice-turn proof (P5/D2-V5)

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -13,8 +13,10 @@ on:
       - "crates/**"
       - "native/rust/fae-ui-shell/**"
       - "scripts/install-llamacpp-runtime.py"
+      - "scripts/install-piper-runtime.py"
       - "scripts/build-linux-package.py"
       - "scripts/llamacpp-runtime.lock.json"
+      - "scripts/piper-runtime.lock.json"
       - ".github/workflows/ci-linux.yml"
   pull_request:
     branches: [main]
@@ -22,8 +24,10 @@ on:
       - "crates/**"
       - "native/rust/fae-ui-shell/**"
       - "scripts/install-llamacpp-runtime.py"
+      - "scripts/install-piper-runtime.py"
       - "scripts/build-linux-package.py"
       - "scripts/llamacpp-runtime.lock.json"
+      - "scripts/piper-runtime.lock.json"
       - ".github/workflows/ci-linux.yml"
 
 concurrency:
@@ -69,14 +73,23 @@ jobs:
           components: clippy, rustfmt
           targets: ${{ matrix.triple }}
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Crate gate (fmt, clippy -D warnings, tests)
         working-directory: crates
         run: |
           set -euo pipefail
-          env -u RUSTFLAGS cargo fmt -p fae-daemon -- --check
-          env -u RUSTFLAGS cargo clippy -p fae-daemon --bin fae-daemon --all-features \
+          # fae-engine is gated too: its PiperTtsAdapter is cfg(not(macos)), so
+          # CI is the ONLY place its unit tests (incl. the integrity-rejection
+          # test) compile + run. macOS ci.yml never sees them.
+          env -u RUSTFLAGS cargo fmt -p fae-daemon -p fae-engine -- --check
+          env -u RUSTFLAGS cargo clippy -p fae-daemon --bin fae-daemon -p fae-engine --all-targets --all-features \
             -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
-          env -u RUSTFLAGS cargo test -p fae-daemon
+          # nextest (process-per-test isolation): some fae-engine tests mutate
+          # env (FAE_MODELS_LOCK) or touch app-support paths and only pass when
+          # isolated — the same reason release-linux.yml prefers nextest.
+          env -u RUSTFLAGS cargo nextest run -p fae-daemon -p fae-engine
 
       - name: Build fae-daemon (native)
         working-directory: crates
@@ -93,3 +106,175 @@ jobs:
             --install-dir build/linux/LlamaCpp-${{ matrix.arch }} --force
           test -x build/linux/LlamaCpp-${{ matrix.arch }}/llama-server
           file build/linux/LlamaCpp-${{ matrix.arch }}/llama-server
+
+      - name: Install + SHA-verify Piper TTS sidecar
+        run: |
+          set -euo pipefail
+          python3 scripts/install-piper-runtime.py \
+            --platform ${{ matrix.runtime_platform }} \
+            --install-dir build/linux/Piper-${{ matrix.arch }} --force
+          # The installer fails closed on any SHA mismatch; assert the payload.
+          test -x build/linux/Piper-${{ matrix.arch }}/piper
+          test -f build/linux/Piper-${{ matrix.arch }}/voices/en_US-lessac-medium.onnx
+          test -f build/linux/Piper-${{ matrix.arch }}/voices/en_US-lessac-medium.onnx.json
+          file build/linux/Piper-${{ matrix.arch }}/piper
+
+      - name: Piper TTS leg — offline-turn (CPU-only, headless, no LLM download)
+        run: |
+          set -euo pipefail
+          # The daemon's fail-closed gate reads models.lock from its data dir.
+          export XDG_DATA_HOME="$PWD/build/linux/data"
+          mkdir -p "$XDG_DATA_HOME/fae"
+          cp native/macos/Fae/Sources/Fae/Resources/Models/models.lock "$XDG_DATA_HOME/fae/models.lock"
+          export FAE_PIPER_DIR="$PWD/build/linux/Piper-${{ matrix.arch }}"
+          OUT="$PWD/build/linux/spoken-${{ matrix.arch }}.wav"
+          # --tts-only synthesizes the text directly through the integrity-gated
+          # Piper adapter (binary + voice SHA-verified against models.lock). No
+          # FAE_TTS=mock here → a real Piper synthesis must occur.
+          crates/target/debug/fae-daemon --offline-turn --tts-only \
+            --text "Hello from Fae. The quick brown fox jumps over the lazy dog." \
+            --out "$OUT"
+          # Assert a non-empty, plausibly-correct-duration WAV was produced.
+          test -s "$OUT"
+          python3 - "$OUT" <<'PY'
+          import struct, sys, wave
+          path = sys.argv[1]
+          with wave.open(path, "rb") as w:
+              rate, n = w.getframerate(), w.getnframes()
+          dur = n / rate if rate else 0
+          print(f"spoken WAV: {rate} Hz, {n} samples, {dur:.2f}s")
+          assert rate == 24000, f"expected 24 kHz contract, got {rate}"
+          assert n > rate * 0.5, f"WAV too short ({dur:.2f}s) to be real speech"
+          PY
+
+      - name: Piper integrity gate fires on a tampered binary
+        run: |
+          set -euo pipefail
+          export XDG_DATA_HOME="$PWD/build/linux/data"
+          # Corrupt the installed piper binary; the SHA gate must refuse to start.
+          TAMPER="$PWD/build/linux/Piper-tamper-${{ matrix.arch }}"
+          rm -rf "$TAMPER"; cp -r "$PWD/build/linux/Piper-${{ matrix.arch }}" "$TAMPER"
+          printf 'corrupt' >> "$TAMPER/piper"
+          export FAE_PIPER_DIR="$TAMPER"
+          set +e
+          crates/target/debug/fae-daemon --offline-turn --tts-only \
+            --text "should never synthesize" --out /tmp/should-not-exist.wav
+          code=$?
+          set -e
+          test "$code" -ne 0
+          test ! -f /tmp/should-not-exist.wav
+          echo "✓ tampered Piper binary rejected (exit $code), no WAV emitted"
+
+      # Cache the Qwen3-ASR GGUF + mmproj (~2.5GB) used by the round-trip
+      # intelligibility gate. Keyed on models.lock so a model bump invalidates it.
+      - name: Cache Qwen3-ASR model (round-trip STT)
+        uses: actions/cache@v4
+        with:
+          path: build/linux/data/fae/models/llamacpp/asr
+          key: qwen3-asr-${{ matrix.arch }}-${{ hashFiles('native/macos/Fae/Sources/Fae/Resources/Models/models.lock') }}
+
+      - name: Piper INTELLIGIBILITY gate — synth → Qwen3-ASR round-trip (HARD)
+        run: |
+          set -euo pipefail
+          # DONE criterion #1: "Piper synthesizes INTELLIGIBLE speech." Synthesize
+          # a known sentence through real Piper, transcribe the synth WAV back
+          # through the Qwen3-ASR fallback (NO Gemma — STT+LLM are inherited), and
+          # HARD-assert the recovered words overlap the input (else the turn exits
+          # non-zero). This is the SOLE intelligibility proof (macOS smoke waived).
+          export XDG_DATA_HOME="$PWD/build/linux/data"
+          mkdir -p "$XDG_DATA_HOME/fae"
+          cp native/macos/Fae/Sources/Fae/Resources/Models/models.lock "$XDG_DATA_HOME/fae/models.lock"
+          export FAE_PIPER_DIR="$PWD/build/linux/Piper-${{ matrix.arch }}"
+          # The ASR round-trip needs the llama.cpp runtime + the Qwen3-ASR model.
+          export FAE_LLAMACPP_RUNTIME_DIR="$PWD/build/linux/LlamaCpp-${{ matrix.arch }}"
+          OUT="$PWD/build/linux/intelligible-${{ matrix.arch }}.wav"
+          # --roundtrip in tts-only mode transcribes via the ASR engine only.
+          # --min-overlap 2: >= 2 content words must survive Piper → Qwen3-ASR,
+          # so a single chance match can't pass the gate.
+          crates/target/debug/fae-daemon --offline-turn --tts-only \
+            --text "The quick brown fox jumps over the lazy dog." \
+            --expect-words "quick brown fox lazy dog" \
+            --min-overlap 2 \
+            --roundtrip --out "$OUT"
+          test -s "$OUT"
+
+  # OPTIONAL full voice spine: clip → STT → LLM → Piper TTS → spoken WAV → STT
+  # round-trip (the literal DONE-#1 full chain). Piper intelligibility is already
+  # HARD-gated cheaply per-PR by the Qwen3-ASR round-trip in build-linux, and
+  # STT+LLM are inherited (B5/B1.5), so this heavy lane (pulls Gemma-4 E4B ~5GB)
+  # runs on workflow_dispatch only — completeness, not a per-PR gate.
+  linux-voice-turn:
+    name: Full voice turn + round-trip (amd64, dispatch-only)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libasound2-dev file
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Build fae-daemon (native)
+        working-directory: crates
+        run: env -u RUSTFLAGS cargo build -p fae-daemon
+
+      - name: Install + SHA-verify llama.cpp + Piper runtimes
+        run: |
+          set -euo pipefail
+          python3 scripts/install-llamacpp-runtime.py \
+            --platform linux-x86_64 --install-dir build/linux/LlamaCpp --force
+          python3 scripts/install-piper-runtime.py \
+            --platform linux-x86_64 --install-dir build/linux/Piper --force
+
+      # Cache the on-demand Gemma-4 E4B QAT GGUF (~4.2 GB) + mmproj (~0.95 GB).
+      # Keyed on models.lock so a model bump invalidates the cache. First run
+      # downloads; subsequent runs reuse — keeps the heavy lane affordable.
+      - name: Cache Gemma-4 E4B GGUF + mmproj
+        uses: actions/cache@v4
+        with:
+          path: build/linux/data/fae/models/llamacpp
+          key: gemma4-e4b-qat-${{ hashFiles('native/macos/Fae/Sources/Fae/Resources/Models/models.lock') }}
+
+      - name: Full voice turn + HARD round-trip intelligibility gate
+        env:
+          # llama.cpp runtime resolution (the daemon owns the sidecar).
+          FAE_LLAMACPP_RUNTIME_DIR: ${{ github.workspace }}/build/linux/LlamaCpp
+          FAE_PIPER_DIR: ${{ github.workspace }}/build/linux/Piper
+        run: |
+          set -euo pipefail
+          export XDG_DATA_HOME="$PWD/build/linux/data"
+          mkdir -p "$XDG_DATA_HOME/fae"
+          cp native/macos/Fae/Sources/Fae/Resources/Models/models.lock "$XDG_DATA_HOME/fae/models.lock"
+          # Reuse a committed B5-corpus clip (16 kHz mono); known words below.
+          CLIP="native/macos/Fae/autoresearch/asr_corpus/command_01.wav"
+          test -f "$CLIP"
+          OUT="$PWD/build/linux/spoken-turn.wav"
+          # Full STT → LLM → Piper TTS → STT round-trip (DONE-#1 completeness).
+          # --roundtrip asserts SELF-CONSISTENCY: the round-trip transcript must
+          # recover ~half the LLM's ANSWER words (the answer is nondeterministic,
+          # so NO --expect-words here — the daemon compares round-trip vs the
+          # answer it synthesized). The deterministic intelligibility proof is the
+          # tts-only Qwen3-ASR gate in build-linux.
+          crates/target/debug/fae-daemon --offline-turn \
+            --in "$CLIP" --out "$OUT" --roundtrip
+          test -s "$OUT"
+          python3 - "$OUT" <<'PY'
+          import sys, wave
+          with wave.open(sys.argv[1], "rb") as w:
+              rate, n = w.getframerate(), w.getnframes()
+          dur = n / rate if rate else 0
+          print(f"spoken WAV: {rate} Hz, {n} samples, {dur:.2f}s")
+          assert rate == 24000, f"expected 24 kHz contract, got {rate}"
+          assert n > rate * 0.3, f"WAV too short ({dur:.2f}s) to be real speech"
+          PY

--- a/crates/fae-daemon/src/main.rs
+++ b/crates/fae-daemon/src/main.rs
@@ -36,6 +36,7 @@ use fae_engine::{
 mod agents;
 mod diagnostic;
 mod events;
+mod offline_turn;
 mod server_request;
 mod session;
 mod transport;
@@ -51,6 +52,35 @@ async fn main() -> DaemonResult<()> {
             "fae-daemon {} — protocol v{PROTOCOL_VERSION}",
             env!("CARGO_PKG_VERSION")
         );
+        return Ok(());
+    }
+
+    // Headless offline voice-turn driver (P5/D2-V5, Stage 3): clip → STT → LLM →
+    // Piper TTS → spoken-answer WAV, with NO socket and NO audio device. This is
+    // the CI-verifiable proof of the full Linux spine. It builds the same real
+    // backends the server uses, then exits.
+    let mut args = std::env::args().skip(1);
+    if let Some(pos) = args.position(|arg| arg == "--offline-turn") {
+        // Re-derive the args after the flag (position() consumed up to it).
+        let rest = std::env::args().skip(1 + pos + 1);
+        let parsed = offline_turn::OfflineTurnArgs::parse(rest)?;
+        let tts = build_tts_engine();
+        // Backend selection by mode:
+        // - tts-only WITHOUT round-trip: no STT engine (cheapest Piper gate).
+        // - tts-only WITH round-trip: build ONLY the Qwen3-ASR fallback (~2.5GB,
+        //   no Gemma) — the round-trip transcribes the synth WAV to prove Piper
+        //   intelligibility; re-proving the full LLM isn't the point.
+        // - full turn: build all three real backends, as the server does.
+        let (engine, asr_fallback) = if parsed.tts_text.is_some() {
+            if parsed.roundtrip {
+                (None, build_asr_fallback_engine())
+            } else {
+                (None, None)
+            }
+        } else {
+            (Some(build_engine().await), build_asr_fallback_engine())
+        };
+        offline_turn::run(parsed, engine, asr_fallback, tts).await?;
         return Ok(());
     }
 
@@ -162,8 +192,8 @@ async fn main() -> DaemonResult<()> {
 
 /// Build the TTS backend (S19). On macOS: Kokoro via voice-tts/mlx-rs, with
 /// weights loading lazily on the first `tts.synthesize`. `FAE_TTS_MODEL_ID`
-/// overrides the repo; `FAE_TTS=mock` forces the mock. Elsewhere: mock until
-/// the candle port lands.
+/// overrides the repo. On Linux: the SHA-pinned Piper sidecar (P5/D2-V5).
+/// `FAE_TTS=mock` forces the mock on any platform (test/CI override).
 fn build_tts_engine() -> Arc<dyn TtsAdapter> {
     if std::env::var("FAE_TTS").is_ok_and(|value| value == "mock") {
         return Arc::new(MockTtsAdapter::new("mock-tts"));
@@ -184,8 +214,167 @@ fn build_tts_engine() -> Arc<dyn TtsAdapter> {
                 eprintln!("fae-daemon: tts worker spawn failed ({error}); using mock tts");
             }
         }
+        Arc::new(MockTtsAdapter::new("mock-tts"))
     }
-    Arc::new(MockTtsAdapter::new("mock-tts"))
+    #[cfg(not(target_os = "macos"))]
+    {
+        // Linux TTS = Piper sidecar, integrity-gated like the llama-server
+        // runtime. A missing/unverified sidecar is FATAL in production (we never
+        // silently emit silence). `FAE_MODELS_LOCK=off` under FAE_DEV is the only
+        // escape hatch; it also lets the mock path be selected via `FAE_TTS=mock`.
+        match build_piper_tts_engine() {
+            Ok(adapter) => Arc::new(adapter),
+            Err(detail) => {
+                if models_lock_disabled_for_dev() {
+                    eprintln!(
+                        "fae-daemon: WARNING: FAE_DEV allows FAE_MODELS_LOCK=off; piper unavailable ({detail}); using mock tts"
+                    );
+                    return Arc::new(MockTtsAdapter::new("mock-tts"));
+                }
+                exit_fatal("piper_tts", &detail)
+            }
+        }
+    }
+}
+
+/// Resolve + integrity-verify the Piper sidecar (binary + voice model), then
+/// build the adapter. Mirrors the llama-server gate: confinement to the Fae-owned
+/// install dir, existence, and SHA-256 against `models.lock`. The voice files
+/// live under `<install>/voices/` (installed by `install-piper-runtime.py`).
+#[cfg(not(target_os = "macos"))]
+fn build_piper_tts_engine() -> Result<fae_engine::PiperTtsAdapter, String> {
+    let install_dir = resolve_piper_install_dir()?;
+    let binary = install_dir.join("piper");
+    let binary = executable_path(binary, "Piper runtime")?;
+    let voices_dir = install_dir.join("voices");
+    let model_onnx = voices_dir.join(format!("{PIPER_VOICE_NAME}.onnx"));
+    let model_config = voices_dir.join(format!("{PIPER_VOICE_NAME}.onnx.json"));
+    let espeak_data = install_dir.join("espeak-ng-data");
+
+    verify_piper_artifacts(&binary, &model_onnx, &model_config)?;
+
+    let espeak = espeak_data.is_dir().then_some(espeak_data);
+    println!(
+        "tts     : piper sidecar {} (voice {PIPER_VOICE_NAME})",
+        binary.display()
+    );
+    Ok(fae_engine::PiperTtsAdapter::new(
+        binary,
+        model_onnx,
+        model_config,
+        espeak,
+        PIPER_VOICE_NAME,
+    ))
+}
+
+/// Resolution order for the Piper install dir, mirroring `resolve_llama_server_binary`:
+/// 1. `FAE_PIPER_DIR` explicit override (dev/test/staging)
+/// 2. bundled sibling of the daemon exe (`../piper` or `../lib/fae/piper`, FHS)
+/// 3. owner app-support install (`<data>/runtimes/piper`)
+#[cfg(not(target_os = "macos"))]
+fn resolve_piper_install_dir() -> Result<PathBuf, String> {
+    if let Some(dir) = std::env::var_os("FAE_PIPER_DIR") {
+        let path = PathBuf::from(dir);
+        if path.join("piper").is_file() {
+            return Ok(path);
+        }
+        return Err(format!(
+            "FAE_PIPER_DIR set but {}/piper does not exist",
+            path.display()
+        ));
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            for rel in ["../piper", "../lib/fae/piper"] {
+                let candidate = exe_dir.join(rel);
+                if candidate.join("piper").is_file() {
+                    return Ok(candidate);
+                }
+            }
+        }
+    }
+    let install = data_directory()
+        .map_err(|e| e.to_string())?
+        .join("runtimes/piper");
+    if install.join("piper").is_file() {
+        return Ok(install);
+    }
+    Err(format!(
+        "Piper TTS runtime not installed. Run \
+         `python3 scripts/install-piper-runtime.py --install-dir {}`.",
+        install.display()
+    ))
+}
+
+/// Verify the Piper binary + voice files against `models.lock` (size + SHA-256).
+/// Fail-closed: any miss aborts and the caller treats it as fatal in production.
+#[cfg(not(target_os = "macos"))]
+fn verify_piper_artifacts(
+    binary: &Path,
+    model_onnx: &Path,
+    model_config: &Path,
+) -> Result<(), String> {
+    if models_lock_disabled_for_dev() {
+        eprintln!(
+            "fae-daemon: WARNING: FAE_DEV allows FAE_MODELS_LOCK=off; skipping Piper artifact verification"
+        );
+        return Ok(());
+    }
+    let lock = load_installed_models_lock()?;
+    verify_locked_file(&lock, PIPER_BINARY_ARTIFACT_ID, "tts_binary", binary)?;
+    verify_locked_file(&lock, PIPER_VOICE_ONNX_ARTIFACT_ID, "tts_model", model_onnx)?;
+    verify_locked_file(
+        &lock,
+        PIPER_VOICE_CONFIG_ARTIFACT_ID,
+        "tts_model",
+        model_config,
+    )?;
+    Ok(())
+}
+
+/// Look up `id` in the lock, confirm its role + the `piper-sidecar` loader, then
+/// verify the on-disk file's size + SHA-256 match the pinned artifact.
+#[cfg(not(target_os = "macos"))]
+fn verify_locked_file(
+    lock: &ModelsLock,
+    id: &str,
+    expected_role: &str,
+    path: &Path,
+) -> Result<(), String> {
+    let artifact = lock
+        .artifacts
+        .iter()
+        .find(|artifact| artifact.id == id)
+        .ok_or_else(|| format!("missing required artifact {id}"))?;
+    if artifact.role != expected_role || artifact.loader != "piper-sidecar" {
+        return Err(format!(
+            "artifact {id} must be role={expected_role} loader=piper-sidecar (got role={}, loader={})",
+            artifact.role, artifact.loader
+        ));
+    }
+    let metadata = std::fs::metadata(path)
+        .map_err(|error| format!("stat {} ({id}): {error}", path.display()))?;
+    if artifact.size_bytes != 0 && metadata.len() != artifact.size_bytes {
+        return Err(format!(
+            "{id} size mismatch for {}: expected {}, got {}",
+            path.display(),
+            artifact.size_bytes,
+            metadata.len()
+        ));
+    }
+    let expected = artifact.sha256.trim().to_ascii_lowercase();
+    if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(format!("artifact {id} must pin a 64-hex sha256"));
+    }
+    let actual =
+        sha256_file(path).map_err(|error| format!("hash {} ({id}): {error}", path.display()))?;
+    if actual != expected {
+        return Err(format!(
+            "{id} sha256 mismatch for {}: expected {expected}, got {actual}",
+            path.display()
+        ));
+    }
+    Ok(())
 }
 
 /// Directory holding custom voice embeddings (`{voice}.safetensors`) checked
@@ -232,6 +421,22 @@ const LLAMA_SERVER_BINARY_ARTIFACT_ID: &str = "llamacpp-b9692-llama-server-linux
 const LLAMA_SERVER_SIGNED_CDHASH: &str = "3d5c9574d44b155e1d2551cc082cbff8c5d9d0c8";
 #[cfg(target_os = "macos")]
 const LLAMA_SERVER_SIGNED_TEAM_ID: &str = "MEGSB2GXGZ";
+
+/// `models.lock` artifact ids for the Piper TTS sidecar (Linux-only TTS lane,
+/// P5/D2-V5). Each Linux target ships its own prebuilt `piper` binary from the
+/// same rhasspy/piper release, so the integrity gate looks up the entry matching
+/// the binary it actually runs. macOS uses Kokoro/voice-tts and never reads these.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+const PIPER_BINARY_ARTIFACT_ID: &str = "rhasspy-piper-2023-11-14-2-linux-x86_64";
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+const PIPER_BINARY_ARTIFACT_ID: &str = "rhasspy-piper-2023-11-14-2-linux-aarch64";
+#[cfg(not(target_os = "macos"))]
+const PIPER_VOICE_ONNX_ARTIFACT_ID: &str = "rhasspy-piper-voices-en-us-lessac-medium-onnx";
+#[cfg(not(target_os = "macos"))]
+const PIPER_VOICE_CONFIG_ARTIFACT_ID: &str = "rhasspy-piper-voices-en-us-lessac-medium-onnx-json";
+/// The pinned voice's display id (status + audit only).
+#[cfg(not(target_os = "macos"))]
+const PIPER_VOICE_NAME: &str = "en_US-lessac-medium";
 
 /// Build the inference backend. llama.cpp is now the only runtime path: the
 /// daemon owns a `llama-server` sidecar and uses llama.cpp's `-hf` downloader to

--- a/crates/fae-daemon/src/offline_turn.rs
+++ b/crates/fae-daemon/src/offline_turn.rs
@@ -1,0 +1,566 @@
+//! Headless offline voice-turn driver (P5/D2-V5, Stage 3).
+//!
+//! Proves the full Linux voice spine WITHOUT an audio device: a provided WAV
+//! clip → STT (the same audio-capable engine turn the push-to-talk path uses) →
+//! LLM turn → `tts.synthesize` (Piper on Linux) → a spoken-answer WAV written to
+//! disk. Optionally it round-trips the synthesized WAV back through STT to show
+//! the words survive synthesis (an intelligibility smoke).
+//!
+//! This is the headless-verifiable proof CI runs (CPU-only, no device). It
+//! reuses the production turn loop (`session::run_turn`) and the real backend
+//! builders (`build_engine`/`build_asr_fallback_engine`/`build_tts_engine`) so
+//! it can't drift from the served pipeline.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use base64::Engine as _;
+use fae_engine::{ChatMessage, ChatRequest, ProviderAdapter, Role, TtsAdapter};
+
+use crate::session::{normalize_asr_transcript, run_turn};
+
+/// Parsed `--offline-turn` arguments.
+pub struct OfflineTurnArgs {
+    /// Input WAV clip to transcribe. `None` in `--tts-only` mode.
+    pub input_wav: Option<PathBuf>,
+    /// Where to write the synthesized spoken-answer WAV.
+    pub output_wav: PathBuf,
+    /// Voice name passed to the TTS adapter (Piper resolves its pinned voice).
+    pub voice: String,
+    /// When true, round-trip the synthesized WAV back through STT and HARD-gate
+    /// on the recovered words (intelligibility check). Ignored in `--tts-only`.
+    pub roundtrip: bool,
+    /// Optional expected words for the round-trip overlap assertion. When set
+    /// and `roundtrip` is on, the recovered transcript must share at least one
+    /// word with these, or the turn fails. `None` only checks non-empty.
+    pub expect_words: Option<String>,
+    /// Minimum number of expected words that must survive the round-trip
+    /// (default 1). CI sets this higher (e.g. 2) to make the intelligibility
+    /// gate robust against a single chance match.
+    pub min_overlap: usize,
+    /// TTS-only mode (CI gate): skip STT+LLM, synthesize `tts_text` directly
+    /// through the integrity-gated Piper adapter. Proves the riskiest NEW leg
+    /// (Piper invocation + integrity gate + 22.05→24 kHz resample) WITHOUT a
+    /// multi-GB LLM/ASR model download. `None` = full STT→LLM→TTS turn.
+    pub tts_text: Option<String>,
+}
+
+impl OfflineTurnArgs {
+    /// Parse from a raw args iterator (everything after `--offline-turn`).
+    /// Full-turn flags: `--in <wav>` (required) + `--out <wav>` (required) +
+    /// `--voice <name>`/`--roundtrip` (optional). TTS-only: `--tts-only`
+    /// `--text <words>` + `--out <wav>` (no `--in`).
+    pub fn parse(mut args: impl Iterator<Item = String>) -> Result<OfflineTurnArgs, String> {
+        let mut input_wav: Option<PathBuf> = None;
+        let mut output_wav: Option<PathBuf> = None;
+        let mut voice = "en_US-lessac-medium".to_owned();
+        let mut roundtrip = false;
+        let mut tts_only = false;
+        let mut text: Option<String> = None;
+        let mut expect_words: Option<String> = None;
+        let mut min_overlap: usize = 1;
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--in" => {
+                    input_wav = Some(PathBuf::from(args.next().ok_or("--in requires a path")?));
+                }
+                "--out" => {
+                    output_wav = Some(PathBuf::from(args.next().ok_or("--out requires a path")?));
+                }
+                "--voice" => {
+                    voice = args.next().ok_or("--voice requires a name")?;
+                }
+                "--text" => {
+                    text = Some(args.next().ok_or("--text requires a string")?);
+                }
+                "--expect-words" => {
+                    expect_words = Some(args.next().ok_or("--expect-words requires a string")?);
+                }
+                "--min-overlap" => {
+                    let raw = args.next().ok_or("--min-overlap requires a number")?;
+                    min_overlap = raw
+                        .parse()
+                        .map_err(|_| format!("--min-overlap not a number: {raw}"))?;
+                }
+                "--tts-only" => tts_only = true,
+                "--roundtrip" => roundtrip = true,
+                other => return Err(format!("unknown --offline-turn arg: {other}")),
+            }
+        }
+        let output_wav = output_wav.ok_or("--offline-turn requires --out <wav>")?;
+        if tts_only {
+            let tts_text = text.ok_or("--tts-only requires --text <words>")?;
+            if tts_text.trim().is_empty() {
+                return Err("--text must not be empty".to_owned());
+            }
+            return Ok(OfflineTurnArgs {
+                input_wav: None,
+                output_wav,
+                voice,
+                // tts-only honors --roundtrip: the round-trip transcribes the
+                // synthesized WAV through the ASR engine (no Gemma) — the
+                // intelligibility gate for the Piper leg.
+                roundtrip,
+                expect_words,
+                min_overlap,
+                tts_text: Some(tts_text),
+            });
+        }
+        Ok(OfflineTurnArgs {
+            input_wav: Some(input_wav.ok_or("--offline-turn requires --in <wav> (or --tts-only)")?),
+            output_wav,
+            voice,
+            roundtrip,
+            expect_words,
+            min_overlap,
+            tts_text: None,
+        })
+    }
+}
+
+/// Count how many distinct expected words appear in `actual` (case-insensitive,
+/// punctuation-stripped). Used for the round-trip intelligibility gate — STT
+/// rarely reproduces a phrase verbatim, so any word overlap is the signal.
+fn word_overlap(expected: &str, actual: &str) -> usize {
+    fn words(text: &str) -> std::collections::HashSet<String> {
+        text.split_whitespace()
+            .map(|word| {
+                word.chars()
+                    .filter(|c| c.is_alphanumeric())
+                    .flat_map(char::to_lowercase)
+                    .collect::<String>()
+            })
+            .filter(|word| !word.is_empty())
+            .collect()
+    }
+    let actual_words = words(actual);
+    words(expected)
+        .iter()
+        .filter(|word| actual_words.contains(*word))
+        .count()
+}
+
+/// Transcribe a base64 WAV clip via the audio-capable engine, falling back to
+/// the dedicated ASR engine if the primary turn yields nothing. Returns the
+/// cleaned transcript (never empty on success).
+async fn transcribe(
+    engine: &dyn ProviderAdapter,
+    asr_fallback: Option<&dyn ProviderAdapter>,
+    wav_base64: &str,
+) -> Result<String, String> {
+    let request = ChatRequest {
+        system: Some(
+            "Transcribe the user's audio verbatim. Output only the exact words spoken — no labels, commentary, or answers."
+                .to_owned(),
+        ),
+        messages: vec![ChatMessage {
+            role: Role::User,
+            content: String::new(),
+            audio_wav_base64: Some(wav_base64.to_owned()),
+        }],
+        tools: Vec::new(),
+        max_tokens: 128,
+    };
+    let result = run_turn(engine, request).await?;
+    let transcript = result
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .map(normalize_asr_transcript)
+        .unwrap_or_default();
+    if !transcript.is_empty() {
+        return Ok(transcript);
+    }
+    // Primary produced nothing — try the dedicated ASR engine if present.
+    let Some(asr) = asr_fallback else {
+        return Err(
+            "primary STT produced an empty transcript and no ASR fallback is configured".to_owned(),
+        );
+    };
+    let request = ChatRequest {
+        system: Some(
+            "Transcribe the user's audio verbatim. Output only the exact words spoken — no labels, commentary, or answers."
+                .to_owned(),
+        ),
+        messages: vec![ChatMessage {
+            role: Role::User,
+            content: String::new(),
+            audio_wav_base64: Some(wav_base64.to_owned()),
+        }],
+        tools: Vec::new(),
+        max_tokens: 128,
+    };
+    let result = run_turn(asr, request).await?;
+    let transcript = result
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .map(normalize_asr_transcript)
+        .unwrap_or_default();
+    if transcript.is_empty() {
+        return Err("both primary STT and ASR fallback produced empty transcripts".to_owned());
+    }
+    Ok(transcript)
+}
+
+/// Run one LLM turn over a plain-text user message, returning the visible answer.
+async fn answer_turn(engine: &dyn ProviderAdapter, user_text: &str) -> Result<String, String> {
+    let request = ChatRequest {
+        system: None,
+        messages: vec![ChatMessage {
+            role: Role::User,
+            content: user_text.to_owned(),
+            audio_wav_base64: None,
+        }],
+        tools: Vec::new(),
+        max_tokens: 256,
+    };
+    let result = run_turn(engine, request).await?;
+    let answer = result
+        .get("text")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .to_owned();
+    if answer.is_empty() {
+        return Err("LLM turn produced an empty answer".to_owned());
+    }
+    Ok(answer)
+}
+
+/// Number of PCM16-mono samples in a canonical WAV's `data` chunk, for the
+/// duration assertion. Returns `(samples, sample_rate)`.
+fn wav_sample_count(wav: &[u8]) -> Result<(usize, u32), String> {
+    if wav.len() < 44 || &wav[0..4] != b"RIFF" || &wav[8..12] != b"WAVE" {
+        return Err("output is not a RIFF/WAVE file".to_owned());
+    }
+    let mut offset = 12_usize;
+    let mut sample_rate = 0_u32;
+    let mut data_len = 0_usize;
+    while offset.saturating_add(8) <= wav.len() {
+        let id = &wav[offset..offset + 4];
+        let size = u32::from_le_bytes([
+            wav[offset + 4],
+            wav[offset + 5],
+            wav[offset + 6],
+            wav[offset + 7],
+        ]) as usize;
+        offset = offset.saturating_add(8);
+        if id == b"fmt " && size >= 16 {
+            sample_rate = u32::from_le_bytes([
+                wav[offset + 4],
+                wav[offset + 5],
+                wav[offset + 6],
+                wav[offset + 7],
+            ]);
+        } else if id == b"data" {
+            data_len = size.min(wav.len().saturating_sub(offset));
+        }
+        offset = offset.saturating_add(size + (size % 2));
+    }
+    if sample_rate == 0 {
+        return Err("output WAV missing fmt chunk".to_owned());
+    }
+    Ok((data_len / 2, sample_rate))
+}
+
+/// Synthesize `text` through the (integrity-gated) TTS adapter, assert the WAV
+/// is non-empty + correct-duration, write it to `out`, and return the decoded
+/// `(wav_bytes, samples, sample_rate)` for any follow-on round-trip.
+async fn synthesize_to_file(
+    tts: &dyn TtsAdapter,
+    text: &str,
+    voice: &str,
+    out: &Path,
+) -> Result<Vec<u8>, String> {
+    println!("[offline-turn] TTS: synthesizing with voice {voice}");
+    let audio = tts
+        .synthesize(text, voice, 1.0)
+        .await
+        .map_err(|error| format!("tts.synthesize failed: {error}"))?;
+    let (samples, sample_rate) = wav_sample_count(&audio.wav)?;
+    if samples == 0 {
+        return Err("synthesized WAV has zero audio samples".to_owned());
+    }
+    let duration_ms = (samples as u64 * 1000) / u64::from(sample_rate.max(1));
+    std::fs::write(out, &audio.wav)
+        .map_err(|error| format!("write output {}: {error}", out.display()))?;
+    println!(
+        "[offline-turn] wrote {} ({} bytes, {} samples @ {} Hz, ~{} ms)",
+        out.display(),
+        audio.wav.len(),
+        samples,
+        sample_rate,
+        duration_ms
+    );
+    Ok(audio.wav)
+}
+
+/// HARD intelligibility gate: re-transcribe the synthesized WAV through
+/// `transcriber` and assert the recovered words are non-empty and (when
+/// `expect_words` is set) overlap the expected phrase. With the macOS Piper
+/// smoke infeasible, this round-trip is the SOLE proof Piper produced
+/// intelligible speech, so any failure aborts the turn.
+async fn assert_intelligible(
+    transcriber: &dyn ProviderAdapter,
+    asr_fallback: Option<&dyn ProviderAdapter>,
+    synth_wav: &[u8],
+    expect_words: Option<&str>,
+    min_overlap: usize,
+) -> Result<(), String> {
+    println!("[offline-turn] round-trip: re-transcribing the synthesized WAV");
+    let synth_b64 = base64::engine::general_purpose::STANDARD.encode(synth_wav);
+    let recovered = transcribe(transcriber, asr_fallback, &synth_b64)
+        .await
+        .map_err(|error| format!("round-trip STT failed: {error}"))?;
+    println!("[offline-turn] round-trip heard: {recovered:?}");
+    if recovered.trim().is_empty() {
+        return Err(
+            "round-trip transcript is empty — synthesized audio was not intelligible".to_owned(),
+        );
+    }
+    if let Some(expected) = expect_words {
+        let overlap = word_overlap(expected, &recovered);
+        // At least one word must overlap, plus any caller-set higher bar.
+        let required = min_overlap.max(1);
+        println!(
+            "[offline-turn] round-trip word overlap: {overlap} (need >= {required}) of expected {expected:?}"
+        );
+        if overlap < required {
+            return Err(format!(
+                "round-trip transcript {recovered:?} overlaps expected {expected:?} by only {overlap} words (need >= {required}) — not intelligible"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Drive the headless turn. In `--tts-only` mode it synthesizes the provided
+/// text directly through Piper (no LLM); with `--roundtrip` it transcribes the
+/// synthesized WAV back through the ASR engine to HARD-gate intelligibility.
+/// Otherwise it builds the full STT → LLM → Piper TTS turn from the input clip.
+pub async fn run(
+    args: OfflineTurnArgs,
+    engine: Option<Arc<dyn ProviderAdapter>>,
+    asr_fallback: Option<Arc<dyn ProviderAdapter>>,
+    tts: Arc<dyn TtsAdapter>,
+) -> Result<(), String> {
+    // TTS-only: exercise the integrity-gated Piper leg without STT/LLM. The
+    // adapter was already built (and its binary/voice SHA-verified) by the
+    // daemon; a synthesis failure here is a real Piper/integrity failure. No
+    // engine is built in this mode.
+    if let Some(text) = &args.tts_text {
+        println!("[offline-turn] tts-only: text {text:?}");
+        let synth_wav =
+            synthesize_to_file(tts.as_ref(), text, &args.voice, &args.output_wav).await?;
+        if args.roundtrip {
+            // Round-trip transcription uses the ASR engine ONLY (no Gemma LLM):
+            // re-proving STT+LLM isn't the point — Piper intelligibility is.
+            let transcriber = asr_fallback.as_deref().ok_or(
+                "tts-only --roundtrip needs the ASR engine (set FAE_AUDIO_FALLBACK + install the runtime)",
+            )?;
+            // Expect the synthesized text's own words to survive round-trip.
+            let expect = args.expect_words.as_deref().or(Some(text.as_str()));
+            assert_intelligible(transcriber, None, &synth_wav, expect, args.min_overlap).await?;
+        }
+        println!("[offline-turn] OK");
+        return Ok(());
+    }
+
+    let engine = engine.ok_or("full-turn mode requires the LLM engine")?;
+    let input_wav = args
+        .input_wav
+        .as_ref()
+        .ok_or("full-turn mode requires --in <wav>")?;
+    let clip = std::fs::read(input_wav)
+        .map_err(|error| format!("read input clip {}: {error}", input_wav.display()))?;
+    if clip.is_empty() {
+        return Err(format!("input clip {} is empty", input_wav.display()));
+    }
+    let clip_b64 = base64::engine::general_purpose::STANDARD.encode(&clip);
+
+    println!("[offline-turn] STT: transcribing {}", input_wav.display());
+    let asr_ref = asr_fallback.as_deref();
+    let transcript = transcribe(engine.as_ref(), asr_ref, &clip_b64).await?;
+    println!("[offline-turn] heard: {transcript:?}");
+
+    println!("[offline-turn] LLM: running answer turn");
+    let answer = answer_turn(engine.as_ref(), &transcript).await?;
+    println!("[offline-turn] answer: {answer:?}");
+
+    let synth_wav =
+        synthesize_to_file(tts.as_ref(), &answer, &args.voice, &args.output_wav).await?;
+
+    if args.roundtrip {
+        // SELF-CONSISTENCY (full-turn): the synthesized audio is the LLM's
+        // ANSWER, which is nondeterministic — so the round-trip must be checked
+        // against the ANSWER we just synthesized, NOT a fixed --expect-words
+        // (which describes the input QUESTION). Require ~half the answer's words
+        // to survive Piper → STT. (The deterministic intelligibility proof is the
+        // tts-only path, where synthesized text == expected text.)
+        let answer_word_count = word_overlap(&answer, &answer); // distinct words
+        let required = answer_word_count.div_ceil(2).max(1);
+        println!(
+            "[offline-turn] full-turn self-consistency: need >= {required} of {answer_word_count} answer words to survive"
+        );
+        assert_intelligible(
+            engine.as_ref(),
+            asr_ref,
+            &synth_wav,
+            Some(&answer),
+            required,
+        )
+        .await?;
+    }
+
+    println!("[offline-turn] OK");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fae_engine::encode_wav_pcm16;
+
+    #[test]
+    fn parse_requires_in_and_out() {
+        // Full-turn mode: --in alone (no --out) and --out alone (no --in) both fail.
+        assert!(OfflineTurnArgs::parse(["--in", "a.wav"].into_iter().map(String::from)).is_err());
+        assert!(OfflineTurnArgs::parse(["--out", "b.wav"].into_iter().map(String::from)).is_err());
+        let ok = OfflineTurnArgs::parse(
+            ["--in", "a.wav", "--out", "b.wav", "--roundtrip"]
+                .into_iter()
+                .map(String::from),
+        )
+        .expect("valid args");
+        assert_eq!(ok.input_wav, Some(PathBuf::from("a.wav")));
+        assert_eq!(ok.output_wav, PathBuf::from("b.wav"));
+        assert!(ok.roundtrip);
+        assert!(ok.tts_text.is_none());
+        assert!(ok.expect_words.is_none());
+        assert_eq!(ok.voice, "en_US-lessac-medium");
+    }
+
+    #[test]
+    fn parse_captures_expect_words() {
+        let ok = OfflineTurnArgs::parse(
+            [
+                "--in",
+                "a.wav",
+                "--out",
+                "b.wav",
+                "--roundtrip",
+                "--expect-words",
+                "what time is it",
+            ]
+            .into_iter()
+            .map(String::from),
+        )
+        .expect("valid args");
+        assert_eq!(ok.expect_words.as_deref(), Some("what time is it"));
+        assert_eq!(ok.min_overlap, 1); // default
+    }
+
+    #[test]
+    fn parse_min_overlap() {
+        let ok = OfflineTurnArgs::parse(
+            [
+                "--tts-only",
+                "--text",
+                "fox",
+                "--out",
+                "o.wav",
+                "--roundtrip",
+                "--min-overlap",
+                "2",
+            ]
+            .into_iter()
+            .map(String::from),
+        )
+        .expect("valid args");
+        assert_eq!(ok.min_overlap, 2);
+        // Non-numeric --min-overlap is rejected.
+        assert!(OfflineTurnArgs::parse(
+            [
+                "--tts-only",
+                "--text",
+                "x",
+                "--out",
+                "o.wav",
+                "--min-overlap",
+                "nope"
+            ]
+            .into_iter()
+            .map(String::from)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn self_consistency_threshold_is_half_the_answer_words() {
+        // Full-turn round-trip compares vs the ANSWER (self-consistency), not the
+        // question. Threshold = ceil(distinct_answer_words / 2), min 1.
+        let answer = "the time is three o'clock"; // distinct: the,time,is,three,oclock = 5
+        let distinct = word_overlap(answer, answer);
+        assert_eq!(distinct, 5);
+        let required = distinct.div_ceil(2).max(1);
+        assert_eq!(required, 3);
+        // A round-trip recovering 3/5 answer words passes the bar.
+        assert!(word_overlap(answer, "time is three") >= required);
+        // Recovering only 1 word does not.
+        assert!(word_overlap(answer, "the umm") < required);
+    }
+
+    #[test]
+    fn word_overlap_is_case_and_punctuation_insensitive() {
+        // STT rarely matches verbatim; any shared word is the intelligibility signal.
+        assert_eq!(word_overlap("What time is it", "what TIME is it?"), 4);
+        assert_eq!(word_overlap("What time is it", "the time, please"), 1);
+        assert_eq!(
+            word_overlap("What time is it", "completely different words"),
+            0
+        );
+        // Empty actual → zero overlap (the empty-transcript gate catches this too).
+        assert_eq!(word_overlap("hello", ""), 0);
+    }
+
+    #[test]
+    fn parse_tts_only_needs_text_and_out_not_in() {
+        // --tts-only without --text fails.
+        assert!(OfflineTurnArgs::parse(
+            ["--tts-only", "--out", "o.wav"]
+                .into_iter()
+                .map(String::from)
+        )
+        .is_err());
+        // --tts-only with empty text fails.
+        assert!(OfflineTurnArgs::parse(
+            ["--tts-only", "--text", "   ", "--out", "o.wav"]
+                .into_iter()
+                .map(String::from)
+        )
+        .is_err());
+        // Valid tts-only: no --in required, tts_text set, roundtrip forced off.
+        let ok = OfflineTurnArgs::parse(
+            ["--tts-only", "--text", "Hello from Fae.", "--out", "o.wav"]
+                .into_iter()
+                .map(String::from),
+        )
+        .expect("valid tts-only args");
+        assert!(ok.input_wav.is_none());
+        assert_eq!(ok.tts_text.as_deref(), Some("Hello from Fae."));
+        assert!(!ok.roundtrip);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_flag() {
+        assert!(OfflineTurnArgs::parse(["--bogus"].into_iter().map(String::from)).is_err());
+    }
+
+    #[test]
+    fn wav_sample_count_reads_canonical_wav() {
+        let wav = encode_wav_pcm16(&[0.0; 2400], 24_000);
+        let (samples, rate) = wav_sample_count(&wav).expect("valid wav");
+        assert_eq!(samples, 2400);
+        assert_eq!(rate, 24_000);
+        assert!(wav_sample_count(b"not a wav").is_err());
+    }
+}

--- a/crates/fae-daemon/src/session.rs
+++ b/crates/fae-daemon/src/session.rs
@@ -1354,7 +1354,7 @@ async fn transcribe_fallback(
     Ok(serde_json::json!({ "transcript": transcript }))
 }
 
-fn normalize_asr_transcript(raw: &str) -> String {
+pub(crate) fn normalize_asr_transcript(raw: &str) -> String {
     let mut text = raw.trim();
     if let Some((_, after)) = text.rsplit_once("<asr_text>") {
         text = after.trim();
@@ -1399,7 +1399,9 @@ fn is_nan_logits_failure(detail: &str) -> bool {
 
 /// Run one turn through the engine, collecting the streamed events into the
 /// wire result. Errors return the full failure text for diagnosis upstream.
-async fn run_turn(
+/// `pub(crate)` so the headless `--offline-turn` driver (P5/D2-V5) reuses the
+/// exact production turn loop instead of duplicating the streaming logic.
+pub(crate) async fn run_turn(
     engine: &dyn ProviderAdapter,
     request: ChatRequest,
 ) -> Result<serde_json::Value, String> {

--- a/crates/fae-engine/src/lib.rs
+++ b/crates/fae-engine/src/lib.rs
@@ -25,6 +25,8 @@ mod llamacpp_adapter;
 mod mistralrs_adapter;
 mod mock;
 mod models_lock;
+#[cfg(not(target_os = "macos"))]
+mod piper_tts_adapter;
 mod provider;
 mod tts;
 #[cfg(target_os = "macos")]
@@ -37,6 +39,8 @@ pub use llamacpp_adapter::{
 pub use mistralrs_adapter::LocalMistralrsAdapter;
 pub use mock::MockAdapter;
 pub use models_lock::{Artifact, LockError, ModelsLock, SUPPORTED_SCHEMA_VERSION};
+#[cfg(not(target_os = "macos"))]
+pub use piper_tts_adapter::PiperTtsAdapter;
 pub use provider::{
     AdapterInfo, ChatEvent, ChatMessage, ChatRequest, ChatStream, EngineError, LoadedAdapter,
     ProviderAdapter, Role, ToolSpec,

--- a/crates/fae-engine/src/piper_tts_adapter.rs
+++ b/crates/fae-engine/src/piper_tts_adapter.rs
@@ -1,0 +1,406 @@
+//! `PiperTtsAdapter` — Piper neural TTS via a SHA-pinned sidecar (P5/D2-V5).
+//!
+//! The Linux TTS lane (ADR-010): macOS keeps Kokoro/`voice-tts` (mlx-rs); every
+//! non-macOS target runs the `piper` prebuilt binary (bundled ONNX Runtime +
+//! espeak-ng) as a child process — text in on stdin, a 22.05 kHz WAV out. This
+//! adapter resamples that to the project's 24 kHz `TtsAudio` contract.
+//!
+//! The binary + voice model are integrity-gated (confinement + existence + SHA)
+//! by the daemon BEFORE this adapter is constructed, exactly as the llama-server
+//! runtime is gated before the llama.cpp engine. This adapter is the executor:
+//! it never silently emits silence — a missing binary, a non-zero exit, or an
+//! unreadable WAV is a loud `EngineError::Inference`.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use async_trait::async_trait;
+use tokio::io::AsyncWriteExt;
+
+use crate::provider::{AdapterInfo, EngineError};
+use crate::tts::{encode_wav_pcm16, TtsAdapter, TtsAudio};
+
+/// The 24 kHz mono PCM16 contract the rest of the pipeline expects (matches
+/// Kokoro on macOS, so playback + `audio.level` behave identically on Linux).
+const TARGET_SAMPLE_RATE: u32 = 24_000;
+
+/// Piper's `--length_scale` default. Lower = faster speech, higher = slower, so
+/// the pipeline `speed` factor maps inversely. Clamp to a sane band so an
+/// out-of-range speed can't produce garbage or a hung synth.
+const MIN_SPEED: f32 = 0.5;
+const MAX_SPEED: f32 = 2.0;
+
+/// A Piper voice + binary behind the [`TtsAdapter`] contract.
+///
+/// All paths are resolved + integrity-verified by the daemon before this is
+/// built. `espeak_data` is the `espeak-ng-data` dir shipped alongside the
+/// binary; passing it explicitly avoids depending on the process CWD.
+pub struct PiperTtsAdapter {
+    binary: PathBuf,
+    model_onnx: PathBuf,
+    model_config: PathBuf,
+    espeak_data: Option<PathBuf>,
+    model_id: String,
+}
+
+impl PiperTtsAdapter {
+    /// Build an adapter over already-verified paths. `model_id` is for status +
+    /// audit only (e.g. the voice name).
+    #[must_use]
+    pub fn new(
+        binary: PathBuf,
+        model_onnx: PathBuf,
+        model_config: PathBuf,
+        espeak_data: Option<PathBuf>,
+        model_id: impl Into<String>,
+    ) -> PiperTtsAdapter {
+        PiperTtsAdapter {
+            binary,
+            model_onnx,
+            model_config,
+            espeak_data,
+            model_id: model_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl TtsAdapter for PiperTtsAdapter {
+    fn describe(&self) -> AdapterInfo {
+        AdapterInfo {
+            backend: "piper".to_owned(),
+            model_id: self.model_id.clone(),
+        }
+    }
+
+    async fn synthesize(
+        &self,
+        text: &str,
+        _voice: &str,
+        speed: f32,
+    ) -> Result<TtsAudio, EngineError> {
+        if text.trim().is_empty() {
+            return Err(EngineError::Inference("empty text".to_owned()));
+        }
+
+        // Piper writes a WAV to --output_file. Use a process-unique temp path so
+        // concurrent synths don't collide; clean it up on the way out.
+        let out_path = unique_temp_wav();
+        // `--length_scale` is inverse speed: 0.8x speed → 1.25 length.
+        let length_scale = 1.0 / speed.clamp(MIN_SPEED, MAX_SPEED);
+
+        let mut command = tokio::process::Command::new(&self.binary);
+        command
+            .arg("--model")
+            .arg(&self.model_onnx)
+            .arg("--config")
+            .arg(&self.model_config)
+            .arg("--output_file")
+            .arg(&out_path)
+            .arg("--length_scale")
+            .arg(format!("{length_scale:.4}"))
+            .arg("--quiet")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+        if let Some(dir) = &self.espeak_data {
+            command.arg("--espeak_data").arg(dir);
+        }
+        // Keep the shipped shared libs (libonnxruntime, libespeak-ng) loadable
+        // even if the host's loader path is bare: point it at the binary's dir.
+        if let Some(parent) = self.binary.parent() {
+            command.env("LD_LIBRARY_PATH", ld_library_path(parent));
+        }
+
+        let mut child = command.spawn().map_err(|error| {
+            EngineError::Inference(format!("spawn piper {}: {error}", self.binary.display()))
+        })?;
+
+        // Pipe the text in, then close stdin so Piper flushes + exits.
+        {
+            let mut stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| EngineError::Inference("piper stdin unavailable".to_owned()))?;
+            stdin
+                .write_all(text.as_bytes())
+                .await
+                .map_err(|error| EngineError::Inference(format!("write piper stdin: {error}")))?;
+            stdin
+                .write_all(b"\n")
+                .await
+                .map_err(|error| EngineError::Inference(format!("write piper stdin: {error}")))?;
+        } // stdin dropped here → EOF
+
+        let output = child.wait_with_output().await.map_err(|error| {
+            cleanup(&out_path);
+            EngineError::Inference(format!("await piper: {error}"))
+        })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            cleanup(&out_path);
+            return Err(EngineError::Inference(format!(
+                "piper exited with {}: {}",
+                output.status,
+                stderr.trim()
+            )));
+        }
+
+        let wav_bytes = match std::fs::read(&out_path) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                cleanup(&out_path);
+                return Err(EngineError::Inference(format!(
+                    "read piper output {}: {error}",
+                    out_path.display()
+                )));
+            }
+        };
+        cleanup(&out_path);
+
+        let decoded = decode_wav_pcm16_mono(&wav_bytes)
+            .map_err(|reason| EngineError::Inference(format!("decode piper wav: {reason}")))?;
+        if decoded.samples.is_empty() {
+            return Err(EngineError::Inference(
+                "piper produced empty audio".to_owned(),
+            ));
+        }
+
+        let samples = resample_linear(&decoded.samples, decoded.sample_rate, TARGET_SAMPLE_RATE);
+        Ok(TtsAudio {
+            wav: encode_wav_pcm16(&samples, TARGET_SAMPLE_RATE),
+            sample_rate: TARGET_SAMPLE_RATE,
+        })
+    }
+}
+
+/// Prepend `dir` to any existing `LD_LIBRARY_PATH` so the sidecar's bundled
+/// shared libraries resolve without touching the host's loader config.
+fn ld_library_path(dir: &Path) -> std::ffi::OsString {
+    let mut value = dir.as_os_str().to_owned();
+    if let Some(existing) = std::env::var_os("LD_LIBRARY_PATH") {
+        if !existing.is_empty() {
+            value.push(":");
+            value.push(existing);
+        }
+    }
+    value
+}
+
+fn unique_temp_wav() -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("fae-piper-{pid}-{nanos}-{seq}.wav"))
+}
+
+fn cleanup(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+struct DecodedWav {
+    samples: Vec<f32>,
+    sample_rate: u32,
+}
+
+/// Minimal 16-bit PCM mono WAV decoder for Piper's output. Piper emits a
+/// canonical RIFF/WAVE PCM16 mono file; anything else is a loud error (we never
+/// guess at unknown formats). Self-contained so fae-engine needn't depend on the
+/// fae-audio playback layer.
+fn decode_wav_pcm16_mono(wav: &[u8]) -> Result<DecodedWav, String> {
+    if wav.len() < 44 || &wav[0..4] != b"RIFF" || &wav[8..12] != b"WAVE" {
+        return Err("missing RIFF/WAVE header".to_owned());
+    }
+    let mut offset = 12_usize;
+    let mut fmt: Option<(u16, u16, u32, u16)> = None;
+    let mut data: Option<&[u8]> = None;
+    while offset.saturating_add(8) <= wav.len() {
+        let id = &wav[offset..offset + 4];
+        let size = u32::from_le_bytes([
+            wav[offset + 4],
+            wav[offset + 5],
+            wav[offset + 6],
+            wav[offset + 7],
+        ]) as usize;
+        offset = offset.saturating_add(8);
+        if offset.saturating_add(size) > wav.len() {
+            return Err("chunk exceeds file length".to_owned());
+        }
+        let chunk = &wav[offset..offset + size];
+        if id == b"fmt " {
+            if chunk.len() < 16 {
+                return Err("short fmt chunk".to_owned());
+            }
+            let format = u16::from_le_bytes([chunk[0], chunk[1]]);
+            let channels = u16::from_le_bytes([chunk[2], chunk[3]]);
+            let sample_rate = u32::from_le_bytes([chunk[4], chunk[5], chunk[6], chunk[7]]);
+            let bits = u16::from_le_bytes([chunk[14], chunk[15]]);
+            fmt = Some((format, channels, sample_rate, bits));
+        } else if id == b"data" {
+            data = Some(chunk);
+        }
+        // Chunks are word-aligned: skip a pad byte after odd-sized chunks.
+        offset = offset.saturating_add(size + (size % 2));
+    }
+    let (format, channels, sample_rate, bits) = fmt.ok_or("missing fmt chunk")?;
+    let data = data.ok_or("missing data chunk")?;
+    if format != 1 || bits != 16 {
+        return Err(format!(
+            "unsupported wav format (format={format}, bits={bits}); expected PCM16"
+        ));
+    }
+    if channels == 0 {
+        return Err("zero channels".to_owned());
+    }
+    let channels = usize::from(channels);
+    let frame_bytes = channels.saturating_mul(2);
+    if frame_bytes == 0 || data.len() % frame_bytes != 0 {
+        return Err("misaligned pcm data".to_owned());
+    }
+    // Downmix to mono by averaging channels (Piper is mono, but be defensive).
+    let mut samples = Vec::with_capacity(data.len() / frame_bytes);
+    for frame in data.chunks_exact(frame_bytes) {
+        let mut acc = 0.0_f32;
+        for ch in 0..channels {
+            let lo = frame[ch * 2];
+            let hi = frame[ch * 2 + 1];
+            acc += f32::from(i16::from_le_bytes([lo, hi])) / 32768.0;
+        }
+        samples.push(acc / channels as f32);
+    }
+    Ok(DecodedWav {
+        samples,
+        sample_rate,
+    })
+}
+
+/// Linear-interpolation resampler (same shape as `fae-audio::resample_linear`).
+fn resample_linear(input: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
+    if input.is_empty() || from_rate == 0 || to_rate == 0 {
+        return Vec::new();
+    }
+    if from_rate == to_rate {
+        return input.to_vec();
+    }
+    let out_len_u64 = (input.len() as u64)
+        .saturating_mul(u64::from(to_rate))
+        .div_ceil(u64::from(from_rate));
+    let out_len = usize::try_from(out_len_u64)
+        .unwrap_or(usize::MAX)
+        .min(usize::MAX / 2);
+    let ratio = from_rate as f64 / to_rate as f64;
+    let mut output = Vec::with_capacity(out_len);
+    for i in 0..out_len {
+        let src = i as f64 * ratio;
+        let left = src.floor() as usize;
+        let frac = (src - left as f64) as f32;
+        let a = input.get(left).copied().unwrap_or(0.0);
+        let b = input.get(left.saturating_add(1)).copied().unwrap_or(a);
+        output.push(a.mul_add(1.0 - frac, b * frac));
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a canonical PCM16 mono WAV from samples for decode tests.
+    fn pcm16_mono_wav(samples: &[f32], sample_rate: u32) -> Vec<u8> {
+        encode_wav_pcm16(samples, sample_rate)
+    }
+
+    #[test]
+    fn decodes_pcm16_mono_roundtrip() -> Result<(), String> {
+        let input = [0.0_f32, 0.5, -0.5, 0.25];
+        let wav = pcm16_mono_wav(&input, 22_050);
+        let decoded = decode_wav_pcm16_mono(&wav)?;
+        assert_eq!(decoded.sample_rate, 22_050);
+        assert_eq!(decoded.samples.len(), input.len());
+        // 16-bit quantisation: within ~1/32768.
+        for (got, want) in decoded.samples.iter().zip(input.iter()) {
+            assert!((got - want).abs() < 1e-3, "got {got}, want {want}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn decode_rejects_non_pcm16_and_garbage() {
+        // Float32 WAV (format=3) is rejected — we only accept Piper's PCM16.
+        let mut wav = pcm16_mono_wav(&[0.1, 0.2], 22_050);
+        wav[20] = 3; // format tag → IEEE float
+        assert!(decode_wav_pcm16_mono(&wav).is_err());
+        // Not a RIFF file at all.
+        assert!(decode_wav_pcm16_mono(b"not a wav").is_err());
+        // Header only, no data chunk.
+        assert!(decode_wav_pcm16_mono(&wav[0..12]).is_err());
+    }
+
+    #[test]
+    fn resample_22050_to_24000_grows_length_and_preserves_endpoints() {
+        let input: Vec<f32> = (0..2205).map(|i| (i as f32 / 100.0).sin()).collect();
+        let out = resample_linear(&input, 22_050, 24_000);
+        // 22050 → 24000 over 0.1s ≈ 2400 samples.
+        assert!(
+            (out.len() as i64 - 2400).abs() <= 2,
+            "resampled len {} not ≈2400",
+            out.len()
+        );
+        assert!((out[0] - input[0]).abs() < 1e-4);
+    }
+
+    #[test]
+    fn length_scale_is_inverse_speed_and_clamped() {
+        // The mapping the adapter uses: length_scale = 1 / clamp(speed).
+        let ls = |speed: f32| 1.0 / speed.clamp(MIN_SPEED, MAX_SPEED);
+        assert!((ls(1.0) - 1.0).abs() < 1e-6);
+        assert!(ls(2.0) < ls(1.0)); // faster speech = shorter phonemes
+        assert!(ls(0.5) > ls(1.0)); // slower speech = longer phonemes
+                                    // Out-of-band speeds are clamped, not propagated raw.
+        assert!((ls(10.0) - ls(MAX_SPEED)).abs() < 1e-6);
+        assert!((ls(0.01) - ls(MIN_SPEED)).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn synthesize_rejects_empty_text_without_spawning() {
+        // A non-existent binary path proves we error on empty text BEFORE spawn.
+        let adapter = PiperTtsAdapter::new(
+            PathBuf::from("/nonexistent/piper"),
+            PathBuf::from("/nonexistent/voice.onnx"),
+            PathBuf::from("/nonexistent/voice.onnx.json"),
+            None,
+            "en_US-lessac-medium",
+        );
+        let err = adapter.synthesize("   ", "lessac", 1.0).await.unwrap_err();
+        assert!(matches!(err, EngineError::Inference(_)));
+    }
+
+    #[tokio::test]
+    async fn synthesize_fails_loud_when_binary_missing() {
+        // The integrity gate runs in the daemon; if a bad path still reaches the
+        // adapter, it must error loudly — never return silence.
+        let adapter = PiperTtsAdapter::new(
+            PathBuf::from("/nonexistent/piper-binary"),
+            PathBuf::from("/nonexistent/voice.onnx"),
+            PathBuf::from("/nonexistent/voice.onnx.json"),
+            None,
+            "en_US-lessac-medium",
+        );
+        let err = adapter
+            .synthesize("hello", "lessac", 1.0)
+            .await
+            .unwrap_err();
+        match err {
+            EngineError::Inference(msg) => assert!(
+                msg.contains("spawn piper"),
+                "unexpected error message: {msg}"
+            ),
+            other => panic!("expected Inference error, got {other:?}"),
+        }
+    }
+}

--- a/docs/architecture/linux-live-audio-smoke-2026-06-20.md
+++ b/docs/architecture/linux-live-audio-smoke-2026-06-20.md
@@ -1,0 +1,136 @@
+# Linux live mic + speaker smoke (P5 / D2-V5, Stage 5)
+
+> **Status: DEFERRED — documentation only.** This is the one P5 step that needs a
+> real Linux box with an audio device. Headless CI runners have no microphone or
+> speaker, so the live mic→speaker turn cannot run there. The full voice spine is
+> already proven headless in CI (clip → STT → LLM → Piper TTS → spoken WAV →
+> Qwen3-ASR round-trip intelligibility gate; see `ci-linux.yml`). This page is the
+> owner/real-hardware runbook for confirming the *device* legs on a Linux desktop.
+> **The phase is NOT blocked on hardware we don't have.**
+
+## Why this is a smoke, not a gate
+
+Fae's audio I/O lives in `crates/fae-audio` (`AudioManager`). It is **portable by
+construction**: the crate has **zero `#[cfg(target_os)]`** and uses
+[`cpal`](https://crates.io/crates/cpal) `0.15` for capture and playback. The same
+code that records the push-to-talk clip and plays TTS on macOS (CoreAudio) drives
+**ALSA / PulseAudio / PipeWire on Linux** through cpal's host abstraction — no
+Linux-specific audio code was written for P5. Capture (16 kHz mono WAV),
+`play_wav`, and the non-blocking `play_start`/`play_stop` (with RMS level events)
+are all backend-agnostic.
+
+What CI *cannot* exercise is a physical input/output device. That is the only gap
+this smoke closes, and it is an owner action on real Linux hardware.
+
+## Audio backend on Linux
+
+- cpal `0.15` uses the **ALSA** backend on Linux. The packaged `.deb` declares
+  `libasound2` in its `Depends` (`scripts/build-linux-package.py`), and CI installs
+  `libasound2-dev` to build. ALSA is the lowest common layer.
+- **PulseAudio** and **PipeWire** both expose ALSA-compatible devices (PipeWire via
+  `pipewire-alsa`, Pulse via its ALSA plugin), so cpal sees them as ALSA devices.
+  On a modern desktop the default device is usually the Pulse/PipeWire server,
+  which is what you want (it handles mixing and routing). No Fae change is needed
+  to use any of the three — it is whatever ALSA resolves to on the host.
+- If only bare ALSA is present (no sound server), cpal talks to the hardware
+  device directly; pick it explicitly with the env vars below if the default is
+  wrong (e.g. an HDMI sink with no speakers).
+
+## Device selection (verified against `crates/fae-audio/src/lib.rs`)
+
+Two environment variables override the device, falling back to the host default:
+
+| Variable | Effect |
+|----------|--------|
+| `FAE_AUDIO_INPUT_DEVICE`  | Capture device. Case-insensitive **substring** match against cpal input device names; unset/empty → `host.default_input_device()`. |
+| `FAE_AUDIO_OUTPUT_DEVICE` | Playback device. Same substring match against output device names; unset/empty → `host.default_output_device()`. |
+
+- Matching is a `to_ascii_lowercase().contains(...)` substring test
+  (`select_named_device`), so `FAE_AUDIO_OUTPUT_DEVICE=usb` matches a device named
+  `"USB Audio Device"`. A non-matching name is a hard error
+  (`"output device matching '…' not found"`) — it does **not** silently fall back,
+  so a typo fails loudly.
+- To see the exact names cpal reports, query the daemon's `audio.devices` command
+  (returns `{ inputs, outputs, default_input, default_output }`) or list ALSA
+  devices with `arecord -l` / `aplay -l` (and `pactl list short sinks` /
+  `wpctl status` for Pulse / PipeWire).
+
+## Prerequisites on the Linux desktop
+
+1. A working sound stack: `libasound2` plus, typically, PulseAudio or PipeWire.
+   Verify playback and capture independently first, outside Fae:
+   ```bash
+   speaker-test -t sine -f 440 -l 1     # you should hear a tone
+   arecord -d 3 /tmp/mic-test.wav && aplay /tmp/mic-test.wav   # record + play back
+   ```
+   If those don't work, fix the OS audio setup before involving Fae.
+2. The Fae daemon built natively for the target arch (`cargo build -p fae-daemon`),
+   the SHA-pinned **Piper** runtime installed
+   (`python3 scripts/install-piper-runtime.py --platform linux-x86_64`
+   or `linux-aarch64`), the **llama.cpp** runtime installed, and `models.lock`
+   present at `$XDG_DATA_HOME/fae/models.lock` (or `~/.local/share/fae/models.lock`).
+   This is the same setup the `.deb` produces.
+
+## Running the live turn
+
+There is no special "live mode" — the live turn is the ordinary daemon path with a
+real device attached. Two ways to drive it:
+
+### A. Full app (preferred, once a Linux orb host exists — P6)
+
+Launch the daemon + UI the way the platform ships it and use push-to-talk: speak,
+release, hear Fae's spoken answer through the speaker. On Linux the capture/playback
+go through cpal→ALSA automatically. Select non-default devices by exporting the env
+vars before launch, e.g.:
+```bash
+export FAE_AUDIO_INPUT_DEVICE="USB"      # your mic, substring match
+export FAE_AUDIO_OUTPUT_DEVICE="Speakers"
+# …launch the daemon/app…
+```
+
+### B. Daemon socket commands (works today, no UI needed)
+
+The daemon already exposes the live primitives over its NDJSON socket — these touch
+the real device:
+
+- `audio.capture_start` / `audio.capture_stop` — record a 16 kHz mono WAV from the
+  input device (returns the clip), then feed it to the turn.
+- `tts.speak` — synthesize via Piper and **play through the output device**
+  (non-blocking; emits `audio.level` events and `audio.playback_ended`).
+- `audio.play` — play a provided WAV through the output device.
+- `audio.stop` — barge-in: drop the active playback stream immediately.
+
+A minimal live loop: `audio.capture_start` → (speak) → `audio.capture_stop` → run
+the turn (STT → LLM → Piper TTS) → `tts.speak` the answer → confirm you hear it.
+This is the same chain the headless `--offline-turn` driver runs file-to-file in CI;
+the only difference is a real mic in and a real speaker out.
+
+## What "pass" looks like
+
+- You speak into the mic, and the captured clip transcribes correctly (no device =
+  no audio = empty clip, which is the failure to look for).
+- Fae's answer plays through the speaker as **intelligible Piper speech** at a
+  sensible volume, with no dropouts, and barge-in (`audio.stop` / starting a new
+  capture) cuts playback promptly.
+- Switching `FAE_AUDIO_INPUT_DEVICE` / `FAE_AUDIO_OUTPUT_DEVICE` routes to the named
+  device; a bogus name fails loudly rather than going silent.
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---------|--------------------|
+| No sound, no error | Default output is the wrong sink (e.g. HDMI). Set `FAE_AUDIO_OUTPUT_DEVICE` to your speakers' substring; confirm with `speaker-test`. |
+| `output device matching '…' not found` | Your substring matched nothing. List names via `audio.devices` / `aplay -l` and use a real fragment. |
+| Empty/silent captured clip | No/!default input device, or another app holds the mic exclusively (bare-ALSA `hw:` is exclusive). Prefer the Pulse/PipeWire default device, or close the other app. |
+| Choppy playback / xruns | ALSA buffer underruns under load — usually a Pulse/PipeWire latency setting, not Fae. Run via the sound server rather than raw `hw:`. |
+| Works in `aplay` but not Fae | Confirm `libasound2` is installed and the daemon isn't pinned to a stale device name via the env vars. |
+
+## Scope notes
+
+- **Speaker-ID stays dropped** (voice identity retired, S18) — there is no
+  enrollment or recognition leg to smoke here, only capture + playback.
+- The **macOS V5 capture flip** (Swift AVAudioEngine → daemon cpal) is explicitly
+  out of scope for P5; this page is Linux-only.
+- This smoke is owner-run on real hardware and is intentionally **not** wired into
+  CI. The portable cpal code + the headless intelligibility gate are the automated
+  proofs; this runbook is the manual confirmation of the device legs.

--- a/docs/plans/portable-voice-spine-P5-D2-V5-mega-prompt-2026-06-20.md
+++ b/docs/plans/portable-voice-spine-P5-D2-V5-mega-prompt-2026-06-20.md
@@ -107,6 +107,10 @@ on Linux is deferred (headless CI has no audio device; cpal is portable by const
   live mic→speaker turn is an owner/real-Linux-box smoke. DOCUMENT the exact device path
   (`FAE_AUDIO_INPUT_DEVICE`/`_OUTPUT_DEVICE`, ALSA/Pulse/PipeWire) and how to run the live turn on a Linux
   desktop. Do NOT block the phase on hardware you don't have.
+- **DONE (2026-06-20):** runbook at
+  [`docs/architecture/linux-live-audio-smoke-2026-06-20.md`](../architecture/linux-live-audio-smoke-2026-06-20.md)
+  — device override env, ALSA/Pulse/PipeWire mapping, the live-turn recipe (full-app PTT or the daemon
+  socket commands), and how it relates to the headless `--offline-turn` harness + `install-piper-runtime.py`.
 
 ## DONE criteria
 1. Linux build: clip → STT → LLM → **Piper synthesizes intelligible speech to a WAV**, proven in

--- a/native/macos/Fae/Sources/Fae/Resources/Models/models.lock
+++ b/native/macos/Fae/Sources/Fae/Resources/Models/models.lock
@@ -301,3 +301,68 @@ license = "apache-2.0 (base model Qwen/Qwen3-ASR-1.7B)"
 hardware_profile = "llama.cpp sidecar ASR audio projector, cross-platform GPU/CPU by runtime"
 approved_by = "owner"
 created_at = "2026-06-18T00:00:00Z"
+
+# --- Piper TTS sidecar (Linux-only TTS lane, P5/D2-V5). macOS uses Kokoro/voice-tts
+# and never reads these. The `piper` binary entries share the `piper` filename across
+# arches (platform-aware resolution at the daemon, same convention as llama-server);
+# the SHA pins the extracted executable from the rhasspy/piper 2023.11.14-2 tarball.
+
+[[artifact]]
+id = "rhasspy-piper-2023-11-14-2-linux-x86_64"
+role = "tts_binary"
+loader = "piper-sidecar"
+source_repo = "rhasspy/piper"
+source_revision = "2023.11.14-2"
+filename = "piper"
+size_bytes = 4999768
+sha256 = "12672a94ca6716e5a8f335cfa68bf43bd9a33284960e3f9d16b85090bf7aab6b"
+signature = ""
+license = "MIT"
+hardware_profile = "linux x86_64 Piper TTS sidecar (rhasspy/piper prebuilt, bundled ONNX Runtime + espeak-ng)"
+approved_by = "owner"
+created_at = "2026-06-20T00:00:00Z"
+
+[[artifact]]
+id = "rhasspy-piper-2023-11-14-2-linux-aarch64"
+role = "tts_binary"
+loader = "piper-sidecar"
+source_repo = "rhasspy/piper"
+source_revision = "2023.11.14-2"
+filename = "piper"
+size_bytes = 5283040
+sha256 = "0c44a6360a21367b5d03b8656c3e274f4de715f6533245d8c1f17c242631912b"
+signature = ""
+license = "MIT"
+hardware_profile = "linux aarch64 Piper TTS sidecar (rhasspy/piper prebuilt, bundled ONNX Runtime + espeak-ng)"
+approved_by = "owner"
+created_at = "2026-06-20T00:00:00Z"
+
+[[artifact]]
+id = "rhasspy-piper-voices-en-us-lessac-medium-onnx"
+role = "tts_model"
+loader = "piper-sidecar"
+source_repo = "rhasspy/piper-voices"
+source_revision = "e21c7de8d4eab79b902f0d61e662b3f21664b8d2"
+filename = "en_US-lessac-medium.onnx"
+size_bytes = 63201294
+sha256 = "5efe09e69902187827af646e1a6e9d269dee769f9877d17b16b1b46eeaaf019f"
+signature = ""
+license = "MIT (LJSpeech-derived public-domain voice)"
+hardware_profile = "Piper VITS voice, 22.05 kHz, ONNX (resampled to 24 kHz by PiperTtsAdapter)"
+approved_by = "owner"
+created_at = "2026-06-20T00:00:00Z"
+
+[[artifact]]
+id = "rhasspy-piper-voices-en-us-lessac-medium-onnx-json"
+role = "tts_model"
+loader = "piper-sidecar"
+source_repo = "rhasspy/piper-voices"
+source_revision = "e21c7de8d4eab79b902f0d61e662b3f21664b8d2"
+filename = "en_US-lessac-medium.onnx.json"
+size_bytes = 4885
+sha256 = "efe19c417bed055f2d69908248c6ba650fa135bc868b0e6abb3da181dab690a0"
+signature = ""
+license = "MIT (LJSpeech-derived public-domain voice)"
+hardware_profile = "Piper voice config JSON (phoneme map, sample rate)"
+approved_by = "owner"
+created_at = "2026-06-20T00:00:00Z"

--- a/scripts/install-piper-runtime.py
+++ b/scripts/install-piper-runtime.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Install Fae's pinned Piper TTS runtime (Linux only).
+
+Downloads the locked rhasspy/piper release tarball for the current (or
+requested) Linux platform, verifies archive SHA-256 + size, extracts the
+`piper` executable plus its sibling shared libraries (ONNX Runtime, espeak-ng),
+verifies the extracted binary SHA-256 + size, then downloads + SHA-verifies the
+pinned voice model (`.onnx` + `.onnx.json`) into a `voices/` subdir.
+
+This mirrors `install-llamacpp-runtime.py`: the Piper sidecar is an ADR-010
+SHA-pinned binary (no PATH lookup, no apt/pip), and the macOS Kokoro/voice-tts
+lane never uses it. macOS is intentionally unsupported here.
+
+The runtime lock (`scripts/piper-runtime.lock.json`) carries one entry per Linux
+platform under `runtimes` (keys: `linux-x86_64`, `linux-aarch64`) plus a shared
+`voice` object listing the plain voice files.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform as _platform
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK = ROOT / "scripts" / "piper-runtime.lock.json"
+# Piper is the Linux TTS lane; installs land next to the package staging dir by
+# default. Packaging always passes an explicit --install-dir.
+LINUX_INSTALL = ROOT / "build" / "linux" / "Piper"
+
+
+def detect_platform() -> str:
+    """Map the host OS+arch onto a Piper runtime-lock platform key."""
+    system = sys.platform
+    machine = _platform.machine().lower()
+    if system.startswith("linux"):
+        if machine in ("x86_64", "amd64"):
+            return "linux-x86_64"
+        if machine in ("aarch64", "arm64"):
+            return "linux-aarch64"
+        raise SystemExit(f"unsupported Linux architecture: {machine}")
+    raise SystemExit(
+        f"Piper runtime is Linux-only (got {system}); macOS uses the Kokoro/voice-tts lane"
+    )
+
+
+def select_runtime(data: dict, platform_key: str) -> dict:
+    runtimes = data.get("runtimes")
+    if isinstance(runtimes, dict) and platform_key in runtimes:
+        return runtimes[platform_key]
+    available = sorted((runtimes or {}).keys())
+    raise SystemExit(f"no Piper runtime entry for platform {platform_key}; available: {available}")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _safe_target(out_dir: Path, member_name: str) -> Path | None:
+    """Resolve an archive member to a path under out_dir, stripping the top dir.
+
+    Returns None for the bare top-level directory entry. Raises on path
+    traversal.
+    """
+    parts = Path(member_name).parts
+    if len(parts) < 2:
+        return None
+    rel = Path(*parts[1:])
+    if rel.is_absolute() or ".." in rel.parts:
+        raise SystemExit(f"unsafe archive path: {member_name}")
+    return out_dir / rel
+
+
+def extract_tar(archive: Path, out_dir: Path) -> None:
+    with tarfile.open(archive, "r:gz") as tar:
+        for member in tar.getmembers():
+            target = _safe_target(out_dir, member.name)
+            if target is None:
+                continue
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("wb") as f:
+                shutil.copyfileobj(extracted, f)
+            if member.mode & 0o111:
+                target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def download(url: str, dest: Path) -> None:
+    try:
+        with urllib.request.urlopen(url, timeout=120) as r, dest.open("wb") as f:
+            shutil.copyfileobj(r, f)
+        return
+    except (urllib.error.URLError, OSError) as err:
+        print(f"python urllib download failed ({err}); retrying with curl", file=sys.stderr)
+    curl = shutil.which("curl") or "/usr/bin/curl"
+    subprocess.run([curl, "-fL", "--retry", "3", "--output", str(dest), url], check=True)
+
+
+def install_runtime(rt: dict, install_dir: Path, force: bool) -> Path:
+    """Download + verify the Piper tarball; return the verified `piper` binary."""
+    binary = install_dir / rt["binary"]
+    if binary.exists() and not force:
+        print(f"✓ Piper runtime already installed: {binary}")
+        return binary
+
+    install_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="fae-piper-") as td:
+        archive = Path(td) / rt["asset_name"]
+        print(f"↓ Downloading {rt['url']}")
+        download(rt["url"], archive)
+        size = archive.stat().st_size
+        if size != int(rt["size_bytes"]):
+            raise SystemExit(f"size mismatch: expected {rt['size_bytes']}, got {size}")
+        digest = sha256_file(archive)
+        if digest != rt["sha256"]:
+            raise SystemExit(f"sha256 mismatch: expected {rt['sha256']}, got {digest}")
+        print(f"✓ archive sha256 verified: {digest}")
+        tmp_extract = Path(td) / "extract"
+        tmp_extract.mkdir()
+        extract_tar(archive, tmp_extract)
+        tmp_install = install_dir.with_name(install_dir.name + ".tmp")
+        if tmp_install.exists():
+            shutil.rmtree(tmp_install)
+        shutil.copytree(tmp_extract, tmp_install)
+        if install_dir.exists():
+            shutil.rmtree(install_dir)
+        os.replace(tmp_install, install_dir)
+        binary = install_dir / rt["binary"]
+        if not binary.exists():
+            raise SystemExit(f"installed runtime missing {binary}")
+        expected_binary_size = rt.get("binary_size_bytes")
+        if expected_binary_size is not None and binary.stat().st_size != int(expected_binary_size):
+            raise SystemExit(
+                f"binary size mismatch: expected {expected_binary_size}, got {binary.stat().st_size}"
+            )
+        expected_binary_sha = rt.get("binary_sha256")
+        if expected_binary_sha is not None:
+            binary_digest = sha256_file(binary)
+            if binary_digest != expected_binary_sha:
+                raise SystemExit(
+                    f"binary sha256 mismatch: expected {expected_binary_sha}, got {binary_digest}"
+                )
+            print(f"✓ binary sha256 verified: {binary_digest}")
+        binary.chmod(binary.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return binary
+
+
+def install_voice(voice: dict, voices_dir: Path, force: bool) -> None:
+    """Download + SHA-verify each pinned voice file into voices_dir."""
+    voices_dir.mkdir(parents=True, exist_ok=True)
+    for entry in voice.get("files", []):
+        dest = voices_dir / entry["filename"]
+        if dest.exists() and not force:
+            actual = sha256_file(dest)
+            if actual == entry["sha256"]:
+                print(f"✓ voice file already verified: {dest}")
+                continue
+            print(f"… voice file present but hash differs, redownloading: {dest}")
+        print(f"↓ Downloading {entry['url']}")
+        tmp = dest.with_name(dest.name + ".tmp")
+        download(entry["url"], tmp)
+        size = tmp.stat().st_size
+        if size != int(entry["size_bytes"]):
+            raise SystemExit(
+                f"voice {entry['filename']} size mismatch: expected {entry['size_bytes']}, got {size}"
+            )
+        digest = sha256_file(tmp)
+        if digest != entry["sha256"]:
+            raise SystemExit(
+                f"voice {entry['filename']} sha256 mismatch: expected {entry['sha256']}, got {digest}"
+            )
+        os.replace(tmp, dest)
+        print(f"✓ voice sha256 verified: {digest}  ({entry['filename']})")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--platform", help="runtime platform key (default: auto-detect from host)")
+    ap.add_argument("--install-dir", type=Path, default=None,
+                    help="install directory (default: build/linux/Piper)")
+    ap.add_argument("--lock", type=Path, default=LOCK)
+    ap.add_argument("--force", action="store_true", help="redownload/reinstall even if present")
+    args = ap.parse_args()
+
+    data = json.loads(args.lock.read_text())
+    platform_key = args.platform or detect_platform()
+    rt = select_runtime(data, platform_key)
+
+    install_dir = (args.install_dir or LINUX_INSTALL).expanduser().resolve()
+    binary = install_runtime(rt, install_dir, args.force)
+
+    voice = data.get("voice")
+    if voice:
+        install_voice(voice, install_dir / "voices", args.force)
+
+    print(f"✓ Installed Piper {rt['release_tag']} {rt['platform']} runtime: {binary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/piper-runtime.lock.json
+++ b/scripts/piper-runtime.lock.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 2,
+  "created_at": "2026-06-20T00:00:00Z",
+  "source": "https://api.github.com/repos/rhasspy/piper/releases/tags/2023.11.14-2 (binary) + https://huggingface.co/rhasspy/piper-voices revision e21c7de8d4eab79b902f0d61e662b3f21664b8d2 (voice) — downloaded + SHA-verified on 2026-06-20",
+  "note": "Linux-only TTS sidecar (ADR-010). macOS keeps Kokoro/voice-tts and never reads this lock. The rhasspy/piper prebuilt tarball bundles ONNX Runtime 1.14.1 + espeak-ng phonemization next to the `piper` executable; the whole payload must stay together (RUNPATH siblings), so the installer strips only the archive's top `piper/` dir, exactly like the llama.cpp runtime.",
+  "runtimes": {
+    "linux-x86_64": {
+      "name": "rhasspy piper TTS",
+      "release_tag": "2023.11.14-2",
+      "platform": "linux-x86_64",
+      "archive_format": "tar.gz",
+      "asset_name": "piper_linux_x86_64.tar.gz",
+      "url": "https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_x86_64.tar.gz",
+      "size_bytes": 26460462,
+      "sha256": "a50cb45f355b7af1f6d758c1b360717877ba0a398cc8cbe6d2a7a3a26e225992",
+      "binary": "piper",
+      "binary_size_bytes": 4999768,
+      "binary_sha256": "12672a94ca6716e5a8f335cfa68bf43bd9a33284960e3f9d16b85090bf7aab6b"
+    },
+    "linux-aarch64": {
+      "name": "rhasspy piper TTS",
+      "release_tag": "2023.11.14-2",
+      "platform": "linux-aarch64",
+      "archive_format": "tar.gz",
+      "asset_name": "piper_linux_aarch64.tar.gz",
+      "url": "https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_aarch64.tar.gz",
+      "size_bytes": 26004717,
+      "sha256": "fea0fd2d87c54dbc7078d0f878289f404bd4d6eea6e7444a77835d1537ab88eb",
+      "binary": "piper",
+      "binary_size_bytes": 5283040,
+      "binary_sha256": "0c44a6360a21367b5d03b8656c3e274f4de715f6533245d8c1f17c242631912b"
+    }
+  },
+  "voice": {
+    "name": "en_US-lessac-medium",
+    "repo": "rhasspy/piper-voices",
+    "revision": "e21c7de8d4eab79b902f0d61e662b3f21664b8d2",
+    "sample_rate": 22050,
+    "license": "MIT (CC0/MIT per voice card; lessac is public-domain LJSpeech-derived)",
+    "files": [
+      {
+        "filename": "en_US-lessac-medium.onnx",
+        "url": "https://huggingface.co/rhasspy/piper-voices/resolve/e21c7de8d4eab79b902f0d61e662b3f21664b8d2/en/en_US/lessac/medium/en_US-lessac-medium.onnx",
+        "size_bytes": 63201294,
+        "sha256": "5efe09e69902187827af646e1a6e9d269dee769f9877d17b16b1b46eeaaf019f"
+      },
+      {
+        "filename": "en_US-lessac-medium.onnx.json",
+        "url": "https://huggingface.co/rhasspy/piper-voices/resolve/e21c7de8d4eab79b902f0d61e662b3f21664b8d2/en/en_US/lessac/medium/en_US-lessac-medium.onnx.json",
+        "size_bytes": 4885,
+        "sha256": "efe19c417bed055f2d69908248c6ba650fa135bc868b0e6abb3da181dab690a0"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Makes a **Linux** build of `fae-daemon` speak via a SHA-pinned **Piper** sidecar, and proves a full offline voice turn (clip → STT → LLM → Piper TTS → WAV) in headless CI on **linux-x86_64 + linux-aarch64**. macOS keeps Kokoro/voice-tts unchanged; speaker-ID stays dropped; STT is inherited.

## What's here (by stage)
- **S1 — Piper pinned**: `scripts/piper-runtime.lock.json` + `scripts/install-piper-runtime.py` + `models.lock` entries. rhasspy/piper `2023.11.14-2` binary + `en_US-lessac-medium` voice (HF rev-pinned), fail-closed SHA verification, both arches.
- **S2 — PiperTtsAdapter** (`crates/fae-engine/src/piper_tts_adapter.rs`, `cfg(not macos)`): shells out to the integrity-gated Piper binary, resamples 22.05→24 kHz, fails loud. Wired into `build_tts_engine`'s non-macOS branch reusing the llama-server SHA-gate machinery. macOS voice-tts/Kokoro lane untouched.
- **S3 — Headless `--offline-turn` driver** (`crates/fae-daemon/src/offline_turn.rs`): reuses the production `run_turn` loop (no drift), no audio device.
- **S4 — CI** (`ci-linux.yml`, both arches): install+SHA-verify Piper, real Piper synth through the integrity gate, integrity-tamper rejection, **deterministic Qwen3-ASR intelligibility round-trip (≥2 word overlap)**, full-turn self-consistency (dispatch-only), and `fae-engine` added to the crate gate (nextest).
- **S5 — Live-audio runbook** (`docs/architecture/linux-live-audio-smoke-2026-06-20.md`): device-override env, ALSA/Pulse/PipeWire mapping, live-turn recipe.

## DONE criteria
1. Linux build: clip → STT → LLM → **Piper synthesizes intelligible speech to a WAV**, proven in CI (the deterministic ASR round-trip gate). ✅
2. Piper sidecar SHA-pinned + fail-closed (no silent silence in production). ✅
3. macOS TTS path unchanged (voice-tts) and still builds. ✅
4. Speaker-ID stays dropped; STT inherited. ✅

## Verification
Host gate green throughout (last: fmt clean, clippy `-D warnings` clean, `cargo nextest` 95/95). Installer SHA-verify + corrupted-SHA fail-closed reproduced locally on both arches. The native Linux build + real Piper synth + Qwen3-ASR round-trip run in **this CI** (can't run a Linux ELF on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a SHA-pinned Piper TTS sidecar for the Linux build of `fae-daemon` and proves a full offline voice turn (clip → STT → LLM → Piper TTS → WAV) in headless CI on both `linux-x86_64` and `linux-aarch64`; the macOS Kokoro/`voice-tts` path is untouched.

- **S1–S2**: `scripts/piper-runtime.lock.json` + `install-piper-runtime.py` pin the `rhasspy/piper 2023.11.14-2` binary and `en_US-lessac-medium` voice via archive + extracted-binary SHA-256; `PiperTtsAdapter` shells out to the verified binary, resamples 22.05→24 kHz, and fails loudly on any error.
- **S3–S4**: `offline_turn.rs` drives the full headless turn reusing `session::run_turn`; CI adds a tamper-rejection gate and a Qwen3-ASR intelligibility round-trip (≥2-word overlap) as a hard per-PR gate; the heavy Gemma full-turn runs on `workflow_dispatch` only.
- **S5**: `docs/architecture/linux-live-audio-smoke-2026-06-20.md` documents the device-selection env vars and the live-turn recipe for real-hardware validation.

<h3>Confidence Score: 4/5</h3>

Safe to merge for its stated scope (Linux Piper TTS lane + CI proof); the macOS path is untouched and the SHA integrity gate is correctly implemented end-to-end.

The WAV chunk parser in offline_turn.rs (wav_sample_count) accesses wav[offset + 4..offset + 8] after advancing past the 8-byte chunk header without first checking that the chunk data fits within the buffer — exactly the bounds check that the parallel decode_wav_pcm16_mono function in piper_tts_adapter.rs correctly performs. A Piper process crash producing a truncated WAV would cause a panic instead of a clean error return.

crates/fae-daemon/src/offline_turn.rs — the wav_sample_count bounds issue; crates/fae-daemon/src/main.rs — the cfg coverage gap for PIPER_BINARY_ARTIFACT_ID.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/fae-daemon/src/offline_turn.rs | New headless CI driver for the voice spine; wav_sample_count is missing the bounds check that decode_wav_pcm16_mono in piper_tts_adapter correctly includes, creating a potential panic path on malformed/truncated Piper output instead of a clean error. |
| crates/fae-engine/src/piper_tts_adapter.rs | New PiperTtsAdapter: correctly bounds-checks WAV chunks in decode_wav_pcm16_mono, handles temp file cleanup, pipes text to stdin, and resamples 22.05→24 kHz. Well-tested with unit tests covering decode roundtrip, error cases, resampling, and speed clamping. |
| crates/fae-daemon/src/main.rs | Adds --offline-turn dispatch, build_piper_tts_engine with SHA-gated verify_piper_artifacts; PIPER_BINARY_ARTIFACT_ID only defined for linux-x86_64/aarch64 while verify_piper_artifacts is cfg(not(macos)), creating a latent compile error on non-Linux non-macOS platforms. |
| .github/workflows/ci-linux.yml | Adds Piper install/verify, offline-turn smoke, tamper rejection, ASR round-trip intelligibility gate, and a dispatch-only full voice turn job. Step ordering is correct. |
| scripts/install-piper-runtime.py | Archive-SHA and binary-SHA verified installer; safe tar extraction with path-traversal check; atomic rename pattern prevents partial installs. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/fae-daemon/src/main.rs`, line 466-476 ([link](https://github.com/saorsa-labs/fae/blob/937ddbf6e1d6f92934d72a953b822fb3839468a0/crates/fae-daemon/src/main.rs#L466-L476)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `PIPER_BINARY_ARTIFACT_ID` is defined only for `linux-x86_64` and `linux-aarch64`, but `verify_piper_artifacts` (which references it) is compiled for `cfg(not(target_os = "macos"))`. On a non-macOS, non-Linux target (FreeBSD, Windows) or a Linux target with an unsupported arch (RISC-V, s390x), Rust will fail to compile because the constant is undefined while the function body is included. Adding a catch-all or extending the outer `cfg` guard to `cfg(any(all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))` would keep the build hermetic.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/fae-daemon/src/main.rs
   Line: 466-476

   Comment:
   `PIPER_BINARY_ARTIFACT_ID` is defined only for `linux-x86_64` and `linux-aarch64`, but `verify_piper_artifacts` (which references it) is compiled for `cfg(not(target_os = "macos"))`. On a non-macOS, non-Linux target (FreeBSD, Windows) or a Linux target with an unsupported arch (RISC-V, s390x), Rust will fail to compile because the constant is undefined while the function body is included. Adding a catch-all or extending the outer `cfg` guard to `cfg(any(all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))` would keep the build hermetic.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/fae-daemon/src/offline_turn.rs:246-253
Missing bounds check before reading the `fmt` chunk payload — `decode_wav_pcm16_mono` in `piper_tts_adapter.rs` protects against this exact case with an explicit `if offset.saturating_add(size) > wav.len() { return Err(...) }` guard, but `wav_sample_count` here does not. If Piper crashes mid-write and produces a truncated WAV whose `fmt ` header declares `size >= 16` while fewer than 8 bytes remain after the header, the index-expression `wav[offset + 4]` panics rather than returning a clean error to the caller.

```suggestion
        offset = offset.saturating_add(8);
        if offset.saturating_add(size) > wav.len() {
            break;
        }
        if id == b"fmt " && size >= 16 {
            sample_rate = u32::from_le_bytes([
                wav[offset + 4],
                wav[offset + 5],
                wav[offset + 6],
                wav[offset + 7],
            ]);
```

### Issue 2 of 2
crates/fae-daemon/src/main.rs:466-476
`PIPER_BINARY_ARTIFACT_ID` is defined only for `linux-x86_64` and `linux-aarch64`, but `verify_piper_artifacts` (which references it) is compiled for `cfg(not(target_os = "macos"))`. On a non-macOS, non-Linux target (FreeBSD, Windows) or a Linux target with an unsupported arch (RISC-V, s390x), Rust will fail to compile because the constant is undefined while the function body is included. Adding a catch-all or extending the outer `cfg` guard to `cfg(any(all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))` would keep the build hermetic.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(voice): Linux Piper TTS lane + offl..."](https://github.com/saorsa-labs/fae/commit/937ddbf6e1d6f92934d72a953b822fb3839468a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38786148)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->