### PR TITLE
refactor(training): P9/C1 — TrainingBackend seam over the two training lanes

### DIFF
--- a/docs/plans/p9-training-seam-gates-design-2026-06-21.md
+++ b/docs/plans/p9-training-seam-gates-design-2026-06-21.md
@@ -1,0 +1,168 @@
+# P9 / C1+C4 — Training seam + mandatory eval gates: design (2026-06-21)
+
+Branch: `feat/p9-training-seam-gates`. Reviewer-gated (codex on design + code; codex already gave a second
+opinion that shaped this scope). macOS-testable; no Linux host needed.
+
+## Objective (roadmap)
+
+> Formalize the `TrainingBackend` seam (`prepareDataset/trainAdapter/convertAdapter/…`) across MLX/Unsloth/PEFT,
+> and enforce **FaeBenchmark regression gates** on every adapter before deploy ("LoRA prevents forgetting" was
+> REFUTED — gates are mandatory). **Done:** the training loop is backend-agnostic behind the seam; no adapter
+> deploys without passing gates.
+
+Codex second-opinion refinement (verified in code): the literal "FaeBenchmark mandatory" is too Apple/MLX-specific —
+FaeBenchmark is MLX-backed and loads adapter **directories**, but the daemon lane produces a **GGUF**, so
+FaeBenchmark cannot evaluate the daemon adapter. The portable gate is the **daemon scale-0/1 A/B eval**;
+FaeBenchmark stays the Apple-lane convenience. So C4 = a lane-appropriate **mandatory, fail-closed eval gate**,
+not "wire FaeBenchmark everywhere."
+
+## Current-state findings (the real bug C4 must fix)
+
+The nightly self-improvement loop can today **auto-deploy an adapter with no real evaluation**:
+
+1. Training writes the candidate straight into the live `currentAdapterPath` BEFORE eval
+   (`ImprovementCycleCoordinator.swift:534`).
+2. No production path calls `setBenchmarkPath`, so `isBenchmarkAvailable` is false
+   (`TrainingBridge.swift:194,703`) → step 6 always takes the **loss-proxy** path (`:582`).
+3. Loss-proxy failure becomes a **zero delta** (`:826-830`), which the internal `ExternalReviewGate` **passes**
+   (`ExternalReviewGate.swift:228`).
+4. `performDeploy` deploys `state.currentAdapterPath` (`:790-797`) — i.e. whatever training produced.
+
+Net: train → (no real eval) → review passes neutral deltas → deploy. That is the exact hole the roadmap calls out.
+
+Additional wiring mismatches (so we don't pretend FaeBenchmark already gates the GGUF lane):
+- `runBenchmark` passes `--model auto` (`TrainingBridge.swift:726`); FaeBenchmark has no `auto` and rejects unknown
+  model names (`FaeBenchmark/main.swift:25,1618`).
+- FaeBenchmark adapter mode writes a comparison JSON (`FaeBenchmark/main.swift:1763`), not the `models` schema
+  `TrainingBridge` parses (`TrainingBridge.swift:791`).
+- FaeBenchmark loads adapter **directories** via MLX (`FaeBenchmark/main.swift:478,504`); the daemon lane emits a
+  **GGUF** (`ImprovementCycleCoordinator.swift:512-513`).
+
+## Design
+
+### C1 — `TrainingBackend` seam
+
+Today backend choice is a branch on `daemonTrainingBaseModel != nil` (`ImprovementCycleCoordinator.swift:501`)
+with two concrete `TrainingBridge` lanes (mlx-tune `launchTraining/pollUntilComplete` `:520,526`; PEFT
+`trainPeftAndConvert` `:510`). Extract a protocol:
+
+```swift
+protocol TrainingBackend: Sendable {
+    var id: String { get }                              // "mlx", "peft", (future) "unsloth"
+    func trainAdapter(dataset: TrainingDataset) async throws -> AdapterCandidate
+}
+struct AdapterCandidate: Sendable {
+    let path: String          // GGUF (peft/daemon) or adapter dir (mlx)
+    let kind: AdapterKind     // .gguf | .mlxDir
+    let finalLoss: Double?
+}
+```
+
+- `MlxTuneBackend` wraps `launchTraining`+`pollUntilComplete` → `AdapterCandidate(kind: .mlxDir)`.
+- `PeftDaemonBackend` wraps `trainPeftAndConvert` → `AdapterCandidate(kind: .gguf)`.
+- `UnslothBackend`: **not implemented** — documented as a future conformer (Unsloth is CUDA-only, planned per
+  open-gaps). The seam must not pretend it exists.
+- `ImprovementCycleCoordinator` selects a backend (same condition as today) and calls `trainAdapter`; no behavior
+  change to the lanes themselves — this is a refactor that makes the lane swap explicit and testable.
+
+`AdapterKind` is what lets C4 pick the right evaluator.
+
+### C4 — mandatory, fail-closed eval gate
+
+**1. Split candidate state from active/deployed state.**
+Add `pendingAdapterPath` to the improvement state. Training writes the candidate to `pendingAdapterPath`
+(NOT `currentAdapterPath`). `currentAdapterPath`/`previousAdapterPath` remain the *deployed* + rollback pointers.
+Deploy promotes `pending → current` (and `current → previous`) ONLY after the gate passes. A candidate that
+fails the gate can never be deployed because it never reaches `currentAdapterPath`.
+
+**2. `AdapterEvaluator` seam (lane-appropriate), mirroring C1.**
+```swift
+protocol AdapterEvaluator: Sendable {
+    func evaluate(_ candidate: AdapterCandidate) async throws -> EvalOutcome  // real deltas, or .unavailable
+}
+```
+- `DaemonABEvaluator` (GGUF lane, the portable primary gate): runs a held-out eval set through the daemon at
+  `set_adapter_scale(0)` (base) vs `(1)` (candidate) and scores — this is the arch-doc-designated portable eval.
+  **Staging note:** the daemon A/B *scoring* harness is new; see Staging below.
+- `FaeBenchmarkEvaluator` (MLX dir lane, Apple convenience): the existing FaeBenchmark path, but only for
+  `.mlxDir` candidates, and with the `--model auto` / output-schema mismatches fixed (or the evaluator reports
+  `.unavailable` rather than silently passing).
+
+**3. Fail-closed at the deploy boundary (the safety fix).**
+- The loss-based proxy is **demoted**: it may annotate a proposal for a human, but it can **never** satisfy the
+  gate, and a failed/zero eval is **never** a pass. Remove the zero-delta fallback as a deploy-eligible outcome
+  (`:826-830`).
+- If the lane's real evaluator returns `.unavailable` (or throws): persist an **audited** `candidate_blocked`
+  result (reason `benchmark_unavailable` / `benchmark_failed`), surface a setup action item, and return to
+  **idle**. Do **NOT** enter `.proposing` — because `approveDeployment()` deploys whatever is staged
+  (`:726-735`), entering `.proposing` with an un-gated candidate would re-open the hole.
+- Only a **real** eval that meets the regression threshold (no dimension regressed beyond tolerance) may move the
+  candidate to `.proposing` (semi-auto) or auto-deploy (earned mode).
+
+**4. Auto-deploy stays gated.** Earned auto-deploy (after N approved cycles) also requires a real passing eval;
+fail-closed applies identically.
+
+## Staging (so the safety fix lands even if the A/B harness is larger)
+
+- **C1** (seam refactor) — low risk, pure structure.
+- **C4-safety** (state split + remove loss/zero-delta deploy path + fail-closed-block-when-no-real-eval) —
+  **this closes the hole now**, independent of whether a real evaluator exists yet. With no real evaluator wired,
+  the loop will *block + audit + idle* instead of unsafe-deploying. That is the correct conservative behavior.
+- **C4-capability** (`DaemonABEvaluator` real scoring harness) — makes the GGUF lane actually *pass* a gate so
+  personalization can deploy. Larger; may land in the same PR if tractable, else a tracked follow-on. If deferred,
+  the loop safely blocks daemon-lane deploys until it exists (no regression vs today — today it unsafe-deploys).
+
+## Scope / non-goals
+
+- No Linux host / no daemon tool execution (that's the separate foundation phase before P7).
+- No Unsloth implementation (future conformer only).
+- Don't expand FaeBenchmark to GGUF; it stays the MLX-dir evaluator.
+
+## Verification
+
+1. macOS: `just check` (build + test) green; new unit tests for: backend seam dispatch; state split (candidate
+   never auto-promotes); fail-closed (no real evaluator → `candidate_blocked`, state stays out of `.proposing`,
+   `currentAdapterPath` unchanged); loss-proxy can't satisfy the gate; a passing real eval promotes correctly.
+2. Tests must encode WHY (Rule 9): e.g. "an un-evaluated candidate is never deployable" — fails if someone
+   re-points deploy at `pendingAdapterPath`.
+3. codex review on this design and on the diff.
+
+## Codex design-review changes (APPROVE-WITH-CHANGES — folded in, required)
+
+1. **Persisted gate receipt (the real deploy gate).** `pendingAdapterPath` is necessary but not sufficient —
+   `performDeploy` trusts `currentAdapterPath` (`:790`). Add a persisted `GateReceipt { candidatePath, kind,
+   sha256, deltas, evaluatorId, at }` in the improvement state. `performDeploy` MUST verify a receipt exists whose
+   `candidatePath` == the pending candidate AND whose `sha256` matches the artifact on disk; otherwise refuse to
+   deploy. The receipt — not the state enum — is the authority that "this exact artifact passed a real gate."
+2. **Fence the bypass deploy paths.** `AdapterDeploymentManager.deploy(adapterPath:)` writes an arbitrary path
+   straight to `currentAdapterPath` (`AdapterDeploymentManager.swift:119-124`) — restrict it to consume only a
+   receipt-bearing gated candidate (or remove/mark test-only). `shouldAutoDeploy` (trust threshold, `:103`) must
+   NOT imply deploy eligibility — eligibility = a valid receipt. The `training.personal_adapter_path` SelfConfig
+   hot-swap is an explicit **owner manual override**: keep it, but route it through a clearly-audited
+   manual-override path (logged, never via the auto-loop's gated deploy), and document it as out-of-gate by design.
+3. **Never review an unavailable/failed eval.** `ExternalReviewGate.review` passes zero deltas
+   (`ExternalReviewGate.swift:224-236`), so an `.unavailable`/failed evaluator must short-circuit to audited
+   `candidate_blocked` → `.idle` WITHOUT calling `review` and WITHOUT entering `.proposing` (`.evaluating→.idle`
+   is legal, `:31`).
+4. **Migration + recovery.** `ImprovementStore` adds nullable columns (pending path, candidate kind, receipt
+   fields) with read/write/mapper updates (`ImprovementStore.swift:208-220,441-470,749-766`). On upgrade, **repair**
+   any persisted `.proposing`/`.deploying` state that lacks a valid receipt → `candidate_blocked`/`.idle` (an
+   in-flight pre-P9 candidate must not deploy ungated after upgrade).
+5. **Shadow evaluator.** It evaluates `currentAdapterPath` (`ShadowEvaluator.swift:108-185`); post-split that's the
+   *deployed* adapter, not the pending candidate. For this PR, keep it pointed at the deployed adapter (correct as
+   shadow A/B of what's live) and explicitly do NOT treat it as the pending candidate's gate. Document; no behavior
+   change to shadow.
+6. **Tests.** Update the intentionally-broken tests (nil-bridge no longer reaches `.proposing`
+   `ImprovementCycleCoordinatorTests.swift:825-839,891-912`; auto-deploy no longer passes on zero delta `:414-430`;
+   `ImprovementState` init gains fields). Add tests for: receipt-required deploy; receipt sha mismatch refused;
+   bypass fenced; fail-closed blocks without calling review; recovery repairs ungated in-flight state.
+
+Persist `AdapterKind` as the candidate's artifact kind (drives evaluator + receipt).
+
+## Risks
+
+- **Daemon A/B harness size**: if `DaemonABEvaluator` scoring is too big for this PR, ship C1 + C4-safety (the hole
+  closes; daemon-lane deploys block until the evaluator lands). Surfaced, not hidden.
+- **Behavior change**: nightly loop will stop auto-deploying until a real eval is wired — intended (it was deploying
+  unsafely). Documented; the proposal/audit path tells the user what to configure.
+- **State migration**: adding `pendingAdapterPath` to the improvement DB needs a migration; keep it additive/nullable.

--- a/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
@@ -493,40 +493,24 @@ actor ImprovementCycleCoordinator {
                 return
             }
 
-            // 5b–5c. Produce a deployable adapter. On the daemon lane, train a
-            // portable PEFT adapter and convert it to a GGUF the llama.cpp daemon
-            // loads via engine.reload (P3/C3); otherwise use the legacy detached
-            // mlx-tune path (`.safetensors`, MLX-only).
-            let adapterPath: String
+            // 5b–5c. Produce a deployable adapter via the selected TrainingBackend
+            // (P9/C1 seam). Daemon lane → PEFT adapter converted to a GGUF the
+            // llama.cpp daemon loads (P3/C3); otherwise the legacy detached
+            // mlx-tune dir lane (`.safetensors`, MLX-only). The candidate's `kind`
+            // drives the lane-appropriate eval gate + deploy path (P9/C4).
+            let backend: TrainingBackend
             if let daemonBase = daemonTrainingBaseModel {
-                guard let sftPath = exportResult.outputFiles["sft_export"] else {
-                    NSLog("ImprovementCycleCoordinator: no sft_export path in export result")
-                    try? await forceIdle(error: "missing_sft_export")
-                    return
-                }
-                NSLog(
-                    "ImprovementCycleCoordinator: daemon lane — train_peft + GGUF convert (base=%@)",
-                    daemonBase)
-                let peft = try await bridge.trainPeftAndConvert(
-                    sftPath: sftPath, baseModel: daemonBase)
-                // The GGUF (not the PEFT dir) is what the daemon loads.
-                adapterPath = peft.ggufPath
-                NSLog(
-                    "ImprovementCycleCoordinator: daemon training complete — gguf=%@ loss=%.4g",
-                    peft.ggufPath, peft.finalLoss)
+                backend = PeftDaemonBackend(bridge: bridge, baseModel: daemonBase)
             } else {
-                let mode: TrainingMode = exportResult.dpoPairs >= 5 ? .dpo : .sft
-                NSLog("ImprovementCycleCoordinator: launching %@ training (mlx-tune)", mode.rawValue)
-                let launchResult = try await bridge.launchTraining(mode: mode)
-                NSLog(
-                    "ImprovementCycleCoordinator: training started (pid=%d, model=%@, adapter=%@)",
-                    launchResult.pid, launchResult.modelId, launchResult.adapterPath
-                )
-                // Poll until the detached training worker completes.
-                adapterPath = try await bridge.pollUntilComplete()
+                backend = MlxTuneBackend(bridge: bridge)
             }
+            NSLog("ImprovementCycleCoordinator: training via %@ backend", backend.id)
+            let candidate = try await backend.trainAdapter(export: exportResult)
+            let adapterPath = candidate.path
             producedAdapterPath = adapterPath
-            NSLog("ImprovementCycleCoordinator: training complete — adapter at %@", adapterPath)
+            NSLog(
+                "ImprovementCycleCoordinator: training complete — adapter at %@ (kind=%@)",
+                adapterPath, candidate.kind.rawValue)
 
             // 5d. Store adapter path in improvement state.
             try await store.ensureStateRow()
@@ -542,6 +526,17 @@ actor ImprovementCycleCoordinator {
                 try? await forceIdle(error: "training_failed: \(error.localizedDescription)")
                 return
             }
+        } catch let error as TrainingBackendError {
+            // Preserve the pre-P9 diagnostic for the daemon-lane missing dataset
+            // case (surfaced via health reporting as `lastCycleError`).
+            if case .missingDataset("sft_export") = error {
+                NSLog("ImprovementCycleCoordinator: no sft_export path in export result")
+                try? await forceIdle(error: "missing_sft_export")
+            } else {
+                NSLog("ImprovementCycleCoordinator: training failed: %@", error.description)
+                try? await forceIdle(error: "training_failed: \(error.description)")
+            }
+            return
         } catch {
             NSLog("ImprovementCycleCoordinator: training failed: %@", error.localizedDescription)
             try? await forceIdle(error: "training_failed: \(error.localizedDescription)")

--- a/native/macos/Fae/Sources/Fae/Scheduler/TrainingBackend.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/TrainingBackend.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// The on-disk form of a trained adapter — determines which evaluator (P9/C4)
+/// and which deploy path can consume it.
+enum AdapterKind: String, Sendable, Codable {
+    /// A GGUF the llama.cpp daemon loads via `engine.reload` (PEFT/daemon lane).
+    case gguf
+    /// An MLX adapter directory loaded by the in-process MLX engine (mlx-tune lane).
+    case mlxDir
+}
+
+/// A freshly trained adapter awaiting evaluation. Carries the artifact `kind` so
+/// the eval gate and deploy path (P9/C4) pick lane-appropriate handling.
+struct AdapterCandidate: Sendable {
+    let path: String
+    let kind: AdapterKind
+    /// Final training loss when the backend reports it (PEFT lane); nil for the
+    /// detached mlx-tune lane, which doesn't surface a loss synchronously.
+    let finalLoss: Double?
+}
+
+/// Errors surfaced by a training backend.
+enum TrainingBackendError: Error, LocalizedError, CustomStringConvertible {
+    /// A required exported dataset artifact (e.g. `sft_export`) was absent.
+    case missingDataset(String)
+
+    var description: String {
+        switch self {
+        case .missingDataset(let key): return "missing dataset artifact: \(key)"
+        }
+    }
+
+    /// Mirror `description` so `localizedDescription` is meaningful when this
+    /// error reaches a generic `catch` (not an opaque NSError string).
+    var errorDescription: String? { description }
+}
+
+/// P9/C1 — the seam over the concrete training lanes.
+///
+/// `ImprovementCycleCoordinator` selects a backend and calls `trainAdapter`; the
+/// lane mechanics stay in `TrainingBridge`. This makes the lane swap explicit and
+/// unit-testable, and the returned `AdapterCandidate.kind` drives the C4 evaluator
+/// + deploy gate. Conformers today: `MlxTuneBackend` (Apple MLX dir) and
+/// `PeftDaemonBackend` (portable PEFT → GGUF for the llama.cpp daemon). A
+/// CUDA-only `UnslothBackend` is a planned future conformer — not implemented.
+protocol TrainingBackend: Sendable {
+    /// Stable identifier for logs/receipts (e.g. "mlx", "peft").
+    var id: String { get }
+    /// Train and produce a deployable adapter candidate from an exported dataset.
+    func trainAdapter(export: ExportResult) async throws -> AdapterCandidate
+}
+
+/// mlx-tune lane: detached SFT/DPO training producing an MLX adapter directory.
+struct MlxTuneBackend: TrainingBackend {
+    let bridge: TrainingBridge
+    var id: String { "mlx" }
+
+    func trainAdapter(export: ExportResult) async throws -> AdapterCandidate {
+        let mode: TrainingMode = export.dpoPairs >= 5 ? .dpo : .sft
+        let launch = try await bridge.launchTraining(mode: mode)
+        NSLog(
+            "MlxTuneBackend: training started (pid=%d, model=%@, mode=%@)",
+            launch.pid, launch.modelId, mode.rawValue
+        )
+        let path = try await bridge.pollUntilComplete()
+        return AdapterCandidate(path: path, kind: .mlxDir, finalLoss: nil)
+    }
+}
+
+/// PEFT/daemon lane: train a portable PEFT adapter and convert it to a GGUF the
+/// llama.cpp daemon loads via `engine.reload` (P3/C3).
+struct PeftDaemonBackend: TrainingBackend {
+    let bridge: TrainingBridge
+    let baseModel: String
+    var id: String { "peft" }
+
+    func trainAdapter(export: ExportResult) async throws -> AdapterCandidate {
+        guard let sftPath = export.outputFiles["sft_export"] else {
+            throw TrainingBackendError.missingDataset("sft_export")
+        }
+        let peft = try await bridge.trainPeftAndConvert(sftPath: sftPath, baseModel: baseModel)
+        NSLog(
+            "PeftDaemonBackend: training complete — gguf=%@ loss=%.4g",
+            peft.ggufPath, peft.finalLoss
+        )
+        return AdapterCandidate(path: peft.ggufPath, kind: .gguf, finalLoss: peft.finalLoss)
+    }
+}


### PR DESCRIPTION
## Summary

P9/C1 (staged — first of two PRs). A **behavior-preserving** refactor that extracts a `TrainingBackend` seam over the two existing training lanes, so the lane swap is explicit + unit-testable and the produced `AdapterCandidate.kind` (`.gguf` vs `.mlxDir`) can drive the lane-appropriate eval gate + deploy path coming in **C4** (PR 2).

Codex gave a second opinion that reframed P9 from "formalize + tighten" into "close a real unsafe-deploy hole + portable eval gate"; the design (`docs/plans/p9-training-seam-gates-design-2026-06-21.md`) captures the full scope. This PR is just the low-risk C1 seam.

## Changes

- **`TrainingBackend.swift`** (new): `AdapterKind`, `AdapterCandidate`, `TrainingBackend` protocol, `MlxTuneBackend` (mlx-tune dir lane), `PeftDaemonBackend` (PEFT→GGUF daemon lane). `UnslothBackend` documented as a future CUDA-only conformer (not implemented).
- **`ImprovementCycleCoordinator`** training step selects a backend and calls `trainAdapter` — identical lane selection (`daemonTrainingBaseModel` nil vs not) and per-lane logic.
- Preserved the pre-P9 health diagnostic: a typed `TrainingBackendError` catch keeps `lastCycleError == "missing_sft_export"` for the daemon-lane missing-dataset case (codex caught this regression); error is `LocalizedError` so generic paths get a meaningful message too.

## Review + verification

- **Codex code review**: REQUEST-CHANGES (the `missing_sft_export` diagnostic regression) → fixed → resolved. Codex independently verified lane selection, MLX/PEFT logic, `AdapterKind` mapping, sendability, no dead code.
- `swift build` clean; **65 training/improvement tests pass** (44 `ImprovementCycleCoordinatorTests` + 21 `TrainingBridgeTests`) — behavior preserved.

## Next

PR 2 (C4): candidate/active state split, persisted **gate receipt** required by deploy, **fail-closed** eval (no real eval → audited `candidate_blocked` → idle, never `.proposing`), fenced bypass deploy paths (`AdapterDeploymentManager` / `training.personal_adapter_path`), store migration + stale-state recovery, shadow-eval handling. This closes the unsafe auto-deploy hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a `TrainingBackend` seam (P9/C1) over the two existing training lanes, replacing an inline `if/else` in `ImprovementCycleCoordinator` with a protocol dispatch through `MlxTuneBackend` and `PeftDaemonBackend`. Lane-selection logic and all side effects are preserved byte-for-byte; the main new surface is `AdapterCandidate.kind`, which will drive the lane-appropriate eval gate and deploy path in C4.

- **`TrainingBackend.swift`** (new): defines `AdapterKind`, `AdapterCandidate`, `TrainingBackendError`, the `TrainingBackend` protocol, and both concrete backends; `TrainingBackendError` is a `LocalizedError` so generic catch paths get a meaningful message.
- **`ImprovementCycleCoordinator.swift`**: replaces the inlined PEFT/MLX branches with backend instantiation + `trainAdapter`; a targeted `catch let error as TrainingBackendError` block re-maps `missingDataset("sft_export")` → `"missing_sft_export"`, preserving the pre-P9 health diagnostic.
- **`docs/plans/p9-training-seam-gates-design-2026-06-21.md`** (new): documents the current unsafe auto-deploy hole, the C1+C4 scope, Codex review changes, and the staged delivery plan.

<h3>Confidence Score: 4/5</h3>

Safe to merge — this is a pure structural refactor with no behavior change to either training lane.

Lane selection, error recovery, and state writes are identical to the pre-refactor code. The two inline findings are both log/conformance polish rather than functional defects: `AdapterCandidate` missing `Codable` (while `AdapterKind` already has it) will need to be added in C4 anyway, and the `MlxTuneBackend` launch log drops `adapterPath` in favor of `mode`. Neither affects runtime behavior today.

`TrainingBackend.swift` has the two minor suggestions; `ImprovementCycleCoordinator.swift` is straightforward and the error-handler ordering is correct.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| native/macos/Fae/Sources/Fae/Scheduler/TrainingBackend.swift | New file defining the TrainingBackend protocol, AdapterKind/AdapterCandidate value types, TrainingBackendError, and the two concrete backends (MlxTuneBackend, PeftDaemonBackend). Clean design; AdapterCandidate could proactively add Codable conformance since all its fields already support it. |
| native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift | Training step refactored to select a backend and delegate; error handling correctly preserves the missing_sft_export diagnostic. Minor: MlxTuneBackend's launch log now records mode.rawValue where the pre-refactor code recorded launch.adapterPath, slightly reducing diagnostic detail at the launch point. |
| docs/plans/p9-training-seam-gates-design-2026-06-21.md | Design document for the P9 two-PR series; clearly describes the existing unsafe-deploy hole, the C1 seam scope, and the C4 gate requirements. No code changes. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant ICC as ImprovementCycleCoordinator
    participant B as TrainingBackend (selected)
    participant TB as TrainingBridge

    ICC->>ICC: select backend (daemonTrainingBaseModel nil?)
    alt daemon lane
        ICC->>B: PeftDaemonBackend(bridge, baseModel)
    else mlx lane
        ICC->>B: MlxTuneBackend(bridge)
    end
    ICC->>B: trainAdapter(export: exportResult)
    alt PeftDaemonBackend
        B->>B: guard sft_export key (else throw missingDataset)
        B->>TB: trainPeftAndConvert(sftPath, baseModel)
        TB-->>B: PeftResult(ggufPath, finalLoss)
        B-->>ICC: AdapterCandidate(path: ggufPath, kind: .gguf, finalLoss)
    else MlxTuneBackend
        B->>TB: launchTraining(mode)
        TB-->>B: LaunchResult(pid, modelId, adapterPath)
        B->>TB: pollUntilComplete()
        TB-->>B: adapterPath (String)
        B-->>ICC: AdapterCandidate(path, kind: .mlxDir, finalLoss: nil)
    end
    ICC->>ICC: store candidate.path as currentAdapterPath
    note over ICC: candidate.kind logged but not yet persisted (C4)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant ICC as ImprovementCycleCoordinator
    participant B as TrainingBackend (selected)
    participant TB as TrainingBridge

    ICC->>ICC: select backend (daemonTrainingBaseModel nil?)
    alt daemon lane
        ICC->>B: PeftDaemonBackend(bridge, baseModel)
    else mlx lane
        ICC->>B: MlxTuneBackend(bridge)
    end
    ICC->>B: trainAdapter(export: exportResult)
    alt PeftDaemonBackend
        B->>B: guard sft_export key (else throw missingDataset)
        B->>TB: trainPeftAndConvert(sftPath, baseModel)
        TB-->>B: PeftResult(ggufPath, finalLoss)
        B-->>ICC: AdapterCandidate(path: ggufPath, kind: .gguf, finalLoss)
    else MlxTuneBackend
        B->>TB: launchTraining(mode)
        TB-->>B: LaunchResult(pid, modelId, adapterPath)
        B->>TB: pollUntilComplete()
        TB-->>B: adapterPath (String)
        B-->>ICC: AdapterCandidate(path, kind: .mlxDir, finalLoss: nil)
    end
    ICC->>ICC: store candidate.path as currentAdapterPath
    note over ICC: candidate.kind logged but not yet persisted (C4)
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
native/macos/Fae/Sources/Fae/Scheduler/TrainingBackend.swift:14
`AdapterCandidate` is not `Codable`, yet all three of its fields (`String`, `AdapterKind`, `Double?`) already are. C4 will need to persist the candidate kind alongside the path in the improvement store — adding `Codable` now avoids a follow-up conformance addition later and keeps `AdapterKind: Codable` from looking orphaned.

```suggestion
struct AdapterCandidate: Sendable, Codable {
```

### Issue 2 of 2
native/macos/Fae/Sources/Fae/Scheduler/TrainingBackend.swift:61-64
The launch log records `mode.rawValue` where the pre-refactor coordinator logged `launch.adapterPath`. When `pollUntilComplete` eventually returns a different path (or fails), the launch-time adapter directory is no longer visible in logs. Including `launch.adapterPath` here restores that diagnostic without extra effort.

```suggestion
        NSLog(
            "MlxTuneBackend: training started (pid=%d, model=%@, mode=%@, adapter=%@)",
            launch.pid, launch.modelId, mode.rawValue, launch.adapterPath
        )
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(training): P9/C1 — TrainingBack..."](https://github.com/saorsa-labs/fae/commit/b4dbf568916f6cfa99ba3b64568d4c3961842f52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38905301)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->