### PR TITLE
fix(ci): repair macOS Tests gate — 6 real bugs + 6 wrong coverage-test assertions

### DIFF
--- a/native/macos/Fae/Sources/Fae/DeviceHandoff.swift
+++ b/native/macos/Fae/Sources/Fae/DeviceHandoff.swift
@@ -58,6 +58,9 @@ struct DeviceCommandParser {
             .replacingOccurrences(of: "'", with: "")
             .replacingOccurrences(of: ".", with: " ")
             .replacingOccurrences(of: ",", with: " ")
+            // Punctuation→space can produce runs of whitespace (e.g. "move, to,
+            // watch"); collapse them so the `contains` checks below still match.
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !normalized.isEmpty else {

--- a/native/macos/Fae/Sources/Fae/ML/VoiceLibrary.swift
+++ b/native/macos/Fae/Sources/Fae/ML/VoiceLibrary.swift
@@ -146,8 +146,12 @@ actor VoiceLibrary {
 
     /// Sanitize a voice name for use as a filename (lowercase, alphanumeric + hyphens).
     static func sanitizeName(_ name: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(.init(charactersIn: "-_"))
+        // Drop empty segments so runs of disallowed chars collapse to a single
+        // dash ("a!@#b" -> "a-b") and all-symbol input collapses to "unnamed".
         let cleaned = name.lowercased()
-            .components(separatedBy: CharacterSet.alphanumerics.union(.init(charactersIn: "-_")).inverted)
+            .components(separatedBy: allowed.inverted)
+            .filter { !$0.isEmpty }
             .joined(separator: "-")
         return cleaned.isEmpty ? "unnamed" : cleaned
     }

--- a/native/macos/Fae/Sources/Fae/Memory/MemoryBackup.swift
+++ b/native/macos/Fae/Sources/Fae/Memory/MemoryBackup.swift
@@ -27,7 +27,9 @@ enum MemoryBackup {
         let escaped = backupPath.replacingOccurrences(of: "'", with: "''")
 
         let dbQueue = try DatabaseQueue(path: dbPath)
-        try dbQueue.write { db in
+        // VACUUM (and VACUUM INTO) cannot run inside a transaction; `write`
+        // opens one, so use `writeWithoutTransaction`.
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute(sql: "VACUUM INTO '\(escaped)'")
         }
 

--- a/native/macos/Fae/Sources/Fae/Memory/VectorStore.swift
+++ b/native/macos/Fae/Sources/Fae/Memory/VectorStore.swift
@@ -65,8 +65,14 @@ actor VectorStore {
         guard embeddingDim > 0, embedding.count == embeddingDim else { return }
         let blob = floatsToBlob(embedding)
         try dbQueue.write { db in
+            // vec0 virtual tables reject INSERT OR REPLACE on the primary key
+            // (UNIQUE constraint), so delete any existing row first.
             try db.execute(
-                sql: "INSERT OR REPLACE INTO memory_vec(record_id, embedding) VALUES (?, ?)",
+                sql: "DELETE FROM memory_vec WHERE record_id = ?",
+                arguments: [recordId]
+            )
+            try db.execute(
+                sql: "INSERT INTO memory_vec(record_id, embedding) VALUES (?, ?)",
                 arguments: [recordId, blob]
             )
         }
@@ -102,8 +108,14 @@ actor VectorStore {
         guard embeddingDim > 0, embedding.count == embeddingDim else { return }
         let blob = floatsToBlob(embedding)
         try dbQueue.write { db in
+            // vec0 virtual tables reject INSERT OR REPLACE on the primary key
+            // (UNIQUE constraint), so delete any existing row first.
             try db.execute(
-                sql: "INSERT OR REPLACE INTO fact_vec(fact_id, embedding) VALUES (?, ?)",
+                sql: "DELETE FROM fact_vec WHERE fact_id = ?",
+                arguments: [factId]
+            )
+            try db.execute(
+                sql: "INSERT INTO fact_vec(fact_id, embedding) VALUES (?, ?)",
                 arguments: [factId, blob]
             )
         }

--- a/native/macos/Fae/Sources/Fae/Search/Engines/BraveEngine.swift
+++ b/native/macos/Fae/Sources/Fae/Search/Engines/BraveEngine.swift
@@ -49,11 +49,14 @@ struct BraveEngine: SearchEngineProtocol {
 
         for match in matches {
             guard results.count < maxResults else { break }
-            guard let range = Range(match.range(at: 1), in: html) else { continue }
+            guard let fullRange = Range(match.range, in: html),
+                  let range = Range(match.range(at: 1), in: html) else { continue }
             let block = String(html[range])
 
-            // Skip standalone/featured snippets.
-            if block.contains("standalone") { continue }
+            // Skip standalone/featured snippets. The `standalone` class lives on
+            // the outer wrapper tag (outside capture group 1), so check the full
+            // match, not just the inner block.
+            if String(html[fullRange]).contains("standalone") { continue }
 
             // Extract title from .snippet-title.
             let title = extractByClass(from: block, className: "snippet-title")

--- a/native/macos/Fae/Sources/Fae/Tools/BuiltinTools.swift
+++ b/native/macos/Fae/Sources/Fae/Tools/BuiltinTools.swift
@@ -958,9 +958,11 @@ actor InputRequestBridge {
         guard let raw = userInfo?["form_values"] else { return nil }
 
         if let typed = raw as? [String: String] {
-            return typed
+            let cleaned = typed
                 .mapValues { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
                 .filter { !$0.value.isEmpty }
+            // Match the [String: Any] branch: all-empty values collapse to nil.
+            return cleaned.isEmpty ? nil : cleaned
         }
 
         if let anyMap = raw as? [String: Any] {

--- a/native/macos/Fae/Sources/Fae/Tools/ToolAnalytics.swift
+++ b/native/macos/Fae/Sources/Fae/Tools/ToolAnalytics.swift
@@ -122,10 +122,9 @@ actor ToolAnalytics {
     func totalRecords() -> Int {
         do {
             return try dbQueue.read { db in
-                let row = try Row.fetchOne(
-                    db, sql: "SELECT COUNT(*) FROM tool_usage"
-                )
-                return row?[0] as? Int ?? 0
+                // COUNT(*) is an Int64; `row[0] as? Int` fails the dynamic cast
+                // and silently returns 0. Use GRDB's typed fetch instead.
+                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM tool_usage") ?? 0
             }
         } catch {
             return 0

--- a/native/macos/Fae/Tests/IntegrationTests/AgentAndMetaOptStaticTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/AgentAndMetaOptStaticTests.swift
@@ -25,8 +25,8 @@ final class AgentAndMetaOptStaticTests: XCTestCase {
     func testEncodeScoresAllNilStillValid() {
         let scores = DimensionScores(toolCalling: nil, faeCapability: nil, assistantFit: nil, serialization: nil)
         let json = MetaOptimizer.encodeScores(scores)
-        // Encodes to a JSON object with null values, not "{}".
-        XCTAssertFalse(json.isEmpty)
-        XCTAssertTrue(json.contains("null") || json.contains("toolCalling"))
+        // Swift's synthesized Codable omits nil optionals (encodeIfPresent),
+        // so all-nil scores encode to an empty JSON object.
+        XCTAssertEqual(json, "{}")
     }
 }

--- a/native/macos/Fae/Tests/IntegrationTests/AudioAndBackupStaticTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/AudioAndBackupStaticTests.swift
@@ -72,6 +72,7 @@ final class AudioAndBackupStaticTests: XCTestCase {
     }
 
     func testBackupCreatesBackupDirIfMissing() throws {
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         let dbPath = tempDir.appendingPathComponent("src.db").path
         let dbQueue = try DatabaseQueue(path: dbPath)
         try dbQueue.write { db in try db.execute(sql: "CREATE TABLE t (id INTEGER)") }

--- a/native/macos/Fae/Tests/IntegrationTests/EntityLinkerParsingTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EntityLinkerParsingTests.swift
@@ -115,10 +115,11 @@ final class EntityLinkerParsingTests: XCTestCase {
         XCTAssertNil(name)
     }
 
-    func testExtractFirstNameLowercaseReturnsNil() async throws {
+    func testExtractFirstNameLowercaseTakesLeadingWord() async throws {
         let linker = try makeLinker()
-        // All-lowercase, no leading capital -> no name parts.
+        // The first word is accepted even when lowercase (nameParts.isEmpty &&
+        // first.isLetter); the next non-capitalised word stops extraction.
         let name = await linker.extractFirstName(from: "just some words here")
-        XCTAssertNil(name)
+        XCTAssertEqual(name, "just")
     }
 }

--- a/native/macos/Fae/Tests/IntegrationTests/FaeCoreBuilderStaticTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/FaeCoreBuilderStaticTests.swift
@@ -68,7 +68,8 @@ final class FaeCoreBuilderStaticTests: XCTestCase {
 
     func testDecimalFormatsTwoPlaces() {
         XCTAssertEqual(FaeCore.decimal(0.1), "0.10")
-        XCTAssertEqual(FaeCore.decimal(1.005), "1.01") // banker's/printf rounding
+        // Float(1.005) is 1.00499…, so %.2f rounds down to "1.00".
+        XCTAssertEqual(FaeCore.decimal(1.005), "1.00")
         XCTAssertEqual(FaeCore.decimal(123.456), "123.46")
         XCTAssertEqual(FaeCore.decimal(0), "0.00")
     }

--- a/native/macos/Fae/Tests/IntegrationTests/InstrumentationAndVoiceStaticTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/InstrumentationAndVoiceStaticTests.swift
@@ -65,6 +65,7 @@ final class InstrumentationAndVoiceStaticTests: XCTestCase {
     }
 
     func testSanitizeNameReplacesNonAlphanumericWithDash() {
+        // Runs of disallowed chars collapse to a single dash.
         XCTAssertEqual(VoiceLibrary.sanitizeName("a!@#b$%^c"), "a-b-c")
     }
 


### PR DESCRIPTION
## Summary

The **Tests (macOS arm64)** job has been red on `main` since 2026-06-19. Contrary to the prior assumption (MLX crash), the failing run reported **12 real assertion failures**: 10 auto-generated coverage-test files (added 2026-06-17) reached `main`'s CI only via the consolidation merges and were never validated against the gate.

## Real production bugs fixed (caught by the new tests)

| File | Bug | Impact |
|---|---|---|
| `MemoryBackup.swift` | `VACUUM INTO` ran inside `dbQueue.write` (a transaction) | DB backups always threw → `writeWithoutTransaction` |
| `VectorStore.swift` | `INSERT OR REPLACE` on sqlite-vec `vec0` (×2 tables) | Re-embedding an existing id threw → `memory_reindex`/`embedding_reindex` silently broke → DELETE+INSERT |
| `ToolAnalytics.swift` | `row[0] as? Int` on a `COUNT(*)` Int64 | `totalRecords()` always returned 0 → `Int.fetchOne` |
| `BuiltinTools.swift` | `parseFormValues` `[String:String]` branch missing empty→nil guard | inconsistent with sibling branch |
| `DeviceHandoff.swift` | comma→space produced double-spaces defeating `contains` | "move, to, watch" → unsupported → collapse `\s+` |
| `BraveEngine.swift` | "skip standalone" checked capture group 1, not the outer wrapper | featured snippets leaked into results |

## Tests corrected to match correct impl behavior

- `decimal(1.005)` → `"1.00"` (Float is 1.00499…)
- `sanitizeName` now collapses runs (`"a-b-c"`) and all-symbol input → `"unnamed"`
- `encodeScores` all-nil → `"{}"` (Swift omits nil optionals)
- `extractFirstName` deliberately accepts a leading lowercase word (runs on the post-`"my <label> "` remainder, where lowercase voice names are common) — test documents this
- AudioAndBackup dir-missing test: create `tempDir` before opening the DB

## Verification

`swift test` over all 10 affected classes — **105 tests, 0 failures** (dev app quit; non-MLX classes, no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes six real production bugs caught by newly-added coverage tests and corrects six test assertions that were written against incorrect expected behavior. The changes span SQLite/GRDB usage, HTML parsing, whitespace normalization, and floating-point formatting.

- **Production fixes**: `VACUUM INTO` moved out of a transaction (`writeWithoutTransaction`), `INSERT OR REPLACE` replaced with `DELETE + INSERT` for sqlite-vec's `vec0` tables (×2), `COUNT(*)` Int64→Int cast corrected via `Int.fetchOne`, `parseFormValues` made consistent between type branches, Brave HTML parser now checks the outer wrapper for the `standalone` class, and `DeviceHandoff` collapses multi-space runs from punctuation replacement.
- **Test corrections**: Six assertions updated to reflect actual Swift/GRDB/Float behavior (all-nil `DimensionScores` encodes to `\"{}\"`, `Float(1.005)` rounds to `\"1.00\"`, `sanitizeName` collapses disallowed-char runs to single dashes, `extractFirstName` returns the first word even lowercase, and a missing `tempDir` creation that prevented the backup test from running).

<h3>Confidence Score: 5/5</h3>

All six production fixes are narrowly scoped, well-motivated, and verified by 105 passing tests; no new public API surface is introduced.

Every change corrects a clearly broken code path — a VACUUM that always threw, vector upserts that always failed, a COUNT that always returned 0, a snippet filter that never fired, whitespace that defeated string matching, and an inconsistent nil-vs-empty return — and each fix is paired with a passing test. The test-only corrections align assertions with actual Swift runtime behavior (Float precision, encodeIfPresent, and extractFirstName's existing first-word-accepted-lowercase logic). There are no architectural changes, no new dependencies, and no migration concerns.

No files require special attention; all changes are self-contained and backed by tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| native/macos/Fae/Sources/Fae/Memory/MemoryBackup.swift | Fixes VACUUM INTO always throwing by switching from dbQueue.write (transactional) to writeWithoutTransaction; change is correct and well-commented. |
| native/macos/Fae/Sources/Fae/Memory/VectorStore.swift | Replaces INSERT OR REPLACE with DELETE+INSERT (within the same write transaction) for both vec0 tables; atomicity is preserved at the transaction boundary. |
| native/macos/Fae/Sources/Fae/Search/Engines/BraveEngine.swift | Correctly widens the standalone-class check from capture group 1 to the full outer match, so featured snippets are properly suppressed. |
| native/macos/Fae/Sources/Fae/Tools/ToolAnalytics.swift | Fixes totalRecords() always returning 0 by replacing a failing Int64→Int dynamic cast with GRDB's Int.fetchOne. |
| native/macos/Fae/Sources/Fae/Tools/BuiltinTools.swift | Aligns the [String:String] branch of parseFormValues with the [String:Any] branch so an all-empty-values input returns nil rather than an empty dictionary. |
| native/macos/Fae/Sources/Fae/DeviceHandoff.swift | Adds regex-based whitespace collapse after punctuation-to-space substitution so contains() checks still match inputs like 'move, to, watch'. |
| native/macos/Fae/Sources/Fae/ML/VoiceLibrary.swift | Filters empty segments after character-set split so repeated disallowed chars collapse to a single dash and all-symbol input maps to 'unnamed'. |
| native/macos/Fae/Tests/IntegrationTests/AgentAndMetaOptStaticTests.swift | Corrects all-nil DimensionScores expectation to '{}' reflecting Swift's encodeIfPresent behavior for optional properties. |
| native/macos/Fae/Tests/IntegrationTests/AudioAndBackupStaticTests.swift | Adds missing createDirectory call before opening the DatabaseQueue so the backup-dir-missing test can actually run. |
| native/macos/Fae/Tests/IntegrationTests/EntityLinkerParsingTests.swift | Renames and corrects extractFirstName test: documents that the first token is returned even when lowercase, matching the actual implementation. |
| native/macos/Fae/Tests/IntegrationTests/FaeCoreBuilderStaticTests.swift | Corrects decimal(1.005) expectation from '1.01' to '1.00', matching Float's actual binary representation (1.00499...). |
| native/macos/Fae/Tests/IntegrationTests/InstrumentationAndVoiceStaticTests.swift | Adds explanatory comment to sanitizeName test confirming 'a!@#b$%^c' → 'a-b-c' with the new empty-segment filtering. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DeviceHandoff\npunctuation → space\n+ collapse \\s+"] --> B["DeviceCommandParser\nnormalized.contains(…)"]
    C["VectorStore.upsertRecordEmbedding\n/ upsertFactEmbedding"] --> D["dbQueue.write { db in\n  DELETE …\n  INSERT … }\n(single transaction)"]
    E["MemoryBackup.backup"] --> F["dbQueue.writeWithoutTransaction { db in\n  VACUUM INTO '…' }"]
    G["ToolAnalytics.totalRecords"] --> H["Int.fetchOne(db, sql: COUNT(*))\n(no more Int64→Int cast)"]
    I["BraveEngine.parseBraveResults\nmatch.range"] --> J{fullRange\ncontains\n'standalone'?}
    J -- yes --> K["skip block"]
    J -- no --> L["extract title / url / snippet"]
    M["VoiceLibrary.sanitizeName"] --> N["components(separatedBy: inverted)\n.filter { !$0.isEmpty }\n.joined(separator: '-')"]
    N --> O{cleaned\nempty?}
    O -- yes --> P["return 'unnamed'"]
    O -- no --> Q["return cleaned"]
    R["BuiltinTools.parseFormValues\n[String:String] branch"] --> S["mapValues + filter\n→ cleaned"]
    S --> T{cleaned\nempty?}
    T -- yes --> U["return nil"]
    T -- no --> V["return cleaned"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["DeviceHandoff\npunctuation → space\n+ collapse \\s+"] --> B["DeviceCommandParser\nnormalized.contains(…)"]
    C["VectorStore.upsertRecordEmbedding\n/ upsertFactEmbedding"] --> D["dbQueue.write { db in\n  DELETE …\n  INSERT … }\n(single transaction)"]
    E["MemoryBackup.backup"] --> F["dbQueue.writeWithoutTransaction { db in\n  VACUUM INTO '…' }"]
    G["ToolAnalytics.totalRecords"] --> H["Int.fetchOne(db, sql: COUNT(*))\n(no more Int64→Int cast)"]
    I["BraveEngine.parseBraveResults\nmatch.range"] --> J{fullRange\ncontains\n'standalone'?}
    J -- yes --> K["skip block"]
    J -- no --> L["extract title / url / snippet"]
    M["VoiceLibrary.sanitizeName"] --> N["components(separatedBy: inverted)\n.filter { !$0.isEmpty }\n.joined(separator: '-')"]
    N --> O{cleaned\nempty?}
    O -- yes --> P["return 'unnamed'"]
    O -- no --> Q["return cleaned"]
    R["BuiltinTools.parseFormValues\n[String:String] branch"] --> S["mapValues + filter\n→ cleaned"]
    S --> T{cleaned\nempty?}
    T -- yes --> U["return nil"]
    T -- no --> V["return cleaned"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): repair macOS Tests gate — 6 rea..."](https://github.com/saorsa-labs/fae/commit/ec9af5daa08a3d5a87e5d7efb572979672a9fd1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38809143)</sub>

<!-- /greptile_comment -->