### PR TITLE
fix(orb-shell): allow expect/unwrap in tests to fix render-spike clippy

### DIFF
--- a/native/rust/fae-ui-shell/src/main.rs
+++ b/native/rust/fae-ui-shell/src/main.rs
@@ -1,3 +1,9 @@
+// Tests may use `.expect()`/`.unwrap()` per the project convention (production
+// code stays panic-free). The orb-shell CI lints `--all-targets` with
+// `-D clippy::expect_used`/`unwrap_used`, which also covers `#[cfg(test)]` code,
+// so scope those two allows to test builds only.
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 /// Orb-host-owns-state: direct daemon subscription (own connection, drives the
 /// orb mode + voice ride via the grace-hold state machine). Unix-only (the orb
 /// host is a Unix GUI app; there is no non-Unix target). Default ON at runtime


### PR DESCRIPTION
## Problem
The **Linux render spike** ("Ubuntu WebKitGTK + ALSA build proof") job has been **RED on `main`** since ~2026-06-17. Its "Lint Rust orb shell" step runs:

```
cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
```

`--all-targets` lints `#[cfg(test)]` code too, and two test `.expect("parsed")` calls in `native/rust/fae-ui-shell/src/daemon_audio_bridge.rs:298/317` (added with the info-indicator feature) trip `-D clippy::expect_used`.

## Fix
Per the project convention (`.expect()`/`.unwrap()` are fine in tests; production stays panic-free), scope those two allows to **test builds only** via a crate-root `#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]`. Recurrence-proof (future test code won't re-break the lint) and doesn't loosen production linting at all (`-D clippy::panic` and the non-test denies stay in force).

## Verification
Local, exact CI command: `cargo clippy --all-features --all-targets -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used` → **passes** (was: 2 `expect_used` errors).

Unrelated to the voice-spine work (PR #16); separated deliberately. The pre-existing macOS "Tests" flake (MLX-under-swift-test / CoreData XPC, zero real test failures) is a separate issue and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a single crate-root lint attribute to `native/rust/fae-ui-shell/src/main.rs` that restores the broken Linux CI job by allowing `.expect()`/`.unwrap()` in test builds only, consistent with the project's established convention that production code remains panic-free.

- Adds `#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]` to the crate root in `main.rs`, which gates the allow to `#[cfg(test)]` compilation only — production linting (`-D clippy::expect_used`, `-D clippy::unwrap_used`, `-D clippy::panic`) is completely unaffected.
- Fixes the two `.expect("parsed")` calls in `daemon_audio_bridge.rs` (lines 298 and 317) that were tripping the `--all-targets` clippy run, and proofs future test code against the same recurrence.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a single lint attribute gated to test builds, with no effect on production code or runtime behavior.

The change is a one-line crate-root attribute that only activates during test compilation. It does not touch any production logic, does not weaken the lint deny-list for non-test code, and correctly targets exactly the two test calls that broke CI.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| native/rust/fae-ui-shell/src/main.rs | Adds a crate-root `#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]` to allow `.expect()`/`.unwrap()` in test code only, fixing the Linux CI lint failure without relaxing production linting. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["cargo clippy --all-features --all-targets\n-D clippy::expect_used\n-D clippy::unwrap_used"] --> B{Compilation target?}
    B -->|"test build\n(cfg(test))"| C["#![cfg_attr(test, allow(...))] active\n→ expect/unwrap allowed in tests"]
    B -->|"non-test build"| D["allow NOT active\n→ expect/unwrap still denied in production"]
    C --> E["daemon_audio_bridge.rs:298\n.expect('parsed') ✓"]
    C --> F["daemon_audio_bridge.rs:317\n.expect('parsed') ✓"]
    D --> G["Production code\nstays panic-free ✓"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["cargo clippy --all-features --all-targets\n-D clippy::expect_used\n-D clippy::unwrap_used"] --> B{Compilation target?}
    B -->|"test build\n(cfg(test))"| C["#![cfg_attr(test, allow(...))] active\n→ expect/unwrap allowed in tests"]
    B -->|"non-test build"| D["allow NOT active\n→ expect/unwrap still denied in production"]
    C --> E["daemon_audio_bridge.rs:298\n.expect('parsed') ✓"]
    C --> F["daemon_audio_bridge.rs:317\n.expect('parsed') ✓"]
    D --> G["Production code\nstays panic-free ✓"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(orb-shell): allow expect/unwrap in t..."](https://github.com/saorsa-labs/fae/commit/c6c11b224c34987f6d557ecc4b87ff5677d3f976) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38800860)</sub>

<!-- /greptile_comment -->