### PR TITLE
P9/C4 — training-seam + mandatory eval gates (close the unsafe auto-deploy hole)

### DIFF
--- a/docs/architecture/open-gaps-2026-06-16.md
+++ b/docs/architecture/open-gaps-2026-06-16.md
@@ -222,8 +222,12 @@ Owner: [`cross-platform-brain-llamacpp-2026-06-16.md`](./cross-platform-brain-ll
 Owner: [`cross-platform-brain-llamacpp-2026-06-16.md`](./cross-platform-brain-llamacpp-2026-06-16.md)
 §3 + [`full-cross-platform-ml-pipeline-2026-06-11.md`](./full-cross-platform-ml-pipeline-2026-06-11.md).
 Gaps:
-- **C1 — `TrainingBackend` seam** (`prepareDataset / trainAdapter / convertAdapter /
-  evaluateAdapter`) pinned onto the real `TrainingBridge` / `ImprovementCycleCoordinator`.
+- **C1 — `TrainingBackend` seam — ✅ DONE + MERGED (PR #20, squash `11735755`).** Behavior-preserving
+  seam (`TrainingBackend.swift`: `AdapterKind{gguf, mlxDir}`, `AdapterCandidate`,
+  `MlxTuneBackend`/`PeftDaemonBackend`; Unsloth future CUDA-only conformer) pinned onto the real
+  `TrainingBridge` / `ImprovementCycleCoordinator`. Codex caught a regression — the
+  `lastCycleError == "missing_sft_export"` signal is preserved via a typed `TrainingBackendError`
+  catch + `LocalizedError`.
 - **C2 — cross-platform producer** — ✅ **LANDED** (commit c3ff6265). Reframed: one portable
   **`peft`+`transformers`** trainer (`train_peft.py`, device-auto MPS/CUDA/CPU) + `convert_to_gguf.py`
   (PEFT → GGUF via llama.cpp, offline `--base` from HF cache), in the `training-orchestrator` skill
@@ -279,8 +283,26 @@ Gaps:
   `model:management` scope; scale=1 surfaces the adapter-only probe fact, scale=0 removes it). Gate:
   fmt/clippy -D warnings clean, nextest 85/85, swift build clean. **Deferred:** bundled-app `run-dev`
   live proof (release-validation/human-in-loop gate). Formal mandatory FaeBenchmark gate = C4/P9.
-- **C4 — Benchmark gates** remain mandatory (FaeBenchmark) — "LoRA prevents forgetting" was
-  REFUTED; every adapter must pass regression gates before deploy.
+- **C4 — Mandatory eval gates — ✅ STRUCTURALLY DONE (P9/C4 W1–W8, branch `feat/p9-training-seam-gates`
+  @ `74c0758d`, PR #21 open).** Reframed by codex from "formalize + tighten" into "close a REAL
+  unsafe-auto-deploy hole": the nightly loop previously wrote the trained adapter into the live
+  `currentAdapterPath` BEFORE eval, no prod path set `setBenchmarkPath` (so eval always fell to the
+  loss-proxy), a failed loss-eval produced a ZERO delta that `ExternalReviewGate` PASSED, and
+  `performDeploy` shipped that path — adapters auto-deployed with NO real eval. **The hole is now
+  closed:** no path writes `currentAdapterPath` without a verifying, unconsumed, tamper-evident
+  `GateReceipt`{candidatePath, kind, sha256, deltas, evaluatorId, at} minted by an allowlisted real
+  evaluator (sha must match the artifact). The loss-proxy is demoted to a propose-only annotation
+  (NEVER gates); unavailable/failed eval → audited `candidate_blocked` → `.idle` (never reaches
+  `ExternalReviewGate.review` or `.proposing`); bypass deploys are fenced; the `ImprovementStore`
+  migration repairs stale `.proposing`/`.deploying` rows without a receipt on upgrade. **Both lanes
+  have real evaluators:** MLX `.mlxDir` = `FaeBenchmarkEvaluator`; daemon `.gguf` = `DaemonABEvaluator`
+  (A/Bs the live llama.cpp daemon over a SHA-locked held-out suite, `daemon-ab-eval-v1.json`, with
+  restore-on-every-exit as the safety property — the daemon is never left on the un-gated candidate).
+  "LoRA prevents forgetting" was REFUTED, so this regression gate is mandatory before deploy.
+  **Remaining (human-in-loop, NOT blocking the structural gate):** the live daemon-A/B de-risk on real
+  hardware (the `DaemonABEvaluator` is only unit-proven via a mock client) and the held-out eval-set
+  discrimination check — both covered by the runbook
+  [`p9-c4-daemon-ab-live-derisk-2026-06-22.md`](./p9-c4-daemon-ab-live-derisk-2026-06-22.md).
 
 ---
 

--- a/docs/architecture/p9-c4-daemon-ab-live-derisk-2026-06-22.md
+++ b/docs/architecture/p9-c4-daemon-ab-live-derisk-2026-06-22.md
@@ -1,0 +1,185 @@
+# Daemon-A/B live de-risk (P9 / C4, gguf eval lane)
+
+> **Status: DEFERRED — owner/real-hardware runbook.** The `DaemonABEvaluator`
+> (`native/macos/Fae/Sources/Fae/Scheduler/DaemonABEvaluator.swift`) is **unit-proven
+> via a mock `DaemonABClient`** — the A/B orchestration, the per-dimension delta
+> math, and the restore-on-every-exit safety property all have tests. What no test
+> can exercise is the **live** path: a real `fae-daemon` reloading real GGUF LoRA
+> adapters and a real held-out suite that actually *discriminates* a good adapter
+> from a bad one. That is an owner action on a Mac running the daemon LLM lane.
+> **The P9/C4 gate is structurally complete and merged (PR #21) without this — the
+> unsafe auto-deploy hole is closed; this page confirms the live legs.**
+
+## Why this is a smoke, not a gate
+
+The structural safety property is already enforced in code and tests: no path writes
+the live `currentAdapterPath` without a verifying, unconsumed, tamper-evident
+`GateReceipt` minted by an allowlisted real evaluator. For the `.gguf` lane that
+evaluator is `DaemonABEvaluator`, which:
+
+- A/Bs the **live llama.cpp daemon** by reloading the **deployed** adapter, scoring
+  the held-out suite, then reloading the **candidate** and scoring again
+  (`reload(deployed) → score → reload(candidate) → score`), producing a measured
+  per-dimension `EvalDelta`.
+- **Restores the deployed adapter on EVERY exit** (success, throw, timeout,
+  cancellation) and *confirms* it via `runtime.status` — so the live daemon is
+  never left serving the un-gated candidate. This is the deploy-without-receipt
+  hole the series closes, and it is a **hard safety property**, not best-effort.
+
+Unit tests cover all of that with a fake client. The two things only real hardware
+proves are (a) the A/B runs end-to-end against an actual daemon + actual GGUF
+adapters and yields a *measured* (not blocked) delta, and (b) the bundled held-out
+set is **discriminating** — a bad adapter scores measurably worse, not the same.
+
+## Prerequisites
+
+1. **Daemon LLM lane active** — `llm.useDaemonEngine` true, the bundled
+   `llama-server` runtime installed, and a real `fae-daemon` serving Gemma 4 E4B.
+   This is the same setup the bundled app uses (`source ~/.secrets && just run-dev`).
+2. **Two real GGUF LoRA adapters** produced by the P3/C3 producer
+   (`train_peft.py` → `convert_to_gguf.py`, in the `training-orchestrator` skill):
+   - a **deployed baseline** adapter (or none → the daemon base model is the
+     baseline), and
+   - a **candidate** adapter to gate. The `~/llama-spike` workspace already holds
+     such artifacts (`personal-metric*.gguf` etc., per P3/C3).
+3. **Runtime-adapter dev escape** — `FAE_DEV=1` and `FAE_MODELS_LOCK=off`, exactly
+   as P3/C3 used. A runtime LoRA cannot be pinned in `models.lock` (that is *why*
+   the daemon's reload path canonicalizes + SHA-checks the adapter instead); the
+   dev escape lets the daemon load a non-locked GGUF. Production releases must keep
+   the lock ON — this is a dev-only de-risk.
+
+## Real symbols this exercises
+
+| Layer | Symbol |
+|-------|--------|
+| Evaluator | `DaemonABEvaluator.evaluate(candidatePath:baselinePath:)` |
+| Live client | `LiveDaemonABClient` (wraps `DaemonLLMEngine`) |
+| Daemon reload | `DaemonLLMEngine.reloadAdapter(path:)` → daemon `engine.reload` |
+| Daemon scale | `DaemonLLMEngine.setAdapterScale(_:)` → daemon `engine.set_adapter_scale` |
+| Daemon status | `DaemonLLMEngine.runtimeStatus()` → daemon `runtime.status` (`{path, sha256, scale}`) |
+| Per-prompt infer | `DaemonLLMEngine.inferForEval(messages:systemPrompt:options:)` |
+| Registration | `FaeScheduler` → `coordinator.setAdapterEvaluator(daemonEvaluator)` (only when the daemon lane is live AND `DaemonEvalSuite.loadBundled()` SHA-verifies) |
+| Held-out suite | `daemon-ab-eval-v1.json` (SHA-locked via `DaemonEvalSuite.lockedSHA256`) |
+| Gate receipt | `GateReceipt` minted by `ImprovementCycleCoordinator.mintAndStoreGateReceipt`, required by `requireGateReceipt` before deploy |
+
+## Procedure
+
+The eval phase runs inside the nightly improvement cycle. There are two ways to
+drive it; **B is preferred for a focused de-risk** because it isolates the A/B from
+the rest of the cycle.
+
+### A. Trigger the nightly improvement cycle's eval phase
+
+With the daemon lane live, `FaeScheduler` registers the `DaemonABEvaluator` at
+cycle start (see the registration symbol above). Drive a cycle that reaches the
+EVALUATING state — either let `improvement_cycle` fire at 03:00, or force it with
+the `scheduler_trigger` tool / debug console against the `improvement_cycle` task,
+having seeded enough feedback (20+ events, 5+ corrections) and a trained candidate
+GGUF. When the cycle reaches EVALUATING, `DaemonABEvaluator.evaluate` runs the
+`reload(deployed) → score → reload(candidate) → score → restore(deployed)` sequence.
+
+### B. Focused A/B (recommended)
+
+Construct a `DaemonABEvaluator` directly against the live engine and call
+`evaluate` with explicit paths — mirror `FaeScheduler`'s construction:
+
+```swift
+let suite = try DaemonEvalSuite.loadBundled()           // SHA-verifies the bundled set
+let client = LiveDaemonABClient(engine: daemonLLMEngine) // the LIVE daemon
+let evaluator = DaemonABEvaluator(client: client, suite: suite)
+let outcome = try await evaluator.evaluate(
+    candidatePath: "/abs/path/candidate.gguf",
+    baselinePath:  "/abs/path/deployed.gguf")            // nil ⇒ baseline = base model
+print(outcome.delta)                                     // per-dimension EvalDelta
+```
+
+Read the per-dimension delta off `outcome.delta` (toolCalling / faeCapability /
+assistantFit / serialization, in percentage points; `nil` for any dimension the
+A/B could not measure on both sides). Watch the daemon audit log / NSLog for the
+reload + set-scale + restore sequence.
+
+## Pass criteria
+
+1. **Measured, not blocked.** The A/B returns a `GateOutcome` with a *measured*
+   per-dimension `EvalDelta` (deltas present, not `nil`/unavailable). An
+   unavailable/failed eval is `candidate_blocked` → `.idle` by design — that is the
+   fail-closed path, not a pass.
+2. **Restore-on-exit verified (the safety property).** After eval, `runtime.status`
+   shows the daemon back on the **DEPLOYED** adapter (or the base model when none
+   was deployed) — **never the candidate**. Confirm via the daemon audit log /
+   NSLog line `DaemonABEvaluator: restored deployed adapter after eval (…)`. A
+   `restoreUnconfirmed` throw (NSLog `FAILED to restore deployed adapter …
+   (fail-closed)`) is a hard failure: the daemon may be on the un-gated candidate.
+3. **Discrimination — bad candidate is BLOCKED.** Run a deliberately-BAD candidate
+   (e.g. an adapter overfit to garbage, or the base model presented as the
+   "candidate" against a strong deployed adapter). It must produce a **negative**
+   delta and be **blocked** — no receipt, no deploy. This proves the held-out set
+   actually separates good from bad.
+4. **Good candidate passes the full gate.** A genuinely-better candidate produces a
+   non-negative delta, **mints a `GateReceipt`** (sha matching the candidate
+   artifact), and deploys *through* the gate (`requireGateReceipt` consumes the
+   receipt before `currentAdapterPath` is written).
+
+## Eval-set discrimination — known weaknesses (feeds a future `daemon-ab-eval-v2`)
+
+A static read of `daemon-ab-eval-v1.json` (32 examples, 8 per dimension) against
+the `DaemonEvalScorer` rules shows the suite is **structurally sound but skews
+lenient** — every dimension has at least some genuinely discriminating items, but
+several examples any coherent model passes, which compresses the measurable delta:
+
+- **toolCalling (8) — strongest dimension.** 6 `expectToolCall` items check both the
+  tool name AND required arg keys (a real routing+serialization test), plus two
+  `expectNoToolCall` restraint items (`tool-005` "thanks, that's all", `tool-006`
+  "favourite colour?"). This dimension *will* separate a model that mis-routes or
+  drops required args. Keep as-is; it is the load-bearing gate.
+- **serialization (8) — mostly discriminating.** `expectJSONKeys`/`expectJSONArray`
+  (`ser-004/005/007`) and the `SUPERSEDE`-vs-`STORE` item (`ser-003`) are real format
+  tests a sloppy model fails. The four bare `expectLinesPrefixed STORE:` items
+  (`ser-001/002/006/008`) are easier — any model that emits one `STORE:` line passes,
+  regardless of content quality. Weak-ish but not free.
+- **faeCapability (8) — easy trivia, weakly discriminating.** All eight are
+  single-keyword `expectKeywords` factoids (Tokyo, 42, Mars, 366, Shakespeare, CO₂,
+  H₂O, France). Any competent base model and any non-catastrophic candidate both
+  score ~100%, so this dimension contributes **near-zero delta** in practice — it
+  catches only gross capability *regression*, not improvement. This is the weakest
+  dimension for *discrimination* (though useful as a forgetting tripwire).
+- **assistantFit (8) — partly trivial.** The keyword/forbidden items (`fit-001/002/
+  003/005/006/007`) are reasonable persona checks (greeting words present, "as an
+  ai"/"language model" forbidden). But **`fit-004` and `fit-008` are
+  `expectNonEmpty`** — they pass on *any* non-empty answer lacking the forbidden
+  phrases, i.e. essentially free. These two are the clearest "any coherent model
+  passes" examples.
+
+**Net:** the gate is meaningful — toolCalling + the JSON/SUPERSEDE serialization
+items will move the delta for a real change, and the forbidden-phrase checks catch
+persona drift — but `faeCapability` (all trivia) and the two `expectNonEmpty`
+`assistantFit` items add little discrimination and risk a base-vs-candidate tie on
+those dimensions. A future **`daemon-ab-eval-v2`** should: replace the two
+`expectNonEmpty` fit items with keyword/forbidden checks; harden the bare `STORE:`
+serialization items to assert at least key *content* (e.g. `expectKeywords` on the
+extracted value); and add some harder/adversarial capability items (multi-step or
+distractor-laden) so `faeCapability` measures more than rote recall. Any such change
+needs a **new SHA lock** (regenerate `lockedSHA256`) and updated tests — the suite
+is intentionally SHA-pinned so a drifted set is rejected rather than silently
+changing what a pass means.
+
+## What "fail" must look like (safety)
+
+A **failed or interrupted eval must leave the daemon on the DEPLOYED adapter** — the
+restore runs on every exit path (success, throw, timeout, cancellation) precisely so
+an aborted run cannot strand the live daemon on the un-gated candidate. If you kill
+the app mid-eval, confirm `runtime.status` afterwards: it must report the deployed
+adapter, never the candidate. If it reports the candidate, that is a safety
+regression and the `restore-on-every-exit` design did not hold — stop and surface it.
+
+## Scope notes
+
+- This is **dev-only** (`FAE_DEV=1` / `FAE_MODELS_LOCK=off`) because runtime LoRA
+  adapters cannot be `models.lock`-pinned; production keeps the lock ON and the
+  daemon's reload path enforces canonicalize + SHA confinement instead.
+- The **MLX `.mlxDir` lane** uses `FaeBenchmarkEvaluator`, not this A/B; it has its
+  own availability gate (the FaeBenchmark binary must be configured, else the lane
+  stays blocked). This runbook covers only the `.gguf` daemon lane.
+- This smoke is owner-run on real hardware and is intentionally **not** wired into
+  CI (no live daemon + GGUF adapters in the runners). The unit tests + the SHA lock
+  are the automated proofs; this page is the manual confirmation of the live legs.

--- a/docs/plans/p9-c4-consolidated-plan-2026-06-21.md
+++ b/docs/plans/p9-c4-consolidated-plan-2026-06-21.md
@@ -1,0 +1,315 @@
+# P9 / C4 — Consolidated implementation plan (AUTHORITATIVE, 2026-06-21)
+
+> **This is the single source of truth for P9/C4.** It supersedes and folds in:
+> - `p9-training-seam-gates-design-2026-06-21.md` (original design — C1 as-built + C4 sketch)
+> - `p9-c4-gate-integrity-addendum-2026-06-21.md` (the load-bearing integrity design)
+>
+> Every comment from the three design reviews (Claude code-reviewer, Codex, third reviewer) is
+> tracked in the matrix in §2 with a fix and a closing test. **Definition of Done (§6): every row in
+> §2 is `CLOSED` with a passing test, and `just check` is green.** Branch `feat/p9-training-seam-gates`.
+> All work is macOS-testable; no Linux host needed.
+
+---
+
+## 1. Scope
+
+- **C1 — `TrainingBackend` seam: DONE.** Shipped in PR #20 `11735755`
+  (`Sources/Fae/Scheduler/TrainingBackend.swift`: `AdapterKind`, `AdapterCandidate`,
+  `protocol TrainingBackend`, `MlxTuneBackend`, `PeftDaemonBackend`). No further C1 work; this plan
+  only consumes `AdapterCandidate.kind`.
+- **C4 — mandatory, fail-closed eval gate: THIS PLAN.** Closes the verified unsafe-deploy hole and
+  every review finding below.
+
+**The hole (verified at HEAD):** the nightly loop can deploy a freshly-trained adapter with no real
+evaluation. The internal review gate (`ExternalReviewGate.runInternalReview:213-245`) passes both
+**all-nil** and **all-zero** `EvalDelta`s (`compactMap` + `min() ?? 0.0`, only 4 of 5 fields, the
+bridge-absent branch literally builds all-zeros at `ImprovementCycleCoordinator.swift:586-589`), and
+`AdapterDeploymentManager.deploy(adapterPath:store:)` writes `currentAdapterPath` from an arbitrary
+path with no proof of evaluation.
+
+---
+
+## 2. Findings traceability matrix (every review comment)
+
+Severity: **B**locker / **M**ajor / **R**ecommended / **N**it. Status starts `OPEN`; impl flips to
+`CLOSED` only when the linked test passes. IDs are stable references for commits/PR.
+
+| ID | Sev | Source(s) | Finding | Fix (→ §3 / §4) | Closing test (→ §5) |
+|----|-----|-----------|---------|------------------|---------------------|
+| **F1** | B | rev3-M1 | Nil-delta crack: optional `EvalDelta` + `compactMap`/`min() ?? 0.0` ⇒ all-nil PASSES | `decide(MeasuredDeltas)` requires ≥1 measured correctness dim, else `.blockedNoMeasurement` (§3.1) | T-unit-decide, T-golden |
+| **F2** | B | base, rev3-M1 | Zero-delta crack: bridge-absent branch builds all-zeros ⇒ PASS | Delete all-zeros at `ICC:586-589`; unmeasured ⇒ empty `measured` ⇒ block (§3.1) | T-unit-decide, T-golden |
+| **F3** | B | rev3-M2, rev2, codex#1 | Receipt forgeable / state-enum is not deploy authority | Un-forgeable `GateReceipt` (single mint path + allowlist + HMAC), `deploy(receipt:)` verifies (§3.2) | T-forgery, T-golden |
+| **F4** | B | rev3-M5, rev1-M1, rev2 | `AdapterDeploymentManager.deploy(adapterPath:)` is a public receipt-free bypass | Change signature to `deploy(receipt:store:)`; verify before write (§3.2, §4-W4) | T-golden, T-replay |
+| **F5** | B | rev1-B1, codex#5 | ShadowEvaluator must source the **deployed** adapter, never the pending candidate | Verify `ShadowEvaluator` reads deployed path; add invariant + test (§3.5) | T-shadow-source |
+| **F6** | M | rev1-M2 | `approveDeployment` can deploy a `.concern` proposal that holds no receipt | Proposal carries its receipt; approve requires a verifying receipt (§3.2) | T-approve-concern |
+| **F7** | M | rev3-M3, rev2, codex#2 | Objective contradicts kept ungated paths (`personal_adapter_path`, startup auto-load) | Restate Objective loop-scoped; route hot-swap through audited out-of-gate hatch (§3.3) | T-manual-override-audited |
+| **F8** | M | rev3-M4 | `FaeBenchmark --model auto` rejected ⇒ `FaeBenchmarkEvaluator` blocks the MLX lane too | Fix `--model auto` + adapter-mode JSON schema; ships with C4-capability MLX lane (§3.4, §4-W7) | T-benchmark-auto |
+| **F9** | M | rev1-M3, rev3-R4 | TOCTOU: sha checked at decision, engine loads by path later | Verify digest at deploy decision; document load path trusted (scope G2) (§3.2) | T-tamper |
+| **F10** | M | rev3-R4, codex#5 | MLX-dir hashing unstated (path hash meaningless for a dir) | Canonical recursive sorted content manifest + symlink-escape validation (§3.2) | T-mlxdir-digest |
+| **F11** | M | rev2, codex#4 | Recovery too narrow: pre-P9 `.training`/`.evaluating` can hold an ungated live candidate | Recovery repairs ANY non-idle state lacking a verifying receipt → `.idle`/blocked (§3.6) | T-recovery |
+| **F12** | M | rev3-R3 | Evaluator baseline is base model, not the live deployed adapter (can pass while regressing) | Baseline = deployed adapter (scale-0 = deployed); record `baseModelId`/deployed in receipt (§3.4) | T-baseline-deployed |
+| **F13** | M | rev3-M2, codex#5 | Receipt schema underspecified (replay/identity) | Add cycleId, kind, digest, measured, evaluatorId, baseModelId, evalSuiteVersion, gatePolicyVersion, receiptVersion; single-use (§3.2) | T-replay, T-policy-version |
+| **F14** | M | rev3-R1 | Silent nightly dead-loop: C4-safety w/o `DaemonABEvaluator`; no ActionItem surface exists | Refuse-to-train a lane with no evaluator (audited `lane_no_evaluator`); surface in briefing (§3.7, §4-W6) | T-no-evaluator-refuses-train |
+| **F15** | M | rev1-m2 | State-split + fail-closed must land atomically or "loop blocks" isn't delivered | Single PR; W2+W3+W4 are one atomic change; ordering enforced (§4) | T-golden |
+| **F16** | M | codex#3, rev3-R5, rev1-m3 | Must NOT call `reviewGate.review` on unavailable/failed eval | `.blockedNoMeasurement` short-circuits to audited block → `.idle`, no `review()` (§3.1). **Deferred W1→W4** (lands with audited candidate_blocked + receipt backstop; W1 already fail-closes via the gate rule so no deploy occurs). | T-golden (review spy = 0 calls) |
+| **F17** | R | rev3-R2 | Rollback re-promotion is ungated | Allowed (path was once receipt-verified) but emits audited `rollback` event (§3.3) | T-rollback-audited |
+| **F18** | R | rev3-R5 | `EvalOutcome` collides with `ShadowEvaluator`; `EvalDelta`/`AdapterDeltas` duplication | Rename evaluator outcome `GateOutcome`; keep single `EvalDelta` transport; `baseModelId` on candidate inputs (§3.8) | compiles; T-naming (grep guard) |
+| **F19** | R | rev1-n2, codex#4 | `try?`-swallowed errors on persistence; new receipt writes must fail loud | Use real `try` on receipt/state writes; surface failures (Rule 12) (§3.6) | T-receipt-write-fails-loud |
+| **F20** | R | rev3-missing | No golden production-wiring E2E test (highest-value regression guard) | Add `testGoldenProductionWiring_*` with real object graph (§5) | T-golden |
+| **F21** | R | rev3-missing | `AdapterKind`↔engine mismatch possible at deploy (gguf→MLX or dir→daemon) | Deploy-time lane check: gguf→daemon, mlxDir→MLX; mismatch blocks (§3.3) | T-kind-engine-mismatch |
+| **F22** | R | rev3-missing | `pendingAdapterPath` cleanup on block/reject/deploy | Clear pending path + unconsumed receipt on every terminal transition (§3.6) | T-pending-cleanup |
+| **F23** | R | rev3-missing, codex#5 | Eval-set drift / false-pass; evaluator is the trust root | `evalSuiteVersion` in receipt; `gatePolicyVersion` bump invalidates stale receipts (§3.2, open Q3) | T-policy-version |
+| **F24** | N | rev1-m1 | Stale line numbers throughout the original design doc | Re-anchor to symbols in this plan; cite symbols not line numbers | review |
+| **F25** | N | rev1-n1, codex#2 | Owner-override provenance receipt? | Open Q1 — default: audited security-event log only, out-of-gate (§7) | n/a (decision) |
+| **F26** | — | rev1-B2 | "Migration mechanism doesn't exist" | **REFUTED at HEAD** — `ImprovementStore:222-243` already does guarded `ALTER TABLE ADD COLUMN`. Follow that pattern. | `CLOSED-NOACTION` |
+
+> Already-folded Codex APPROVE-WITH-CHANGES items from the base doc (persisted receipt, fence bypass,
+> never-review-unavailable, migration+recovery, shadow-on-deployed, update broken tests) map to
+> F3/F4, F11, F16, F5, and §5 respectively — kept here so nothing is lost.
+
+---
+
+## 3. Design (the fixes)
+
+### 3.1 Gate rule — measured-or-blocked (F1, F2, F16)
+`EvalDelta` (optional fields) stays the transport. The gate consumes `MeasuredDeltas` where a `nil`
+field means **not measured** (NOT 0.0):
+
+```swift
+struct MeasuredDeltas: Sendable {
+    let measured: [GateDimension: Double]   // .toolCalling/.faeCapability/.assistantFit/.serialization
+    let throughputDelta: Double?            // advisory only — never gates
+}
+enum GateDecision: Sendable { case pass, concern, fail, blockedNoMeasurement }
+
+func decide(_ d: MeasuredDeltas) -> GateDecision {
+    let v = Array(d.measured.values)
+    guard !v.isEmpty else { return .blockedNoMeasurement }   // nothing measured
+    if v.contains(where: { $0 < -5.0 }) { return .fail }
+    if v.contains(where: { $0 < 0.0 })  { return .concern }
+    if v.contains(where: { $0 > 0.0 })  { return .pass }     // ≥1 real improvement, no regression
+    return .blockedNoMeasurement                              // all-flat ≈ non-measurement
+}
+```
+- An all-flat (all-zero) measured result is treated as `.blockedNoMeasurement`: it is
+  indistinguishable from a non-measurement and must not auto-deploy (matches the §5 truth table).
+- Delete the all-zeros `EvalDelta` at `ICC:586-589`; the bridge-absent / benchmark-unavailable path
+  yields **empty `measured`** (`EvalDelta.unmeasured`, all-nil). **[DONE in W1.]**
+- **W1 (landed):** the gate rule itself fail-closes — `runInternalReview` delegates to
+  `AdapterGate.decide`, so internal review can never certify an unmeasured/all-flat candidate. A
+  test/interim `injectedMeasuredDelta` seam (formalized by W7's `AdapterEvaluator`) lets the gate be
+  exercised with a real measured delta. The loss-proxy is demoted to advisory logging.
+- **W4 (F16):** the coordinator additionally **short-circuits** a `.blockedNoMeasurement` candidate —
+  audited `candidate_blocked(reason)`, clear pending (§3.6), `forceIdle`, and **do not** call
+  `reviewGate.review`, **do not** enter `.proposing`. (Deferred from W1 to land with the audited
+  candidate_blocked state + the receipt deploy gate, which is the real backstop; until then an
+  unmeasured candidate still *fails* internal review, so it cannot deploy.)
+- Loss-proxy (`lossBasedEvalDelta:805-822`) may annotate proposal text but contributes **zero**
+  entries to `measured`.
+
+### 3.2 `GateReceipt` — un-forgeable, single-use, lane-correct (F3, F4, F9, F10, F13, F23)
+Threat model: local single-user; the real risk is **accidental re-opening** (a future path, a test
+helper in prod, a stale row), not a motivated local attacker. Controls are structural; HMAC is
+tamper-evidence/defense-in-depth.
+
+```swift
+struct GateReceipt: Codable, Sendable {
+    let cycleId, candidatePath: String
+    let kind: AdapterKind
+    let artifactDigest: String       // §3.2 digest, NOT a path hash
+    let measured: [String: Double]
+    let decision: String             // only "pass" is ever persisted
+    let evaluatorId: String          // must be on allowlist
+    let baseModelId: String          // evaluated against THIS deployed baseline (F12)
+    let evalSuiteVersion: String
+    let gatePolicyVersion: Int        // bump when decide() changes ⇒ old receipts invalid
+    let receiptVersion: Int
+    let mintedAt: String
+    let hmac: String                  // HMAC-SHA256 over canonical encoding, key in Keychain
+    // No accessible public init — minted ONLY through the evaluator seam.
+}
+```
+- **Single mint path:** only `AdapterEvaluator` conformers can construct a verifying receipt (move-only
+  `GateMinter` capability, or module-internal init + mint-time allowlist assertion). No other type can
+  produce a receipt whose HMAC verifies.
+- **Allowlist:** `allowedEvaluators = ["DaemonABEvaluator","FaeBenchmarkEvaluator"]`; loss-proxy absent.
+- **Digest (kind-driven):** `.gguf` = file SHA-256; `.mlxDir` = recursive **sorted content manifest**
+  (`sort by relpath; hash relpath\0fileSHA\0…; SHA-256 the whole`) with symlink-escape validation (F10).
+- **Single-use:** `consumed_at` stamped in the SAME transaction as `pending → current`; consumed or
+  `gatePolicyVersion`-stale receipts fail verification (F13/F23).
+- **TOCTOU (F9):** `verify` recomputes the digest at the deploy decision and requires equality. G2 is
+  scoped to "tamper-evidence at deploy decision," not engine-load-time binding (owner's machine trusted).
+- **Key:** per-install random `SymmetricKey` in **Keychain**, not `fae.db`, created first run.
+
+### 3.3 Deploy boundary — receipt is the only authority (F4, F6, F7, F17, F21)
+| Sink (HEAD) | Change |
+|---|---|
+| Auto-loop deploy (`ICC` post-PASS, `:646`+) | promote `pending→current` only via `deploy(receipt:)` inside one txn |
+| `AdapterDeploymentManager.deploy(adapterPath:store:)` `:119` | **→ `deploy(receipt: GateReceipt, store:)`**; verify (allowlist+digest+single-use+policyVersion+kind↔engine) before writing `currentAdapterPath`. No raw-path prod entry. |
+| `approveDeployment()` | approvable only if the held proposal carries a verifying receipt for that exact candidate; `.concern` proposals hold no receipt ⇒ not approvable (F6) |
+| `rollback()` `:136` | re-promotes a once-deployed path; allowed without fresh receipt but emits audited `rollback` event (F17) |
+| `training.personal_adapter_path` → `core.swapPersonalAdapter` `FaeCore.swift:2380` | explicit **owner manual override**, out-of-gate by design; route through audited `manual_adapter_override` security event (F7) |
+| Startup auto-load of `currentAdapterPath` | safe once only receipt-verified paths reach `currentAdapterPath`; add deploy-time **kind↔engine** check: gguf→daemon, mlxDir→MLX, mismatch blocks (F21) |
+
+**Objective (restated, F7):** *"No adapter is deployed by the autonomous improvement loop without a
+verifying `GateReceipt`. The owner may manually override via `training.personal_adapter_path`, which
+is audited and explicitly out-of-gate."*
+
+### 3.4 `AdapterEvaluator` seam (F8, F12)
+```swift
+protocol AdapterEvaluator: Sendable {
+    var id: String { get }                     // on the allowlist
+    func evaluate(_ candidate: AdapterCandidate, baseline: DeployedBaseline)
+        async throws -> GateOutcome             // measured deltas + minted receipt on .pass
+}
+```
+- `DaemonABEvaluator` (`.gguf`): scale-0 = **deployed adapter** (or base if none) vs scale-1 =
+  candidate on a held-out set (F12). **C4-capability** (larger; may follow).
+- `FaeBenchmarkEvaluator` (`.mlxDir`): existing FaeBenchmark, **with `--model auto` reject fixed**
+  (`FaeBenchmark` CLI) and the adapter-mode output schema aligned to what we parse (F8). If those
+  aren't fixed it must report unavailable, never silently pass.
+- No evaluator for a lane ⇒ that lane is treated as "no evaluator" (F14).
+
+### 3.5 ShadowEvaluator (F5)
+Confirm `ShadowEvaluator` sources the **deployed** adapter, never `pendingAdapterPath`. Add an
+explicit invariant + test; no behavior change intended — this is a correctness guard against the
+state split accidentally re-pointing it.
+
+### 3.6 State, migration, recovery, cleanup (F11, F19, F22, F26)
+- **State:** add `pendingAdapterPath`, `pendingAdapterKind`, `pendingCycleId` to `ImprovementState`;
+  `currentAdapterPath`/`previousAdapterPath` stay the deployed+rollback pointers.
+- **Migration:** follow the existing guarded pattern (`PRAGMA table_info` + `if !contains ALTER ADD
+  COLUMN`, `:222-243`) for the three new columns; `CREATE TABLE IF NOT EXISTS gate_receipts` (§ addendum).
+  Exhaustive create/select/update/insert/mapper updates (codex#4).
+- **Recovery (on upgrade/startup):** repair ANY non-idle state (`.training/.evaluating/.proposing/
+  .deploying`) that lacks a verifying receipt for its pending/current candidate → audited
+  `candidate_blocked` → `.idle`. Covers pre-P9 rows whose `currentAdapterPath` was set pre-eval (F11).
+- **Cleanup (F22):** every terminal transition (block/reject/deploy-success) clears `pendingAdapterPath`
+  and deletes/marks any unconsumed receipt for that cycle.
+- **Fail-loud (F19):** receipt/state writes use real `try`; surfaced on failure (no `try?`).
+
+### 3.7 Refuse-to-train without an evaluator (F14)
+Before launching training for a lane, check an evaluator exists+available for that `AdapterKind`. If
+not: skip with audited `lane_no_evaluator`, surface in the morning-briefing text, do not burn a
+training run. (No ActionItem system exists yet — this is the interim surface.)
+
+### 3.8 Swift hygiene (F18, F24)
+Rename evaluator outcome → `GateOutcome` (avoid `ShadowEvaluator` collision); single `EvalDelta`
+transport (no parallel `AdapterDeltas`); add `baseModelId`/`DeployedBaseline` to evaluator inputs;
+cite symbols not line numbers going forward.
+
+---
+
+## 4. Implementation work breakdown (ordered)
+
+Atomic safety set = **W2–W5 ship together** (F15); a partial split would leave a window where a
+blocked lane still mutated the live path.
+
+- **W1 — Gate rule. [LANDED]** `GateDimension`/`MeasuredDeltas`/`GateDecision`/`AdapterGate.decide` +
+  `EvalDelta.measuredDeltas`/`.unmeasured` (`ExternalReviewGate.swift`); `runInternalReview` delegates
+  to `decide` (fail-closes on unmeasured/all-flat); delete all-zeros branch `ICC:586-589` → `.unmeasured`;
+  loss-proxy demoted to advisory; interim `injectedMeasuredDelta` seam (W7 formalizes). Closes **F1, F2**.
+  (F16 — the external-review short-circuit — deferred to W4; W1's gate rule already prevents any
+  unmeasured deploy by failing internal review.) Existing review-gate/proposing tests updated to the
+  fail-closed semantics / a real injected measured delta.
+- **W2 — Receipt type + persistence.** `GateReceipt`, `GateMinter`, allowlist, HMAC (Keychain key),
+  kind-driven digest (+mlxDir manifest+symlink check), `gate_receipts` table + state columns +
+  migration + mappers, single-use/consume. Closes **F3, F10, F13, F19, F23, F26(noaction)**.
+- **W3 — State split.** Training writes `pendingAdapterPath`/kind/cycleId only (never
+  `currentAdapterPath`); `.blockedNoMeasurement` path; cleanup on terminal transitions.
+  Closes **F2(wire), F22**; enables **F15**.
+- **W4 — Deploy fencing.** `AdapterDeploymentManager.deploy(receipt:store:)`; coordinator promotes via
+  receipt verify (digest+allowlist+single-use+policyVersion+kind↔engine); `approveDeployment` requires
+  receipt; rollback audited; `personal_adapter_path` audited out-of-gate hatch; **F16** — short-circuit
+  a `.blockedNoMeasurement` candidate to audited `candidate_blocked` → `.idle` without calling
+  `reviewGate.review`. Closes **F4, F6, F7, F9, F16, F17, F21**.
+- **W5 — Recovery + ShadowEvaluator guard.** Upgrade/startup repair of ungated non-idle states;
+  ShadowEvaluator deployed-source invariant. Closes **F5, F11**. (W2–W5 = the atomic safety PR, F15.)
+- **W6 — Refuse-to-train without evaluator.** Lane evaluator-availability check + audited skip +
+  briefing surface. Closes **F14**.
+- **W7 — `AdapterEvaluator` seam + FaeBenchmark fixes (C4-capability).** `GateOutcome`, evaluator
+  protocol, `FaeBenchmarkEvaluator` (+`--model auto`/schema fix), baseline=deployed; `DaemonABEvaluator`
+  may be a tracked follow-on (lane blocks safely until it lands). Closes **F8, F12, F18**.
+- **W8 — Tests.** All of §5, incl. the golden E2E. Closes **F20** and verifies all above.
+
+> Staging: **W1–W6 + W8** is the safety release — closes the hole with NO real evaluator (loop blocks,
+> audited; lanes refuse-to-train). **W7** unblocks actual personalization deploys. If `DaemonABEvaluator`
+> is too large for this PR, ship it separately; the daemon lane stays safely blocked meanwhile.
+
+---
+
+## 5. Test plan (each maps to finding IDs)
+
+Unit:
+- **T-unit-decide** (F1,F2): truth table for `decide` incl. empty-measured→`.blockedNoMeasurement`,
+  all-zero→`.blockedNoMeasurement` (NOT pass), one `-6`→`.fail`, one `-2`→`.concern`, all `+`→`.pass`.
+- **T-mlxdir-digest** (F10): dir manifest stable under reorder; changes when one file mutates; symlink
+  escaping root rejected.
+- **T-policy-version** (F13,F23): receipt with old `gatePolicyVersion` fails verify; consumed receipt fails.
+- **T-receipt-write-fails-loud** (F19): injected store-write failure propagates (no silent swallow).
+- **T-naming** (F18): grep guard — no `EvalOutcome`; single `EvalDelta` definition.
+
+Integration / golden:
+- **T-golden — `testGoldenProductionWiring_noDeployWithoutReceipt`** (F15,F16,F20, exercises F1–F4):
+  real object graph (temp-DB `ImprovementStore`, real `ExternalReviewGate` with a **review spy**, real
+  `AdapterDeploymentManager`, stub `TrainingBackend`, Keychain key). **No evaluator** ⇒
+  `currentAdapterPath` unchanged, `.idle`, audited `candidate_blocked`, **review spy asserts 0 calls**,
+  no `gate_receipts` row. **Stub evaluator returns `{toolCalling:+3}`** ⇒ exactly one consumed
+  receipt, hmac verifies, `currentAdapterPath==candidate`, digest recomputed matches.
+- **T-tamper** (F9): mutate candidate bytes after mint, before deploy ⇒ deploy refuses, path unchanged.
+- **T-forgery** (F3): hand-inserted `gate_receipts` row w/ wrong hmac ⇒ verify rejects, deploy refuses.
+- **T-replay** (F4,F13): consumed receipt from cycle A presented for candidate B ⇒ rejects.
+- **T-approve-concern** (F6): `.concern` proposal (no receipt) ⇒ `approveDeployment` refuses to deploy.
+- **T-manual-override-audited** (F7): `personal_adapter_path` swap emits `manual_adapter_override` audit,
+  does not touch the gated path.
+- **T-kind-engine-mismatch** (F21): gguf candidate aimed at MLX engine (or vice-versa) ⇒ blocked.
+- **T-no-evaluator-refuses-train** (F14): lane w/o evaluator ⇒ training NOT launched, audited
+  `lane_no_evaluator`.
+- **T-recovery** (F11): seed a pre-P9 `.evaluating` row with `currentAdapterPath` set + no receipt ⇒
+  upgrade repairs to `.idle`, candidate not deployed.
+- **T-baseline-deployed** (F12): evaluator baseline is the deployed adapter, not base model.
+- **T-shadow-source** (F5): ShadowEvaluator reads deployed path; never the pending candidate.
+- **T-pending-cleanup** (F22): block/reject/deploy all clear `pendingAdapterPath` + unconsumed receipt.
+- **T-benchmark-auto** (F8): `FaeBenchmark --model auto` accepted; adapter-mode JSON parses (or
+  evaluator reports unavailable, never silent pass).
+
+Update intentionally-broken existing tests (codex#6): `ImprovementCycleCoordinatorTests` nil-bridge
+cases that expected `.proposing`/zero-delta pass (`:410-419, 824-842`) — they now expect
+`candidate_blocked`/`.idle`; `ImprovementState` init gains fields.
+
+Rule 9: every test encodes WHY ("an un-evaluated candidate is never deployable" / "a forged or stale
+receipt never deploys") so it fails the moment someone re-opens the path.
+
+---
+
+## 6. Definition of Done
+
+1. **Every row in §2 is `CLOSED`** (or `CLOSED-NOACTION` for F26) with its linked test passing.
+2. `just check` green (build + full test suite) on `feat/p9-training-seam-gates`.
+3. No `unwrap/expect/panic/try?` on the new gate/receipt/deploy/persistence paths (Rule 12; F19).
+4. The golden E2E (T-golden) passes in both the no-evaluator (blocks) and evaluator-present (deploys
+   with receipt) configurations.
+5. codex review on the diff confirms no remaining ungated `currentAdapterPath` writer.
+6. Base design doc + addendum carry the "superseded by this plan" banner; this plan is the reference.
+7. Obsidian vault note synced (repo doc-sync rule) — **deferred until implementation is complete**
+   (owner decision, 2026-06-21); do not sync mid-flight.
+
+---
+
+## 7. Open questions (decide before/with W7)
+- **Q1 (F25):** manual-override provenance — audited security-event log only (default), or also mint a
+  provenance receipt? *Leaning: log only; out-of-gate by design.*
+- **Q2:** `DaemonABEvaluator` promotion threshold — reuse ShadowEvaluator's 60% win-rate, or a
+  delta-threshold consistent with `decide`'s ±5%?
+- **Q3 (F23):** where the held-out eval set lives + how `evalSuiteVersion`/`gatePolicyVersion` are
+  provenance-tracked so bumps invalidate stale receipts.
+- **Q4 (F14): RESOLVED — refuse-to-train.** A lane with no available evaluator is skipped before the
+  training run (audited `lane_no_evaluator`, surfaced in the briefing); we do not burn a run to then
+  block. (Owner decision, 2026-06-21.)
+
+## 8. Risks
+- **DaemonABEvaluator size** — if W7's daemon harness is too big, ship W1–W6+W8; daemon lane blocks
+  safely (no regression vs today's unsafe deploy). Surfaced, not hidden.
+- **Behavior change** — nightly loop stops auto-deploying until a real evaluator is wired; intended.
+  The audited block + briefing text tells the user what to configure.
+- **Atomicity (F15)** — W2–W5 must land together; a partial merge re-opens the window.

--- a/docs/plans/p9-c4-gate-integrity-addendum-2026-06-21.md
+++ b/docs/plans/p9-c4-gate-integrity-addendum-2026-06-21.md
@@ -1,0 +1,302 @@
+# P9 / C4 — Gate integrity addendum: the evaluator→receipt→deploy chain (2026-06-21)
+
+> **Folded into `p9-c4-consolidated-plan-2026-06-21.md` (AUTHORITATIVE).** Use that plan as the
+> implementation reference and its §2 matrix as the checklist; this doc is retained as the detailed
+> rationale behind the gate/receipt design.
+>
+> Companion to `p9-training-seam-gates-design-2026-06-21.md`. This addendum fixes the
+> findings that defeat the headline property ("no adapter deploys without a real eval")
+> from three independent design reviews (Claude code-reviewer, Codex, third reviewer).
+> Grounded against HEAD — symbols + line refs verified 2026-06-21, branch
+> `feat/p9-training-seam-gates`.
+
+## 0. Corrections to the base design doc (stale/wrong-vs-HEAD)
+
+These must be folded into the base doc before implementation:
+
+1. **C1 is DONE, not proposed.** `Sources/Fae/Scheduler/TrainingBackend.swift` already ships
+   `AdapterKind{gguf,mlxDir}`, `AdapterCandidate{path,kind,finalLoss}`, `protocol TrainingBackend`,
+   `MlxTuneBackend`, `PeftDaemonBackend` (merged PR #20 `11735755`). Rewrite the C1 section as
+   "as-built"; this addendum + C4 are the only open work.
+2. **The migration mechanism exists.** `ImprovementStore.createSchema` uses
+   `PRAGMA table_info(improvement_state)` + guarded `ALTER TABLE … ADD COLUMN`
+   (`ImprovementStore.swift:222-243`). The base doc's "additive nullable columns" plan is
+   exactly this existing pattern — Review#1's "migration won't execute" is **refuted**. Follow
+   the same `if !columnNames.contains(...)` guard.
+3. **The real gate is `minDelta`/`compactMap`, not `sum < -0.001`.** Any base-doc text describing
+   the gate as a summed-delta threshold or non-optional `EvalDelta` fields is stale. HEAD:
+   `EvalDelta` fields are `Double?` (`ExternalReviewGate.swift:320-331`); the internal verdict is
+   `runInternalReview` (`:213-245`).
+
+## 1. The hole that survives the base design (verified)
+
+`runInternalReview` (`ExternalReviewGate.swift:213-245`):
+
+```swift
+let allDeltas = [
+    evalDelta.toolCallingDelta,
+    evalDelta.faeCapabilityDelta,
+    evalDelta.assistantFitDelta,
+    evalDelta.serializationDelta,
+].compactMap { $0 }            // nils silently dropped; throughputDelta NOT considered
+let minDelta = allDeltas.min() ?? 0.0
+if minDelta < -5.0 { .fail } else if minDelta < 0.0 { .concern } else { .pass }
+```
+
+Two ways an un-evaluated candidate scores **PASS**:
+
+- **All-nil deltas** (e.g. a future evaluator that couldn't measure, or a parser that yields nil):
+  `allDeltas == []` → `min() ?? 0.0 == 0.0` → not `< 0.0` → **PASS**.
+- **All-zero deltas**: the bridge-absent branch constructs exactly this
+  (`ImprovementCycleCoordinator.swift:586-589`): `EvalDelta(toolCallingDelta: 0.0, …)` →
+  `minDelta == 0.0` → **PASS**.
+
+Codex's earlier "remove the zero-delta fallback" fix addresses neither cleanly: the *type* permits
+all-nil, and zero is a legal measured value. The gate must distinguish **"measured, and good"**
+from **"not measured"** — today it cannot.
+
+A second hole: the receipt the base design adds is **forgeable**. `AdapterDeploymentManager.deploy`
+(`:119-126`) is `static func deploy(adapterPath: String, store:)` — it writes an arbitrary path to
+`currentAdapterPath` with no proof of evaluation. Any current or future caller (or a hand-inserted
+SQLite row) re-opens the loop one call away. The receipt must be **un-forgeable by construction**,
+not just "present in a table."
+
+## 2. Fix M1 — the gate requires *measured* improvement, fail-closed
+
+Replace the "min-of-present-or-zero" rule with an explicit measured-coverage rule.
+
+```swift
+/// The result of an evaluator measuring a candidate. Distinguishes
+/// "measured" from "absent" so the gate can fail-closed on absence.
+struct MeasuredDeltas: Sendable {
+    /// Only the dimensions actually measured this cycle. Empty == nothing measured.
+    let measured: [GateDimension: Double]   // .toolCalling, .faeCapability, .assistantFit, .serialization
+    // throughput is advisory-only and never gates (perf, not correctness).
+    let throughputDelta: Double?
+}
+
+enum GateDecision: Sendable { case pass, concern, fail, blockedNoMeasurement }
+
+/// Gate rule (replaces runInternalReview's min-or-zero):
+/// 1. require ≥1 of the FOUR correctness dimensions measured, else .blockedNoMeasurement
+/// 2. any measured dimension < -5.0           → .fail
+/// 3. any measured dimension in [-5.0, 0.0)   → .concern
+/// 4. all measured dimensions ≥ 0.0           → .pass
+func decide(_ d: MeasuredDeltas) -> GateDecision {
+    let values = Array(d.measured.values)
+    guard !values.isEmpty else { return .blockedNoMeasurement }      // ← closes the nil crack
+    if values.contains(where: { $0 < -5.0 }) { return .fail }
+    if values.contains(where: { $0 < 0.0 })  { return .concern }
+    if values.contains(where: { $0 > 0.0 })  { return .pass }        // ≥1 real improvement, no regression
+    return .blockedNoMeasurement                                     // all-flat ≈ non-measurement (closes the zero crack)
+}
+```
+
+Wiring consequences:
+- `EvalDelta` (optional fields) is the *transport*; the gate consumes `MeasuredDeltas`. The adapter
+  from `EvalDelta` → `MeasuredDeltas` drops nils into "not measured" (not into "0.0").
+- **Delete the all-zeros construction** at `ImprovementCycleCoordinator.swift:586-589`. The
+  bridge-absent / benchmark-unavailable path must yield **empty `measured`** → `.blockedNoMeasurement`,
+  NOT a synthetic zero pass.
+- `.blockedNoMeasurement` is terminal-for-this-cycle: audited `candidate_blocked`
+  (reason `benchmark_unavailable`), `forceIdle`, and **do not call `reviewGate.review`** and **do
+  not enter `.proposing`** (matches Codex change #3 in the base doc).
+- The loss-proxy (`lossBasedEvalDelta`, `:805-822`) may still annotate the proposal text, but it
+  contributes **zero entries** to `measured` — it can never satisfy `decide`.
+
+Rule-9 test (encodes WHY): *"a cycle whose evaluator measured nothing must never reach `.proposing`
+or write `currentAdapterPath`"* — fails the instant someone reintroduces a synthetic-zero or
+treats `min() ?? 0.0` as a pass.
+
+## 3. Fix M2 — `GateReceipt`: un-forgeable by construction, single-use, lane-correct hashing
+
+### 3.1 Threat model (be honest)
+This is a local single-user app; the owner already controls the machine, so the threat is **not** a
+motivated attacker forging a row — it is **accidental re-opening**: a future code path, a test helper
+leaking into prod, or a stale in-flight row deploying ungated. So the controls are **structural
+un-forgeability + single minting path + allowlist**, with an HMAC as tamper-evidence/defense-in-depth.
+(Consistent with the project's "voice identity is the security model; DamageControlPolicy is the
+safety net" philosophy.)
+
+### 3.2 Only an evaluator can mint a receipt
+A receipt cannot be constructed by arbitrary code. Its initializer is unavailable outside the
+evaluator seam; evaluators receive a non-`Sendable`, un-storable minting capability.
+
+```swift
+struct GateReceipt: Codable, Sendable {
+    let candidatePath: String
+    let kind: AdapterKind
+    let artifactDigest: String     // §3.4 — content digest, NOT a path hash
+    let measured: [String: Double] // the measured dimensions that produced the verdict
+    let decision: String           // "pass" only ever persisted; concern/fail/block don't mint
+    let evaluatorId: String        // must be on the allowlist (§3.3)
+    let cycleId: String            // ties receipt to the cycle that produced it
+    let baseModelId: String        // candidate evaluated against THIS base (see §5 R3)
+    let evalSuiteVersion: String   // eval-set drift guard (open Q3)
+    let gatePolicyVersion: Int     // bump when decide() changes; old receipts auto-invalid
+    let receiptVersion: Int        // schema evolution
+    let mintedAt: String           // ISO-8601
+    let hmac: String               // HMAC-SHA256 over the canonical encoding of all fields above
+
+    // No public init. Minted only via GateMinter.mint(...).
+    private init(...) { ... }
+}
+
+/// Held only by the AdapterEvaluator seam; cannot be stored or forwarded.
+struct GateMinter: ~Copyable {            // move-only: cannot be stashed for later forgery
+    func mint(_ fields: GateReceiptFields, key: SymmetricKey) -> GateReceipt { ... }
+}
+```
+
+If move-only ergonomics are awkward in the target toolchain, fall back to: receipt init is
+`internal` to the evaluator module + a runtime assertion that `evaluatorId` is on the allowlist at
+mint time. The non-negotiable property: **no type outside `AdapterEvaluator` conformers can produce a
+`GateReceipt` whose `hmac` verifies.**
+
+### 3.3 Evaluator allowlist
+```swift
+static let allowedEvaluators: Set<String> = ["DaemonABEvaluator", "FaeBenchmarkEvaluator"]
+```
+`verify(receipt:)` rejects any `evaluatorId ∉ allowedEvaluators`. The loss-proxy is **not** on the
+list and has no `GateMinter`, so it structurally cannot gate.
+
+### 3.4 Lane-correct artifact digest (`kind` drives it)
+- `.gguf`: SHA-256 of the file bytes.
+- `.mlxDir`: a **canonical content manifest** — recursively walk the dir, sort entries by relative
+  POSIX path, hash `relpath \0 fileSHA256 \0` for each, SHA-256 the concatenation. Validate no
+  symlink escapes the dir root before hashing. (A path-string hash is meaningless for a directory.)
+
+`verify(receipt:)` recomputes the digest for `receipt.kind` and requires equality — closing the
+re-point gap (receipt for A, file swapped to B).
+
+### 3.5 Single-use
+Receipts are consumed on use: `gate_receipts.consumed_at` is stamped inside the same transaction
+that promotes `pending → current`. A consumed (or `gatePolicyVersion`-stale) receipt fails
+verification. Prevents replay of an old passing receipt onto a new candidate.
+
+### 3.6 Persistence (follows the existing migration convention)
+New table, created in `createSchema` alongside the others:
+```sql
+CREATE TABLE IF NOT EXISTS gate_receipts (
+    cycle_id            TEXT PRIMARY KEY,
+    candidate_path      TEXT NOT NULL,
+    kind                TEXT NOT NULL,
+    artifact_digest     TEXT NOT NULL,
+    measured_json       TEXT NOT NULL,
+    evaluator_id        TEXT NOT NULL,
+    base_model_id       TEXT NOT NULL,
+    eval_suite_version  TEXT NOT NULL,
+    gate_policy_version INTEGER NOT NULL,
+    receipt_version     INTEGER NOT NULL,
+    minted_at           TEXT NOT NULL,
+    hmac                TEXT NOT NULL,
+    consumed_at         TEXT
+);
+```
+New `improvement_state` columns via the **same guarded ALTER pattern** (`:222-243`):
+`pending_adapter_path TEXT`, `pending_adapter_kind TEXT`, `pending_cycle_id TEXT`.
+Writes use real `try` (not `try?`) so a receipt-write failure surfaces (Rule 12); a swallowed
+write that later reads as "no receipt" would wrongly block a legitimate deploy.
+
+The HMAC key is a per-install random `SymmetricKey` in the **Keychain** (not in `fae.db`), created
+on first run. Stored separately from the receipts so a copied/edited `.db` row can't carry a valid
+HMAC. (Tamper-evidence, not secrecy from the owner.)
+
+## 4. Fix M3/M5 — fence every sink; receipt is the only deploy authority
+
+| Sink (HEAD) | Change |
+|---|---|
+| Auto-loop deploy (`ImprovementCycleCoordinator`, after review PASS, `:646`+) | promote `pending → current` only via `deploy(receipt:)`; verify receipt in the same txn |
+| `AdapterDeploymentManager.deploy(adapterPath:store:)` (`:119`) | **change signature** to `deploy(receipt: GateReceipt, store:)`; `verify(receipt:)` (allowlist + digest + single-use + policyVersion) before writing `currentAdapterPath`. No raw-path entry point in prod. |
+| `approveDeployment()` (semi-auto) | approvable **only** if the held proposal carries a verifying receipt for that exact candidate; a `.concern` proposal has **no** receipt → not approvable into deploy |
+| `rollback()` (`:136`) | re-promotes a **previously-deployed** path (which by definition once carried a receipt). Allowed without a fresh receipt, but log an audited `rollback` event (R2). |
+| `training.personal_adapter_path` SelfConfig → `core.swapPersonalAdapter` (`FaeCore.swift:2380`) | explicit **owner manual override**, out-of-gate **by design**. Route through a clearly-audited `manual_adapter_override` security event; document in the Objective that the no-ungated-deploy property is **loop-scoped**, with this one audited hatch (resolves M3 contradiction). |
+| Startup auto-load of `currentAdapterPath` | loads whatever the gated loop persisted; safe once §2–§4 hold (only receipt-verified paths ever reach `currentAdapterPath`). Add a deploy-time `AdapterKind`↔engine check (gguf→daemon, mlxDir→MLX) to avoid lane mismatch. |
+
+Restate the base-doc **Objective** as: *"No adapter is deployed by the autonomous improvement loop
+without a verifying GateReceipt. The owner may manually override via
+`training.personal_adapter_path`, which is audited and explicitly out-of-gate."*
+
+## 5. Recommended fixes folded in (from the three reviews)
+
+- **R1 (don't silently dead-loop).** Shipping C4-safety without `DaemonABEvaluator` makes the daemon
+  lane `train → blockedNoMeasurement → idle` every night. There is **no ActionItem surface** today
+  (verified: no such system). Until one exists: **refuse to train a lane that has no evaluator** —
+  check evaluator availability in the training phase and skip with an audited `lane_no_evaluator`
+  reason, so we don't burn a training run to then block. Surface it in the morning briefing text.
+- **R2.** Rollback re-promotion is allowed but must emit an audited event (above).
+- **R3 (baseline correctness).** The evaluator's "base" must be the **currently-deployed adapter**,
+  not the bare base model — else a candidate can pass while regressing vs what the user actually
+  runs. Record `baseModelId`/deployed-adapter in the receipt; `DaemonABEvaluator` A/B should be
+  scale-0 = *deployed adapter* (or base if none), scale-1 = candidate.
+- **R4.** TOCTOU: §3.4 digest is verified at the deploy decision; document that the engine load path
+  is trusted (owner's machine) — G2 is "tamper-evidence at deploy decision," not load-time binding.
+- **R5 (Swift hygiene).** Rename the evaluator outcome type to `GateOutcome` to avoid collision with
+  `ShadowEvaluator`'s result types; keep `EvalDelta` as the single delta transport (don't introduce a
+  parallel `AdapterDeltas`); add `baseModelId` to the evaluator inputs.
+
+## 6. Golden production-wiring E2E test (the regression guard the doc lacks)
+
+One end-to-end test that fails if *any* path reaches a live adapter without a verifying receipt.
+This is the highest-value test — it catches a future re-opening regardless of which sink reintroduces
+it.
+
+```
+testGoldenProductionWiring_noDeployWithoutReceipt():
+  Given a coordinator wired with the PRODUCTION object graph (real ImprovementStore on a temp DB,
+        real ExternalReviewGate, real AdapterDeploymentManager, a stub TrainingBackend that
+        produces a candidate, and NO evaluator configured) and a Keychain HMAC key:
+  When  a full improvement cycle runs:
+  Then  currentAdapterPath is UNCHANGED (still nil / still the prior deployed path),
+        state is .idle,
+        a candidate_blocked audit row exists with reason "benchmark_unavailable" or
+            "lane_no_evaluator",
+        gate_receipts has NO row for this cycleId,
+        reviewGate.review was NOT called (spy asserts zero invocations).
+
+  AND, with a stub evaluator that returns measured deltas {toolCalling:+3.0}:
+  When  the cycle runs and (earned autonomy) auto-deploys:
+  Then  exactly one gate_receipts row exists, hmac verifies, consumed_at is set,
+        currentAdapterPath == candidate.path,
+        artifactDigest recomputed from disk matches the receipt.
+
+  AND, tamper case:
+  Given a persisted passing receipt, when the candidate file bytes are mutated before deploy:
+  Then  deploy refuses (digest mismatch), currentAdapterPath UNCHANGED, audited.
+
+  AND, forgery case:
+  Given a hand-inserted gate_receipts row with a plausible-looking but wrong hmac:
+  Then  verify(receipt:) rejects it, deploy refuses.
+
+  AND, replay case:
+  Given a valid consumed receipt from cycle A, presented for a different candidate in cycle B:
+  Then  verify rejects (consumed / cycleId mismatch), deploy refuses.
+```
+
+Supporting unit tests: `decide(MeasuredDeltas)` truth table incl. empty-measured →
+`.blockedNoMeasurement`; mlxDir manifest digest stability (reorder dir walk → same digest; mutate one
+file → different digest); allowlist rejection of `loss_proxy` evaluatorId; migration adds the three
+state columns on an old DB and `gate_receipts` is created; recovery repairs a stale `.proposing`
+row with no receipt → `.idle`.
+
+## 7. Staging (unchanged intent, sharpened)
+
+1. **C4-integrity (this addendum):** `decide`/`MeasuredDeltas` gate, `GateReceipt` mint+verify,
+   `deploy(receipt:)`, fence all sinks, migration+recovery, golden E2E. Closes the hole even with
+   **no** real evaluator (loop blocks, audited). With R1, the daemon lane refuses-to-train rather
+   than nightly dead-looping.
+2. **C4-capability (DaemonABEvaluator):** scale-0(deployed)/scale-1(candidate) A/B scoring harness →
+   the daemon lane can actually *pass* a gate. Larger; ship together if tractable, else tracked.
+3. **FaeBenchmark `--model auto` + adapter-mode JSON** fix is a prerequisite for the MLX-dir lane's
+   `FaeBenchmarkEvaluator` (it currently rejects `auto` and emits a different schema) — must land
+   with C4-capability for that lane, not as a footnote.
+
+## 8. Open questions for the author
+- Q1: Manual-override receipts — mint a provenance receipt for `personal_adapter_path` too (audited),
+  or leave it purely as a security-event log? (Leaning: log only; it's out-of-gate by design.)
+- Q2: `DaemonABEvaluator` promotion threshold — reuse ShadowEvaluator's 60% win-rate, or a delta
+  threshold consistent with `decide`'s ±5%?
+- Q3: `evalSuiteVersion` provenance — where does the held-out eval set live and how is it versioned
+  so `gatePolicyVersion`/`evalSuiteVersion` bumps invalidate stale receipts?
+- Q4: R1 — is "refuse to train a lane with no evaluator" acceptable, or do we want the training run
+  to proceed and just block deploy (burning the run but exercising the pipeline)?

--- a/docs/plans/p9-training-seam-gates-design-2026-06-21.md
+++ b/docs/plans/p9-training-seam-gates-design-2026-06-21.md
@@ -3,6 +3,21 @@
 Branch: `feat/p9-training-seam-gates`. Reviewer-gated (codex on design + code; codex already gave a second
 opinion that shaped this scope). macOS-testable; no Linux host needed.
 
+> **⚠️ AUTHORITATIVE PLAN: `p9-c4-consolidated-plan-2026-06-21.md`** — implement from that doc; its §2
+> matrix tracks every review finding and is the Definition-of-Done checklist. This doc is the original
+> design narrative, kept for provenance.
+>
+> **⚠️ Superseded in part by `p9-c4-gate-integrity-addendum-2026-06-21.md`.** Three design reviews
+> (Claude code-reviewer, Codex, a third reviewer) found that this doc, as written, does **not**
+> provably close the hole. Read the addendum first — it carries the load-bearing C4 fixes. Corrections
+> to this doc: (1) **C1 is DONE** (`Scheduler/TrainingBackend.swift`, PR #20 `11735755`) — treat the C1
+> section below as as-built, not proposed. (2) The `ImprovementStore` **migration mechanism exists**
+> (`PRAGMA table_info` + guarded `ALTER TABLE ADD COLUMN`, `:222-243`); the additive-column plan
+> matches it. (3) The real gate is `runInternalReview`'s `compactMap`/`min() ?? 0.0` over **optional**
+> `EvalDelta` fields (`ExternalReviewGate.swift:213-245,320-331`) — **all-nil OR all-zero deltas score
+> PASS**, the crack Codex's "remove zero-delta fallback" does not close. The addendum's
+> `decide(MeasuredDeltas)` + un-forgeable `GateReceipt` + `deploy(receipt:)` are required.
+
 ## Objective (roadmap)
 
 > Formalize the `TrainingBackend` seam (`prepareDataset/trainAdapter/convertAdapter/…`) across MLX/Unsloth/PEFT,

--- a/native/macos/Fae/Sources/Fae/Core/FaeCore.swift
+++ b/native/macos/Fae/Sources/Fae/Core/FaeCore.swift
@@ -568,6 +568,10 @@ final class FaeCore: ObservableObject, HostCommandSender {
                     // only if its load() succeeded above (else it fell back to MLX).
                     if let daemonEngine = llmEngine as? DaemonLLMEngine {
                         await sched.setDaemonTrainingBaseModel(daemonEngine.daemonModelID)
+                        // P9/C4 (W7b): hand the live daemon engine to the scheduler so it
+                        // can build the `.gguf`-lane DaemonABEvaluator (A/B the daemon over
+                        // the held-out eval set), un-blocking gated GGUF deploys.
+                        await sched.setDaemonLLMEngine(daemonEngine)
                     }
                     await sched.setAwarenessConfig(config.awareness)
                     await sched.setVisionEnabled(config.vision.enabled)

--- a/native/macos/Fae/Sources/Fae/Core/FaeCore.swift
+++ b/native/macos/Fae/Sources/Fae/Core/FaeCore.swift
@@ -2387,8 +2387,22 @@ final class FaeCore: ObservableObject, HostCommandSender {
             }
             config.training.personalAdapterPath = newPath
             persistConfig(reason: "config.patch.training.personal_adapter_path")
-            // Hot-swap adapter on the running pipeline (no restart required).
+            // P9/C4 (W4, F7): this is the OWNER MANUAL OVERRIDE — it deploys an adapter
+            // OUTSIDE the autonomous loop's receipt gate, by design. Audit it loudly so
+            // an out-of-gate adapter swap is always attributable. (The gated path is
+            // ImprovementCycleCoordinator.performDeploy, which requires a GateReceipt.)
+            // Audit BEFORE the swap (awaited, in the same task) so the out-of-gate
+            // override is always recorded before the adapter changes — not racing it.
             Task { [weak self] in
+                await SecurityEventLogger.shared.log(
+                    event: "manual_adapter_override",
+                    toolName: "self_config",
+                    decision: "allow",
+                    reasonCode: "owner_out_of_gate",
+                    approved: true,
+                    success: true,
+                    arguments: ["personal_adapter_path": newPath ?? "(unload)"]
+                )
                 await self?.pipelineCoordinator?.applyAdapterChange(path: newPath)
             }
             NSLog("FaeCore: adapter path patched → %@", newPath ?? "<unload>")

--- a/native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift
+++ b/native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift
@@ -1023,6 +1023,55 @@ actor DaemonLLMEngine: LLMEngine {
             payload: ["scale": Double(scale)])
     }
 
+    /// The personal adapter the running sidecar currently serves, as reported by
+    /// the daemon's `runtime.status` (`{ adapter: { path, sha256, scale } | null }`).
+    /// `nil` ⇒ the sidecar is serving the base model (no adapter). Used by the
+    /// daemon-lane A/B evaluator (P9/C4 W7b) to CONFIRM the deployed adapter was
+    /// restored after an eval — a daemon left on the un-gated candidate is exactly
+    /// the deploy-without-receipt hole this series closes.
+    struct LoadedAdapterStatus: Sendable, Equatable {
+        let path: String
+        let sha256: String?
+        let scale: Double?
+    }
+
+    /// Query `runtime.status` and return the loaded personal adapter (or `nil` for
+    /// base). Throws `adapterCommandFailed`/`daemonError` on a rejected or malformed
+    /// response so a confirmation failure is never read as "no adapter".
+    func runtimeStatus() async throws -> LoadedAdapterStatus? {
+        guard isLoaded, let connection else { throw DaemonLLMEngineError.notLoaded }
+        let requestID = nextRequestID()
+        let frame = try DaemonWire.encodeFrame(
+            requestID: requestID, command: "runtime.status", payload: [:])
+        let raw = try await connection.roundTrip(frame: frame, expectRequestID: requestID)
+        let response = try DaemonWire.unwrapResponse(raw)
+        let result = (response["result"] as? [String: Any]) ?? [:]
+        guard let adapter = result["adapter"] as? [String: Any] else {
+            // `adapter: null` (base model) is a valid, expected state.
+            return nil
+        }
+        guard let path = adapter["path"] as? String else {
+            throw DaemonLLMEngineError.protocolError("runtime.status adapter missing path")
+        }
+        return LoadedAdapterStatus(
+            path: path,
+            sha256: adapter["sha256"] as? String,
+            scale: (adapter["scale"] as? NSNumber)?.doubleValue
+        )
+    }
+
+    /// One non-streaming text turn collected to a `(text, toolCalls)` result, used
+    /// by the daemon-lane A/B evaluator (P9/C4 W7b) to score the same held-out
+    /// prompt under two adapters. This is a plain text turn — no audio, no
+    /// two-pass — so it reuses `runTurn` directly; tool specs come from `options`.
+    func inferForEval(
+        messages: [LLMMessage],
+        systemPrompt: String,
+        options: GenerationOptions
+    ) async throws -> DaemonWire.Turn {
+        try await runTurn(messages: messages, systemPrompt: systemPrompt, options: options)
+    }
+
     /// `LLMEngine` conformance for the daemon lane: a personal adapter is a GGUF
     /// the daemon loads + activates, not an MLX adapter directory. `directory`
     /// here is the GGUF path (the deploy/self-config layer passes the produced

--- a/native/macos/Fae/Sources/Fae/Memory/ExternalReviewGate.swift
+++ b/native/macos/Fae/Sources/Fae/Memory/ExternalReviewGate.swift
@@ -206,34 +206,32 @@ actor ExternalReviewGate {
 
     /// Run the internal self-review heuristic (no external dependency).
     ///
-    /// Rules:
-    /// - Any eval metric regresses by > 5% → FAIL
-    /// - All metrics are neutral or improved → PASS
-    /// - Minor regression (≤ 5%) on any metric → CONCERN
+    /// Delegates to the fail-closed `AdapterGate.decide` rule so the internal
+    /// reviewer can never certify an un-measured (all-nil) or unimproved
+    /// (all-flat) candidate. The coordinator is expected to short-circuit a
+    /// `.blockedNoMeasurement` candidate before calling the gate at all; this is
+    /// the defence-in-depth path if it ever reaches here.
     private func runInternalReview(
         evalDelta: EvalDelta,
         reviewedAt: String
     ) -> ReviewResult {
-        let allDeltas = [
-            evalDelta.toolCallingDelta,
-            evalDelta.faeCapabilityDelta,
-            evalDelta.assistantFitDelta,
-            evalDelta.serializationDelta,
-        ].compactMap { $0 }
-
-        let minDelta = allDeltas.min() ?? 0.0
         let verdict: ReviewVerdict
         let summary: String
 
-        if minDelta < -5.0 {
-            verdict = .fail
-            summary = "Internal review: regression detected (\(String(format: "%.1f", minDelta))%). Deployment blocked."
-        } else if minDelta < 0.0 {
-            verdict = .concern
-            summary = "Internal review: minor regression (\(String(format: "%.1f", minDelta))%). Human review recommended."
-        } else {
+        switch AdapterGate.decide(evalDelta.measuredDeltas) {
+        case .pass:
             verdict = .pass
-            summary = "Internal review: all metrics stable or improved (min delta: +\(String(format: "%.1f", minDelta))%)."
+            summary = "Internal review: measured improvement with no regression. Deployment permitted."
+        case .concern:
+            verdict = .concern
+            summary = "Internal review: minor regression on a measured metric. Human review recommended."
+        case .fail:
+            verdict = .fail
+            summary = "Internal review: regression > 5% on a measured metric. Deployment blocked."
+        case .blockedNoMeasurement:
+            // Fail-closed: no real measurement (or nothing improved) ⇒ never pass.
+            verdict = .fail
+            summary = "Internal review: no measured improvement — cannot certify. Deployment blocked."
         }
 
         return ReviewResult(
@@ -328,4 +326,93 @@ struct EvalDelta: Sendable {
     let serializationDelta: Double?
     /// Delta in average throughput (tokens per second).
     let throughputDelta: Double?
+}
+
+// MARK: - Gate decision (P9/C4)
+
+/// The correctness dimensions that gate a deploy.
+///
+/// Throughput is deliberately NOT a gate dimension — it is a performance signal,
+/// not a correctness one, and must never make an adapter deployable on its own.
+enum GateDimension: String, Sendable, CaseIterable {
+    case toolCalling
+    case faeCapability
+    case assistantFit
+    case serialization
+}
+
+/// The dimensions actually MEASURED in an evaluation, with their deltas
+/// (percentage points; positive = improvement).
+///
+/// An empty `measured` means **nothing was measured** — which is categorically
+/// different from "measured, and the result was zero". The gate fails closed on
+/// the former (see ``AdapterGate/decide(_:)``).
+struct MeasuredDeltas: Sendable {
+    let measured: [GateDimension: Double]
+    /// Advisory only; never gates.
+    let throughputDelta: Double?
+
+    var isEmpty: Bool { measured.isEmpty }
+}
+
+/// The P9/C4 gate decision over measured correctness deltas.
+enum GateDecision: String, Sendable, Equatable {
+    case pass
+    case concern
+    case fail
+    /// Nothing measurably improved — either no dimension was measured at all, or
+    /// every measured dimension was flat. Fail-closed: never deployable.
+    case blockedNoMeasurement
+}
+
+/// The fail-closed gate rule for P9/C4 adapter deploys.
+///
+/// Replaces the previous `compactMap`/`min() ?? 0.0` heuristic, which passed
+/// both all-nil and all-zero deltas — letting an un-evaluated adapter deploy.
+enum AdapterGate {
+    /// Decide whether a candidate's measured deltas permit deployment.
+    ///
+    /// Rules (fail-closed):
+    /// - **Incomplete measurement** — any of the four correctness dimensions
+    ///   unmeasured (`nil`) ⇒ `.blockedNoMeasurement`. A real evaluator scores
+    ///   every dimension; a partial result means the evaluator malfunctioned and
+    ///   cannot certify a deploy.
+    /// - any measured dimension regressed > 5% ⇒ `.fail`
+    /// - any measured dimension regressed (≤ 5%) ⇒ `.concern`
+    /// - at least one improvement and no regression ⇒ `.pass`
+    /// - all dimensions flat (nothing strictly improved) ⇒ `.blockedNoMeasurement`
+    ///   (an all-flat result is indistinguishable from a non-measurement and must
+    ///   not auto-deploy).
+    static func decide(_ deltas: MeasuredDeltas) -> GateDecision {
+        // Require a COMPLETE measurement: every correctness dimension present.
+        let values = GateDimension.allCases.compactMap { deltas.measured[$0] }
+        guard values.count == GateDimension.allCases.count else { return .blockedNoMeasurement }
+        if values.contains(where: { $0 < -5.0 }) { return .fail }
+        if values.contains(where: { $0 < 0.0 }) { return .concern }
+        if values.contains(where: { $0 > 0.0 }) { return .pass }
+        return .blockedNoMeasurement
+    }
+}
+
+extension EvalDelta {
+    /// The MEASURED correctness deltas. A `nil` field means the dimension was not
+    /// measured this cycle and is therefore excluded (NOT folded in as zero).
+    /// Throughput is carried for annotation but never gates.
+    var measuredDeltas: MeasuredDeltas {
+        var measured: [GateDimension: Double] = [:]
+        if let v = toolCallingDelta { measured[.toolCalling] = v }
+        if let v = faeCapabilityDelta { measured[.faeCapability] = v }
+        if let v = assistantFitDelta { measured[.assistantFit] = v }
+        if let v = serializationDelta { measured[.serialization] = v }
+        return MeasuredDeltas(measured: measured, throughputDelta: throughputDelta)
+    }
+
+    /// An `EvalDelta` carrying NO measured dimensions (all `nil`) — the fail-closed
+    /// "nothing was measured" signal. Distinct from a measured all-zero result.
+    static var unmeasured: EvalDelta {
+        EvalDelta(
+            toolCallingDelta: nil, faeCapabilityDelta: nil,
+            assistantFitDelta: nil, serializationDelta: nil, throughputDelta: nil
+        )
+    }
 }

--- a/native/macos/Fae/Sources/Fae/Memory/ImprovementStore.swift
+++ b/native/macos/Fae/Sources/Fae/Memory/ImprovementStore.swift
@@ -307,6 +307,26 @@ actor ImprovementStore {
             CREATE INDEX IF NOT EXISTS idx_mol_cycle
             ON meta_optimization_log (cycle_number, kept)
         """)
+        // P9/C4 (W2): persisted gate receipts — tamper-evident proof a candidate passed
+        // a real eval. W4 requires a verifying, unconsumed receipt before any deploy.
+        try db.execute(sql: """
+            CREATE TABLE IF NOT EXISTS gate_receipts (
+                cycle_id            TEXT    PRIMARY KEY,
+                candidate_path      TEXT    NOT NULL,
+                kind                TEXT    NOT NULL,
+                artifact_digest     TEXT    NOT NULL,
+                measured_json       TEXT    NOT NULL,
+                decision            TEXT    NOT NULL,
+                evaluator_id        TEXT    NOT NULL,
+                base_model_id       TEXT    NOT NULL,
+                eval_suite_version  TEXT    NOT NULL,
+                gate_policy_version INTEGER NOT NULL,
+                receipt_version     INTEGER NOT NULL,
+                minted_at           TEXT    NOT NULL,
+                hmac                TEXT    NOT NULL,
+                consumed_at         TEXT
+            )
+        """)
     }
 
     // MARK: - Singleton State Row
@@ -817,6 +837,107 @@ actor ImprovementStore {
             receptionScore: row["reception_score"],
             evaluated: (row["evaluated"] as? Int64 ?? 0) != 0,
             evalOutcome: row["eval_outcome"]
+        )
+    }
+
+    // MARK: - Gate Receipts (P9/C4 W2)
+
+    /// Persist a minted gate receipt (one per cycle). Replaces any prior receipt for the
+    /// same cycle id. Failures surface (Rule 12) — a swallowed receipt write followed by
+    /// a deploy that requires a receipt must not silently mis-gate.
+    func insertGateReceipt(_ receipt: GateReceipt) throws {
+        guard let db else { throw ImprovementStoreError.notOpen }
+        let measuredJSON = String(
+            data: try JSONEncoder().encode(receipt.measured), encoding: .utf8
+        ) ?? "{}"
+        try db.write { db in
+            try db.execute(
+                sql: """
+                    INSERT OR REPLACE INTO gate_receipts
+                        (cycle_id, candidate_path, kind, artifact_digest, measured_json,
+                         decision, evaluator_id, base_model_id, eval_suite_version,
+                         gate_policy_version, receipt_version, minted_at, hmac, consumed_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                """,
+                arguments: [
+                    receipt.cycleId, receipt.candidatePath, receipt.kind.rawValue,
+                    receipt.artifactDigest, measuredJSON, receipt.decision,
+                    receipt.evaluatorId, receipt.baseModelId, receipt.evalSuiteVersion,
+                    receipt.gatePolicyVersion, receipt.receiptVersion,
+                    receipt.mintedAt, receipt.hmac,
+                ]
+            )
+        }
+    }
+
+    /// Fetch the gate receipt for a cycle, if present.
+    func gateReceipt(forCycleId cycleId: String) throws -> GateReceipt? {
+        guard let db else { throw ImprovementStoreError.notOpen }
+        return try db.read { db in
+            guard let row = try Row.fetchOne(
+                db,
+                sql: "SELECT * FROM gate_receipts WHERE cycle_id = ? LIMIT 1",
+                arguments: [cycleId]
+            ) else { return nil }
+            return Self.gateReceipt(from: row)
+        }
+    }
+
+    /// Whether the receipt for a cycle has already been consumed (single-use gate).
+    func isGateReceiptConsumed(cycleId: String) throws -> Bool {
+        guard let db else { throw ImprovementStoreError.notOpen }
+        return try db.read { db in
+            guard let row = try Row.fetchOne(
+                db,
+                sql: "SELECT consumed_at FROM gate_receipts WHERE cycle_id = ? LIMIT 1",
+                arguments: [cycleId]
+            ) else { return false }
+            let consumed: String? = row["consumed_at"]
+            return consumed != nil
+        }
+    }
+
+    /// Mark a receipt consumed (single-use). Sets `consumed_at` only if still null, so a
+    /// replayed deploy of the same receipt cannot re-consume it.
+    func consumeGateReceipt(cycleId: String, at timestamp: String) throws {
+        guard let db else { throw ImprovementStoreError.notOpen }
+        try db.write { db in
+            try db.execute(
+                sql: """
+                    UPDATE gate_receipts SET consumed_at = ?
+                    WHERE cycle_id = ? AND consumed_at IS NULL
+                """,
+                arguments: [timestamp, cycleId]
+            )
+        }
+    }
+
+    private static func gateReceipt(from row: Row) -> GateReceipt? {
+        let measuredJSON: String = row["measured_json"] ?? "{}"
+        let decoded = try? JSONDecoder().decode([String: Double].self, from: Data(measuredJSON.utf8))
+        if decoded == nil {
+            // Surface (don't silently swallow) a corrupt measured payload — the receipt's
+            // HMAC will fail verification anyway, but a logged decode failure flags DB damage.
+            NSLog("ImprovementStore: gate_receipts.measured_json failed to decode (db damage?)")
+        }
+        let measured = decoded ?? [:]
+        guard let kindRaw: String = row["kind"], let kind = AdapterKind(rawValue: kindRaw) else {
+            return nil
+        }
+        return GateReceipt(
+            cycleId: row["cycle_id"] ?? "",
+            candidatePath: row["candidate_path"] ?? "",
+            kind: kind,
+            artifactDigest: row["artifact_digest"] ?? "",
+            measured: measured,
+            decision: row["decision"] ?? "",
+            evaluatorId: row["evaluator_id"] ?? "",
+            baseModelId: row["base_model_id"] ?? "",
+            evalSuiteVersion: row["eval_suite_version"] ?? "",
+            gatePolicyVersion: Int(row["gate_policy_version"] as? Int64 ?? 0),
+            receiptVersion: Int(row["receipt_version"] as? Int64 ?? 0),
+            mintedAt: row["minted_at"] ?? "",
+            hmac: row["hmac"] ?? ""
         )
     }
 }

--- a/native/macos/Fae/Sources/Fae/Memory/ImprovementStore.swift
+++ b/native/macos/Fae/Sources/Fae/Memory/ImprovementStore.swift
@@ -89,6 +89,11 @@ struct ImprovementState: Sendable {
     /// The candidate's artifact kind ("gguf" | "mlxDir"), for the W4 evaluator and
     /// deploy routing.
     var pendingAdapterKind: String? = nil
+
+    /// The cycle id that produced the pending candidate (P9/C4 W4). Binds the candidate
+    /// to its `gate_receipts` row so the deploy gate can require a verifying receipt for
+    /// this exact cycle.
+    var pendingCycleId: String? = nil
 }
 
 /// A detected gap between current Fae capabilities and desired behaviour.
@@ -122,6 +127,9 @@ enum ImprovementStoreError: Error, Sendable {
     case notOpen
     /// No singleton improvement state row exists. Call `ensureStateRow()` first.
     case stateNotInitialised
+    /// The gate receipt to consume was missing or already consumed (P9/C4 W4) — the
+    /// atomic promote+consume transaction was rolled back.
+    case receiptNotConsumable
 }
 
 // MARK: - ImprovementStore
@@ -231,7 +239,8 @@ actor ImprovementStore {
                 deferral_count        INTEGER NOT NULL DEFAULT 0,
                 previous_directive    TEXT,
                 pending_adapter_path  TEXT,
-                pending_adapter_kind  TEXT
+                pending_adapter_kind  TEXT,
+                pending_cycle_id      TEXT
             )
         """)
         // Migration: add columns to existing databases that lack them.
@@ -263,6 +272,9 @@ actor ImprovementStore {
         }
         if !columnNames.contains("pending_adapter_kind") {
             try db.execute(sql: "ALTER TABLE improvement_state ADD COLUMN pending_adapter_kind TEXT")
+        }
+        if !columnNames.contains("pending_cycle_id") {
+            try db.execute(sql: "ALTER TABLE improvement_state ADD COLUMN pending_cycle_id TEXT")
         }
         try db.execute(sql: """
             CREATE TABLE IF NOT EXISTS capability_gaps (
@@ -488,7 +500,7 @@ actor ImprovementStore {
                        deferral_count, previous_directive,
                        meta_opt_kept_total, meta_opt_tested_total,
                        meta_opt_last_run_at, meta_opt_consecutive_no_improvement,
-                       pending_adapter_path, pending_adapter_kind
+                       pending_adapter_path, pending_adapter_kind, pending_cycle_id
                 FROM improvement_state LIMIT 1
             """) else {
                 throw ImprovementStoreError.stateNotInitialised
@@ -500,7 +512,33 @@ actor ImprovementStore {
     /// Overwrite the singleton improvement state.
     func writeState(_ state: ImprovementState) throws {
         guard let db else { throw ImprovementStoreError.notOpen }
+        try db.write { db in try Self.upsertState(db, state) }
+    }
+
+    /// Atomically promote (write `state`) AND consume the gate receipt for `cycleId` in
+    /// ONE transaction (P9/C4 W4). The consume is `UPDATE … WHERE consumed_at IS NULL`;
+    /// it must affect exactly one row — otherwise the receipt is missing or already
+    /// consumed, the whole transaction rolls back, and this throws. This makes deploy +
+    /// single-use atomic: a deploy can never commit without consuming a STORED, unconsumed
+    /// receipt, and a receipt can never be double-spent (closes the missing-row bypass,
+    /// the promote-then-consume window, and the check/consume TOCTOU together).
+    func promoteAndConsumeReceipt(
+        state: ImprovementState, cycleId: String, at timestamp: String
+    ) throws {
+        guard let db else { throw ImprovementStoreError.notOpen }
         try db.write { db in
+            try db.execute(
+                sql: "UPDATE gate_receipts SET consumed_at = ? WHERE cycle_id = ? AND consumed_at IS NULL",
+                arguments: [timestamp, cycleId]
+            )
+            guard db.changesCount == 1 else {
+                throw ImprovementStoreError.receiptNotConsumable
+            }
+            try Self.upsertState(db, state)
+        }
+    }
+
+    private static func upsertState(_ db: GRDB.Database, _ state: ImprovementState) throws {
             if let id = state.id {
                 try db.execute(
                     sql: """
@@ -512,7 +550,7 @@ actor ImprovementStore {
                             previous_directive = ?,
                             meta_opt_kept_total = ?, meta_opt_tested_total = ?,
                             meta_opt_last_run_at = ?, meta_opt_consecutive_no_improvement = ?,
-                            pending_adapter_path = ?, pending_adapter_kind = ?
+                            pending_adapter_path = ?, pending_adapter_kind = ?, pending_cycle_id = ?
                         WHERE id = ?
                     """,
                     arguments: [
@@ -523,7 +561,7 @@ actor ImprovementStore {
                         state.deferralCount, state.previousDirective,
                         state.metaOptKeptTotal, state.metaOptTestedTotal,
                         state.metaOptLastRunAt, state.metaOptConsecutiveNoImprovement,
-                        state.pendingAdapterPath, state.pendingAdapterKind,
+                        state.pendingAdapterPath, state.pendingAdapterKind, state.pendingCycleId,
                         id,
                     ]
                 )
@@ -537,8 +575,8 @@ actor ImprovementStore {
                              deferral_count, previous_directive,
                              meta_opt_kept_total, meta_opt_tested_total,
                              meta_opt_last_run_at, meta_opt_consecutive_no_improvement,
-                             pending_adapter_path, pending_adapter_kind)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                             pending_adapter_path, pending_adapter_kind, pending_cycle_id)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     arguments: [
                         state.cycleState, state.lastCycleAt,
@@ -548,11 +586,10 @@ actor ImprovementStore {
                         state.deferralCount, state.previousDirective,
                         state.metaOptKeptTotal, state.metaOptTestedTotal,
                         state.metaOptLastRunAt, state.metaOptConsecutiveNoImprovement,
-                        state.pendingAdapterPath, state.pendingAdapterKind,
+                        state.pendingAdapterPath, state.pendingAdapterKind, state.pendingCycleId,
                     ]
                 )
             }
-        }
     }
 
     /// Increment the deferral counter by 1 and return the new value.
@@ -812,7 +849,8 @@ actor ImprovementStore {
             metaOptLastRunAt: row["meta_opt_last_run_at"],
             metaOptConsecutiveNoImprovement: Int(row["meta_opt_consecutive_no_improvement"] as? Int64 ?? 0),
             pendingAdapterPath: row["pending_adapter_path"],
-            pendingAdapterKind: row["pending_adapter_kind"]
+            pendingAdapterKind: row["pending_adapter_kind"],
+            pendingCycleId: row["pending_cycle_id"]
         )
     }
 
@@ -851,9 +889,12 @@ actor ImprovementStore {
             data: try JSONEncoder().encode(receipt.measured), encoding: .utf8
         ) ?? "{}"
         try db.write { db in
+            // Plain INSERT (not OR REPLACE): re-inserting a cycle id is a programming
+            // error and must fail loudly rather than silently reset `consumed_at` and
+            // un-consume a spent receipt.
             try db.execute(
                 sql: """
-                    INSERT OR REPLACE INTO gate_receipts
+                    INSERT INTO gate_receipts
                         (cycle_id, candidate_path, kind, artifact_digest, measured_json,
                          decision, evaluator_id, base_model_id, eval_suite_version,
                          gate_policy_version, receipt_version, minted_at, hmac, consumed_at)

--- a/native/macos/Fae/Sources/Fae/Memory/ImprovementStore.swift
+++ b/native/macos/Fae/Sources/Fae/Memory/ImprovementStore.swift
@@ -924,6 +924,22 @@ actor ImprovementStore {
         }
     }
 
+    /// Whether ANY consumed gate receipt exists for a given candidate/adapter path
+    /// (P9/C4 W5). Used by recovery to tell a genuinely-deployed `currentAdapterPath`
+    /// (which always has a consumed receipt from its deploy) apart from a pre-P9 un-gated
+    /// candidate (which has none).
+    func hasConsumedReceipt(forCandidatePath path: String) throws -> Bool {
+        guard let db else { throw ImprovementStoreError.notOpen }
+        return try db.read { db in
+            let count = try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM gate_receipts WHERE candidate_path = ? AND consumed_at IS NOT NULL",
+                arguments: [path]
+            ) ?? 0
+            return count > 0
+        }
+    }
+
     /// Whether the receipt for a cycle has already been consumed (single-use gate).
     func isGateReceiptConsumed(cycleId: String) throws -> Bool {
         guard let db else { throw ImprovementStoreError.notOpen }

--- a/native/macos/Fae/Sources/Fae/Memory/ImprovementStore.swift
+++ b/native/macos/Fae/Sources/Fae/Memory/ImprovementStore.swift
@@ -76,6 +76,19 @@ struct ImprovementState: Sendable {
     var metaOptLastRunAt: String?
     /// Consecutive cycles with zero kept changes (plateau detection).
     var metaOptConsecutiveNoImprovement: Int
+
+    // P9/C4 (W3) — candidate state, kept SEPARATE from the deployed pointer.
+
+    /// The candidate adapter under evaluation. Written by the training step; it is
+    /// NEVER the deployed pointer. Promoted to `currentAdapterPath` only by a gated
+    /// deploy, and cleared on any terminal non-deploy outcome (block / reject /
+    /// abort). This keeps an un-evaluated candidate from ever polluting the live
+    /// `currentAdapterPath`, on any path or after a crash.
+    var pendingAdapterPath: String? = nil
+
+    /// The candidate's artifact kind ("gguf" | "mlxDir"), for the W4 evaluator and
+    /// deploy routing.
+    var pendingAdapterKind: String? = nil
 }
 
 /// A detected gap between current Fae capabilities and desired behaviour.
@@ -216,7 +229,9 @@ actor ImprovementStore {
                 training_started_at   TEXT,
                 last_cycle_error      TEXT,
                 deferral_count        INTEGER NOT NULL DEFAULT 0,
-                previous_directive    TEXT
+                previous_directive    TEXT,
+                pending_adapter_path  TEXT,
+                pending_adapter_kind  TEXT
             )
         """)
         // Migration: add columns to existing databases that lack them.
@@ -240,6 +255,14 @@ actor ImprovementStore {
         }
         if !columnNames.contains("meta_opt_consecutive_no_improvement") {
             try db.execute(sql: "ALTER TABLE improvement_state ADD COLUMN meta_opt_consecutive_no_improvement INTEGER NOT NULL DEFAULT 0")
+        }
+        // Migration: candidate (pending) adapter columns, kept separate from the
+        // deployed pointer (P9/C4 W3).
+        if !columnNames.contains("pending_adapter_path") {
+            try db.execute(sql: "ALTER TABLE improvement_state ADD COLUMN pending_adapter_path TEXT")
+        }
+        if !columnNames.contains("pending_adapter_kind") {
+            try db.execute(sql: "ALTER TABLE improvement_state ADD COLUMN pending_adapter_kind TEXT")
         }
         try db.execute(sql: """
             CREATE TABLE IF NOT EXISTS capability_gaps (
@@ -444,7 +467,8 @@ actor ImprovementStore {
                        previous_adapter_path, training_started_at, last_cycle_error,
                        deferral_count, previous_directive,
                        meta_opt_kept_total, meta_opt_tested_total,
-                       meta_opt_last_run_at, meta_opt_consecutive_no_improvement
+                       meta_opt_last_run_at, meta_opt_consecutive_no_improvement,
+                       pending_adapter_path, pending_adapter_kind
                 FROM improvement_state LIMIT 1
             """) else {
                 throw ImprovementStoreError.stateNotInitialised
@@ -467,7 +491,8 @@ actor ImprovementStore {
                             last_cycle_error = ?, deferral_count = ?,
                             previous_directive = ?,
                             meta_opt_kept_total = ?, meta_opt_tested_total = ?,
-                            meta_opt_last_run_at = ?, meta_opt_consecutive_no_improvement = ?
+                            meta_opt_last_run_at = ?, meta_opt_consecutive_no_improvement = ?,
+                            pending_adapter_path = ?, pending_adapter_kind = ?
                         WHERE id = ?
                     """,
                     arguments: [
@@ -478,6 +503,7 @@ actor ImprovementStore {
                         state.deferralCount, state.previousDirective,
                         state.metaOptKeptTotal, state.metaOptTestedTotal,
                         state.metaOptLastRunAt, state.metaOptConsecutiveNoImprovement,
+                        state.pendingAdapterPath, state.pendingAdapterKind,
                         id,
                     ]
                 )
@@ -490,8 +516,9 @@ actor ImprovementStore {
                              previous_adapter_path, training_started_at, last_cycle_error,
                              deferral_count, previous_directive,
                              meta_opt_kept_total, meta_opt_tested_total,
-                             meta_opt_last_run_at, meta_opt_consecutive_no_improvement)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                             meta_opt_last_run_at, meta_opt_consecutive_no_improvement,
+                             pending_adapter_path, pending_adapter_kind)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     arguments: [
                         state.cycleState, state.lastCycleAt,
@@ -501,6 +528,7 @@ actor ImprovementStore {
                         state.deferralCount, state.previousDirective,
                         state.metaOptKeptTotal, state.metaOptTestedTotal,
                         state.metaOptLastRunAt, state.metaOptConsecutiveNoImprovement,
+                        state.pendingAdapterPath, state.pendingAdapterKind,
                     ]
                 )
             }
@@ -762,7 +790,9 @@ actor ImprovementStore {
             metaOptKeptTotal: Int(row["meta_opt_kept_total"] as? Int64 ?? 0),
             metaOptTestedTotal: Int(row["meta_opt_tested_total"] as? Int64 ?? 0),
             metaOptLastRunAt: row["meta_opt_last_run_at"],
-            metaOptConsecutiveNoImprovement: Int(row["meta_opt_consecutive_no_improvement"] as? Int64 ?? 0)
+            metaOptConsecutiveNoImprovement: Int(row["meta_opt_consecutive_no_improvement"] as? Int64 ?? 0),
+            pendingAdapterPath: row["pending_adapter_path"],
+            pendingAdapterKind: row["pending_adapter_kind"]
         )
     }
 

--- a/native/macos/Fae/Sources/Fae/Resources/Models/daemon-ab-eval-v1.json
+++ b/native/macos/Fae/Sources/Fae/Resources/Models/daemon-ab-eval-v1.json
@@ -1,0 +1,320 @@
+{
+  "suiteVersion": "daemon-ab-v1",
+  "examples": [
+    {
+      "id": "tool-001",
+      "dimension": "toolCalling",
+      "system": "You are Fae. Pick the most relevant tool call when one of the available tools fits. If no tool fits, answer in plain text.",
+      "prompt": "What's the weather in Edinburgh right now?",
+      "tools": [
+        {
+          "name": "get_weather",
+          "description": "Get the current weather for a location.",
+          "parameters": {
+            "type": "object",
+            "properties": { "location": { "type": "string" } },
+            "required": ["location"]
+          }
+        }
+      ],
+      "scoring": { "type": "expectToolCall", "name": "get_weather", "requiredArgs": ["location"] }
+    },
+    {
+      "id": "tool-002",
+      "dimension": "toolCalling",
+      "system": "You are Fae. Pick the most relevant tool call when one of the available tools fits. If no tool fits, answer in plain text.",
+      "prompt": "Set a timer for ten minutes.",
+      "tools": [
+        {
+          "name": "set_timer",
+          "description": "Start a countdown timer.",
+          "parameters": {
+            "type": "object",
+            "properties": { "seconds": { "type": "integer" } },
+            "required": ["seconds"]
+          }
+        }
+      ],
+      "scoring": { "type": "expectToolCall", "name": "set_timer", "requiredArgs": ["seconds"] }
+    },
+    {
+      "id": "tool-003",
+      "dimension": "toolCalling",
+      "system": "You are Fae. Pick the most relevant tool call when one of the available tools fits. If no tool fits, answer in plain text.",
+      "prompt": "Find me some quotes about courage.",
+      "tools": [
+        {
+          "name": "quotes_by_keyword",
+          "description": "Return quotes matching a keyword.",
+          "parameters": {
+            "type": "object",
+            "properties": { "word": { "type": "string" } },
+            "required": ["word"]
+          }
+        }
+      ],
+      "scoring": { "type": "expectToolCall", "name": "quotes_by_keyword", "requiredArgs": ["word"] }
+    },
+    {
+      "id": "tool-004",
+      "dimension": "toolCalling",
+      "system": "You are Fae. Pick the most relevant tool call when one of the available tools fits. If no tool fits, answer in plain text.",
+      "prompt": "Add bread and milk to my shopping list.",
+      "tools": [
+        {
+          "name": "add_to_list",
+          "description": "Append items to a named list.",
+          "parameters": {
+            "type": "object",
+            "properties": { "list": { "type": "string" }, "items": { "type": "array" } },
+            "required": ["list", "items"]
+          }
+        }
+      ],
+      "scoring": { "type": "expectToolCall", "name": "add_to_list", "requiredArgs": ["list", "items"] }
+    },
+    {
+      "id": "tool-005",
+      "dimension": "toolCalling",
+      "system": "You are Fae. Pick the most relevant tool call when one of the available tools fits. If no tool fits, answer in plain text.",
+      "prompt": "Thanks, that's all I needed for now.",
+      "tools": [
+        {
+          "name": "get_weather",
+          "description": "Get the current weather for a location.",
+          "parameters": {
+            "type": "object",
+            "properties": { "location": { "type": "string" } },
+            "required": ["location"]
+          }
+        }
+      ],
+      "scoring": { "type": "expectNoToolCall" }
+    },
+    {
+      "id": "tool-006",
+      "dimension": "toolCalling",
+      "system": "You are Fae. Pick the most relevant tool call when one of the available tools fits. If no tool fits, answer in plain text.",
+      "prompt": "What's your favourite colour?",
+      "tools": [
+        {
+          "name": "set_timer",
+          "description": "Start a countdown timer.",
+          "parameters": {
+            "type": "object",
+            "properties": { "seconds": { "type": "integer" } },
+            "required": ["seconds"]
+          }
+        }
+      ],
+      "scoring": { "type": "expectNoToolCall" }
+    },
+    {
+      "id": "tool-007",
+      "dimension": "toolCalling",
+      "system": "You are Fae. Pick the most relevant tool call when one of the available tools fits. If no tool fits, answer in plain text.",
+      "prompt": "Search the web for the latest Mars rover news.",
+      "tools": [
+        {
+          "name": "web_search",
+          "description": "Search the web for a query.",
+          "parameters": {
+            "type": "object",
+            "properties": { "query": { "type": "string" } },
+            "required": ["query"]
+          }
+        }
+      ],
+      "scoring": { "type": "expectToolCall", "name": "web_search", "requiredArgs": ["query"] }
+    },
+    {
+      "id": "tool-008",
+      "dimension": "toolCalling",
+      "system": "You are Fae. Pick the most relevant tool call when one of the available tools fits. If no tool fits, answer in plain text.",
+      "prompt": "Remind me to call mum tomorrow at 6pm.",
+      "tools": [
+        {
+          "name": "create_reminder",
+          "description": "Create a reminder.",
+          "parameters": {
+            "type": "object",
+            "properties": { "text": { "type": "string" }, "when": { "type": "string" } },
+            "required": ["text", "when"]
+          }
+        }
+      ],
+      "scoring": { "type": "expectToolCall", "name": "create_reminder", "requiredArgs": ["text", "when"] }
+    },
+
+    {
+      "id": "ser-001",
+      "dimension": "serialization",
+      "system": "You are Fae. Extract durable user facts worth long-term memory. Output one fact per line using the format STORE: key = value. Output nothing else.",
+      "prompt": "Candidate profile text: Ada Lovelace was born on 10 December 1815 in London. She was a mathematician.",
+      "scoring": { "type": "expectLinesPrefixed", "prefix": "STORE:", "minLines": 1 }
+    },
+    {
+      "id": "ser-002",
+      "dimension": "serialization",
+      "system": "You are Fae. Extract durable user facts worth long-term memory. Output one fact per line using the format STORE: key = value. Output nothing else.",
+      "prompt": "Candidate profile text: Grace Hopper invented the first compiler and was a US Navy rear admiral.",
+      "scoring": { "type": "expectLinesPrefixed", "prefix": "STORE:", "minLines": 1 }
+    },
+    {
+      "id": "ser-003",
+      "dimension": "serialization",
+      "system": "You are Fae. Update durable user memory from new evidence. Output one action per line using STORE: key = value or SUPERSEDE: key = value. Output nothing else.",
+      "prompt": "Current remembered profile:\n**City:** Glasgow\n\nNew evidence: the user just moved to Edinburgh.",
+      "scoring": { "type": "expectLinesPrefixed", "prefix": "SUPERSEDE:", "minLines": 1 }
+    },
+    {
+      "id": "ser-004",
+      "dimension": "serialization",
+      "system": "You output only valid JSON. Respond with a JSON object with keys \"name\" and \"age\". Output nothing else.",
+      "prompt": "The user is called Mira and is 34 years old.",
+      "scoring": { "type": "expectJSONKeys", "keys": ["name", "age"] }
+    },
+    {
+      "id": "ser-005",
+      "dimension": "serialization",
+      "system": "You output only valid JSON. Respond with a JSON object with keys \"city\" and \"country\". Output nothing else.",
+      "prompt": "The capital of France is Paris.",
+      "scoring": { "type": "expectJSONKeys", "keys": ["city", "country"] }
+    },
+    {
+      "id": "ser-006",
+      "dimension": "serialization",
+      "system": "You are Fae. Extract durable user facts worth long-term memory. Output one fact per line using the format STORE: key = value. Output nothing else.",
+      "prompt": "Candidate profile text: The user's dog is a border collie named Skye.",
+      "scoring": { "type": "expectLinesPrefixed", "prefix": "STORE:", "minLines": 1 }
+    },
+    {
+      "id": "ser-007",
+      "dimension": "serialization",
+      "system": "You output only valid JSON. Respond with a JSON array of the three primary colours as strings. Output nothing else.",
+      "prompt": "List the primary colours.",
+      "scoring": { "type": "expectJSONArray", "minCount": 3 }
+    },
+    {
+      "id": "ser-008",
+      "dimension": "serialization",
+      "system": "You are Fae. Extract durable user facts worth long-term memory. Output one fact per line using the format STORE: key = value. Output nothing else.",
+      "prompt": "Candidate profile text: The user works as a marine biologist in Oban.",
+      "scoring": { "type": "expectLinesPrefixed", "prefix": "STORE:", "minLines": 1 }
+    },
+
+    {
+      "id": "cap-001",
+      "dimension": "faeCapability",
+      "system": "You are Fae, a warm, capable voice assistant. Answer correctly and concisely.",
+      "prompt": "What is the capital of Japan?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["tokyo"] }
+    },
+    {
+      "id": "cap-002",
+      "dimension": "faeCapability",
+      "system": "You are Fae, a warm, capable voice assistant. Answer correctly and concisely.",
+      "prompt": "What is 17 plus 25?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["42", "forty-two", "forty two"] }
+    },
+    {
+      "id": "cap-003",
+      "dimension": "faeCapability",
+      "system": "You are Fae, a warm, capable voice assistant. Answer correctly and concisely.",
+      "prompt": "Which planet is known as the Red Planet?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["mars"] }
+    },
+    {
+      "id": "cap-004",
+      "dimension": "faeCapability",
+      "system": "You are Fae, a warm, capable voice assistant. Answer correctly and concisely.",
+      "prompt": "How many days are in a leap year?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["366"] }
+    },
+    {
+      "id": "cap-005",
+      "dimension": "faeCapability",
+      "system": "You are Fae, a warm, capable voice assistant. Answer correctly and concisely.",
+      "prompt": "Who wrote the play Romeo and Juliet?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["shakespeare"] }
+    },
+    {
+      "id": "cap-006",
+      "dimension": "faeCapability",
+      "system": "You are Fae, a warm, capable voice assistant. Answer correctly and concisely.",
+      "prompt": "What gas do plants absorb from the air for photosynthesis?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["carbon dioxide", "co2", "co₂"] }
+    },
+    {
+      "id": "cap-007",
+      "dimension": "faeCapability",
+      "system": "You are Fae, a warm, capable voice assistant. Answer correctly and concisely.",
+      "prompt": "What is the chemical symbol for water?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["h2o", "h₂o"] }
+    },
+    {
+      "id": "cap-008",
+      "dimension": "faeCapability",
+      "system": "You are Fae, a warm, capable voice assistant. Answer correctly and concisely.",
+      "prompt": "In which country is the Eiffel Tower?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["france"] }
+    },
+
+    {
+      "id": "fit-001",
+      "dimension": "assistantFit",
+      "system": "You are Fae, a warm, concise, friendly voice assistant. Greet the user naturally.",
+      "prompt": "Hi Fae, good morning!",
+      "scoring": { "type": "expectKeywords", "anyOf": ["morning", "hello", "hi", "hey"], "forbidden": ["as an ai", "language model", "i cannot", "i'm unable"] }
+    },
+    {
+      "id": "fit-002",
+      "dimension": "assistantFit",
+      "system": "You are Fae, a warm, concise, friendly voice assistant.",
+      "prompt": "Can you help me plan my day?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["yes", "sure", "happy", "of course", "let's", "lets", "can"], "forbidden": ["as an ai", "language model"] }
+    },
+    {
+      "id": "fit-003",
+      "dimension": "assistantFit",
+      "system": "You are Fae, a warm, concise, friendly voice assistant.",
+      "prompt": "I'm feeling a bit stressed today.",
+      "scoring": { "type": "expectKeywords", "anyOf": ["sorry", "understand", "here", "okay", "ok", "take", "breath", "help"], "forbidden": ["as an ai", "language model"] }
+    },
+    {
+      "id": "fit-004",
+      "dimension": "assistantFit",
+      "system": "You are Fae, a warm, concise, friendly voice assistant. Keep replies short.",
+      "prompt": "Tell me a fun fact.",
+      "scoring": { "type": "expectNonEmpty", "forbidden": ["as an ai", "language model", "i cannot", "i'm unable"] }
+    },
+    {
+      "id": "fit-005",
+      "dimension": "assistantFit",
+      "system": "You are Fae, a warm, concise, friendly voice assistant.",
+      "prompt": "What's your name?",
+      "scoring": { "type": "expectKeywords", "anyOf": ["fae"], "forbidden": ["as an ai", "language model"] }
+    },
+    {
+      "id": "fit-006",
+      "dimension": "assistantFit",
+      "system": "You are Fae, a warm, concise, friendly voice assistant.",
+      "prompt": "Goodnight Fae.",
+      "scoring": { "type": "expectKeywords", "anyOf": ["night", "sleep", "rest", "bye", "well"], "forbidden": ["as an ai", "language model"] }
+    },
+    {
+      "id": "fit-007",
+      "dimension": "assistantFit",
+      "system": "You are Fae, a warm, concise, friendly voice assistant.",
+      "prompt": "Thank you so much, that was really helpful.",
+      "scoring": { "type": "expectKeywords", "anyOf": ["welcome", "glad", "happy", "pleasure", "anytime", "no problem"], "forbidden": ["as an ai", "language model"] }
+    },
+    {
+      "id": "fit-008",
+      "dimension": "assistantFit",
+      "system": "You are Fae, a warm, concise, friendly voice assistant.",
+      "prompt": "Could you remind me why you're here?",
+      "scoring": { "type": "expectNonEmpty", "forbidden": ["as an ai", "language model", "i cannot", "i'm unable"] }
+    }
+  ]
+}

--- a/native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift
@@ -113,6 +113,13 @@ enum AdapterDeploymentManager {
     /// caller (ImprovementCycleCoordinator) is responsible for signaling
     /// the pipeline to swap adapters via SelfConfigTool.
     ///
+    /// > ⚠️ P9/C4 (W4 — pending): this writes an ARBITRARY path straight to
+    /// > `currentAdapterPath` with no gate. It is currently called only from tests;
+    /// > the autonomous loop deploys via `ImprovementCycleCoordinator.performDeploy`
+    /// > (which promotes a gated `pendingAdapterPath`). W4 fences this entry point
+    /// > to consume only a receipt-bearing candidate (F4). Do NOT wire it into the
+    /// > production loop before then.
+    ///
     /// - Parameters:
     ///   - adapterPath: Path to the adapter to deploy.
     ///   - store: The improvement store to update.

--- a/native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 // MARK: - DeploymentProposal
@@ -106,30 +107,39 @@ enum AdapterDeploymentManager {
 
     // MARK: - Deploy
 
-    /// Deploy a candidate adapter by updating the improvement state.
+    /// Deploy a **receipt-gated** candidate by updating the improvement state.
     ///
-    /// Moves the current adapter to `previousAdapterPath` and sets the new
-    /// adapter as `currentAdapterPath`. Does NOT trigger model reload — the
-    /// caller (ImprovementCycleCoordinator) is responsible for signaling
-    /// the pipeline to swap adapters via SelfConfigTool.
+    /// Moves the current adapter to `previousAdapterPath` and promotes the receipt's
+    /// candidate to `currentAdapterPath`. Does NOT trigger model reload — the caller is
+    /// responsible for signalling the pipeline to swap adapters.
     ///
-    /// > ⚠️ P9/C4 (W4 — pending): this writes an ARBITRARY path straight to
-    /// > `currentAdapterPath` with no gate. It is currently called only from tests;
-    /// > the autonomous loop deploys via `ImprovementCycleCoordinator.performDeploy`
-    /// > (which promotes a gated `pendingAdapterPath`). W4 fences this entry point
-    /// > to consume only a receipt-bearing candidate (F4). Do NOT wire it into the
-    /// > production loop before then.
+    /// P9/C4 (W4, F4): the previous `deploy(adapterPath:)` wrote an ARBITRARY path with
+    /// no gate. It now requires a verifying, unconsumed `GateReceipt` — there is no longer
+    /// any path in the codebase that deploys an un-gated adapter. The autonomous loop
+    /// deploys via `ImprovementCycleCoordinator.performDeploy`; this util mirrors that
+    /// gate for out-of-loop/manual use.
     ///
     /// - Parameters:
-    ///   - adapterPath: Path to the adapter to deploy.
+    ///   - receipt: A receipt that passed the eval gate for its `candidatePath`.
     ///   - store: The improvement store to update.
-    static func deploy(adapterPath: String, store: ImprovementStore) async throws {
+    ///   - key: HMAC key to verify the receipt (production: the Keychain key).
+    static func deploy(
+        receipt: GateReceipt, store: ImprovementStore, verifyingWith key: SymmetricKey
+    ) async throws {
+        try GateReceiptVerifier.verify(
+            receipt, expectedCandidatePath: receipt.candidatePath, using: key
+        )
         try await store.ensureStateRow()
         var state = try await store.readState()
         state.previousAdapterPath = state.currentAdapterPath
-        state.currentAdapterPath = adapterPath
-        try await store.writeState(state)
-        NSLog("AdapterDeploymentManager: deployed adapter at %@", adapterPath)
+        state.currentAdapterPath = receipt.candidatePath
+        // Atomic promote + consume: requires a STORED, unconsumed receipt row or the whole
+        // transaction rolls back (throws `receiptNotConsumable`). A merely signed receipt
+        // object that was never persisted by an evaluator cannot deploy.
+        try await store.promoteAndConsumeReceipt(
+            state: state, cycleId: receipt.cycleId, at: ISO8601DateFormatter().string(from: Date())
+        )
+        NSLog("AdapterDeploymentManager: deployed receipt-gated adapter at %@", receipt.candidatePath)
     }
 
     // MARK: - Rollback

--- a/native/macos/Fae/Sources/Fae/Scheduler/AdapterEvaluator.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/AdapterEvaluator.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+// MARK: - GateOutcome (P9/C4 W7)
+
+/// The result of evaluating a candidate adapter against the deployed baseline.
+///
+/// Carries the **measured** correctness deltas plus the receipt provenance fields
+/// the coordinator needs to mint a `GateReceipt`. A non-measurement is expressed
+/// as `delta == .unmeasured` so the fail-closed gate (`AdapterGate.decide`) blocks
+/// it — the evaluator never fabricates a synthetic zero-delta "pass".
+struct GateOutcome: Sendable {
+    /// The measured deltas (candidate minus baseline; positive = improvement).
+    /// `.unmeasured` when the evaluator could not produce a real measurement.
+    let delta: EvalDelta
+    /// The baseline the candidate was evaluated AGAINST — the deployed adapter
+    /// (or the base model id when nothing is deployed). Bound into the receipt so a
+    /// pass can never be claimed against the wrong baseline.
+    let baseModelId: String
+    /// Version of the held-out eval suite that produced `delta` (drift guard, bound
+    /// into the receipt).
+    let evalSuiteVersion: String
+}
+
+// MARK: - AdapterEvaluator (P9/C4 W7)
+
+/// Errors surfaced by an `AdapterEvaluator`.
+enum AdapterEvaluatorError: Error, CustomStringConvertible {
+    /// The evaluator's backing harness (e.g. the FaeBenchmark binary) is not configured.
+    case notAvailable(String)
+    /// The evaluation ran but could not produce a usable measurement.
+    case measurementFailed(String)
+
+    var description: String {
+        switch self {
+        case .notAvailable(let why): return "evaluator not available: \(why)"
+        case .measurementFailed(let why): return "evaluation failed: \(why)"
+        }
+    }
+}
+
+/// Evaluates a freshly trained candidate adapter against the currently DEPLOYED
+/// adapter and returns the measured correctness deltas (P9/C4 W7).
+///
+/// The seam exists so each adapter lane gets a lane-appropriate, real evaluator:
+/// - `FaeBenchmarkEvaluator` (`.mlxDir`) wraps the MLX FaeBenchmark binary (W7a).
+/// - `DaemonABEvaluator` (`.gguf`) scale-0/1 A/Bs the daemon adapter (W7b — not yet).
+///
+/// An evaluator's `evaluatorId` MUST be on `GatePolicy.allowedEvaluators` or the
+/// receipt it mints can never verify. The coordinator mints the receipt; the
+/// evaluator only measures (so the privileged minting path stays singular).
+protocol AdapterEvaluator: Sendable {
+    /// The adapter kind this evaluator can score (drives lane selection).
+    var kind: AdapterKind { get }
+    /// Stable id stamped into the minted receipt — must be on the gate allowlist.
+    var evaluatorId: String { get }
+    /// Whether the evaluator's backing harness is configured and usable right now.
+    /// `false` ⇒ the lane stays blocked (W6) rather than burning a training run.
+    func isAvailable() async -> Bool
+    /// Evaluate `candidatePath` against `baselinePath` (the deployed adapter, or
+    /// `nil` for the base model) and return the measured outcome.
+    ///
+    /// - Throws: `AdapterEvaluatorError` if the harness is unavailable or the
+    ///   measurement fails — the coordinator treats a throw as fail-closed.
+    func evaluate(candidatePath: String, baselinePath: String?) async throws -> GateOutcome
+}
+
+// MARK: - FaeBenchmarkEvaluator (mlxDir lane, P9/C4 W7a)
+
+/// Evaluates an MLX adapter directory by running the FaeBenchmark binary on the
+/// candidate and on the deployed baseline, then differencing the accuracies.
+///
+/// ## Baseline = the DEPLOYED adapter, not the base model
+/// The gate measures whether the candidate improves on **what is live today**, not
+/// on the untrained base model. Scoring the candidate against the deployed adapter
+/// is the only delta that answers "should I replace what the user already has?" —
+/// a candidate that beats the base model but regresses against the deployed adapter
+/// must NOT pass. When nothing is deployed (`baselinePath == nil`) the base model is
+/// the baseline (the first adapter genuinely competes against base).
+struct FaeBenchmarkEvaluator: AdapterEvaluator {
+    let bridge: TrainingBridge
+    /// The eval-suite version stamped into the receipt (drift guard).
+    let evalSuiteVersion: String
+
+    var kind: AdapterKind { .mlxDir }
+    var evaluatorId: String { "FaeBenchmarkEvaluator" }
+
+    init(bridge: TrainingBridge, evalSuiteVersion: String = "faebench-v1") {
+        self.bridge = bridge
+        self.evalSuiteVersion = evalSuiteVersion
+    }
+
+    func isAvailable() async -> Bool {
+        await bridge.isBenchmarkAvailable
+    }
+
+    func evaluate(candidatePath: String, baselinePath: String?) async throws -> GateOutcome {
+        guard await bridge.isBenchmarkAvailable else {
+            throw AdapterEvaluatorError.notAvailable("FaeBenchmark binary not configured")
+        }
+        do {
+            // Baseline = the DEPLOYED adapter (or base model when none is deployed).
+            let baseline = try await bridge.runBenchmark(adapterPath: baselinePath)
+            let candidate = try await bridge.runBenchmark(adapterPath: candidatePath)
+            let delta = candidate.delta(from: baseline)
+            // baseModelId records WHAT the candidate was scored against, so a receipt
+            // can never claim a pass vs the wrong baseline. Use the BASELINE run's path
+            // (the deployed adapter) when one is deployed, else the baseline run's
+            // modelId (the un-adapted base model the baseline actually scored) — NOT the
+            // candidate's, which would misread a base-model baseline as a deployed adapter.
+            let baseModelId = baselinePath ?? baseline.modelId
+            return GateOutcome(
+                delta: delta, baseModelId: baseModelId, evalSuiteVersion: evalSuiteVersion
+            )
+        } catch {
+            throw AdapterEvaluatorError.measurementFailed(error.localizedDescription)
+        }
+    }
+}

--- a/native/macos/Fae/Sources/Fae/Scheduler/DaemonABEvaluator.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/DaemonABEvaluator.swift
@@ -1,0 +1,556 @@
+import CryptoKit
+import Foundation
+
+// MARK: - DaemonABEvaluator (gguf lane, P9/C4 W7b)
+
+/// Errors specific to the daemon-lane A/B evaluator. Mapped to
+/// `AdapterEvaluatorError` at the `AdapterEvaluator.evaluate` boundary so the
+/// coordinator's fail-closed handling stays uniform.
+enum DaemonABEvaluatorError: Error, CustomStringConvertible {
+    /// The bundled held-out eval suite is missing or fails its SHA-256 lock.
+    case evalSuiteUnavailable(String)
+    /// The A/B exceeded its wall-clock bound. The deployed adapter is restored first.
+    case timedOut(seconds: Int)
+    /// The live daemon could not be confirmed back on the deployed adapter after eval.
+    /// This is the deploy-without-receipt hole — a daemon left on the un-gated
+    /// candidate — and is therefore loud and fail-closed.
+    case restoreUnconfirmed(expected: String, found: String)
+
+    var description: String {
+        switch self {
+        case .evalSuiteUnavailable(let why): return "daemon A/B eval suite unavailable: \(why)"
+        case .timedOut(let s): return "daemon A/B eval timed out after \(s)s"
+        case .restoreUnconfirmed(let expected, let found):
+            return "daemon A/B eval could not restore deployed adapter "
+                + "(expected \(expected), daemon reports \(found))"
+        }
+    }
+}
+
+// MARK: - Daemon client seam (testable)
+
+/// The single inference result the evaluator scores: the model's spoken text plus
+/// any structured tool calls it emitted (name + argument keys are enough for the
+/// deterministic tool-call scorers).
+struct DaemonABInference: Sendable, Equatable {
+    let text: String
+    let toolCalls: [ToolCallSummary]
+
+    struct ToolCallSummary: Sendable, Equatable {
+        let name: String
+        let argKeys: [String]
+    }
+}
+
+/// The narrow surface the daemon-lane A/B evaluator needs. Abstracted so unit
+/// tests inject a fake that returns canned outputs and records the
+/// reload/scale/infer call sequence — the ONLY way to test the A/B orchestration
+/// + restore-on-every-exit safety property without a live daemon.
+protocol DaemonABClient: Sendable {
+    /// Reload the sidecar with a personal adapter GGUF (or `nil` for base). A
+    /// non-nil path also activates the adapter (scale 1.0), per the daemon lane.
+    func reload(path: String?) async throws
+    /// Set the personal-LoRA scale on the running sidecar (0.0 = base, 1.0 = on).
+    func setScale(_ scale: Float) async throws
+    /// Run one held-out eval example and return text + tool-call structure.
+    func infer(_ example: DaemonEvalExample) async throws -> DaemonABInference
+    /// The adapter the sidecar currently serves (`nil` = base model). Used to
+    /// CONFIRM the deployed adapter was restored after eval.
+    func loadedAdapterPath() async throws -> String?
+}
+
+/// Production `DaemonABClient` wrapping the live `DaemonLLMEngine`. Translates the
+/// held-out example into a plain text turn with the example's tools.
+struct LiveDaemonABClient: DaemonABClient {
+    let engine: DaemonLLMEngine
+    /// Generation cap per eval prompt — eval answers are short; keeps the A/B bounded.
+    let maxTokens: Int
+
+    init(engine: DaemonLLMEngine, maxTokens: Int = 256) {
+        self.engine = engine
+        self.maxTokens = maxTokens
+    }
+
+    func reload(path: String?) async throws {
+        try await engine.reloadAdapter(path: path)
+    }
+
+    func setScale(_ scale: Float) async throws {
+        try await engine.setAdapterScale(scale)
+    }
+
+    func infer(_ example: DaemonEvalExample) async throws -> DaemonABInference {
+        let options = GenerationOptions(
+            temperature: 0.0,
+            maxTokens: maxTokens,
+            suppressThinking: true,
+            tools: example.toolSpecs
+        )
+        let turn = try await engine.inferForEval(
+            messages: [LLMMessage(role: .user, content: example.prompt)],
+            systemPrompt: example.system,
+            options: options
+        )
+        let calls = turn.toolCalls.map {
+            DaemonABInference.ToolCallSummary(name: $0.name, argKeys: Array($0.arguments.keys))
+        }
+        return DaemonABInference(text: turn.text, toolCalls: calls)
+    }
+
+    func loadedAdapterPath() async throws -> String? {
+        try await engine.runtimeStatus()?.path
+    }
+}
+
+// MARK: - Held-out eval suite (SHA-locked bundled resource)
+
+/// One scored held-out example. `dimension` maps it to a `GateDimension`; `scoring`
+/// is a purely rule-based key (NO LLM re-judging).
+struct DaemonEvalExample: Sendable, Codable {
+    let id: String
+    let dimension: String
+    let system: String
+    let prompt: String
+    let tools: [ToolSpec]?
+    let scoring: Scoring
+
+    /// A minimal tool spec (daemon flattens it to `{name, description, parameters}`).
+    struct ToolSpec: Sendable, Codable {
+        let name: String
+        let description: String
+        let parameters: JSONValue
+    }
+
+    /// The deterministic scoring rule for an example.
+    struct Scoring: Sendable, Codable {
+        let type: String
+        let name: String?
+        let requiredArgs: [String]?
+        let prefix: String?
+        let minLines: Int?
+        let keys: [String]?
+        let minCount: Int?
+        let anyOf: [String]?
+        let forbidden: [String]?
+    }
+
+    /// Tools in the MLX/daemon ToolSpec wire shape (`{type, function:{...}}`) the
+    /// engine expects in `GenerationOptions.tools`.
+    var toolSpecs: [[String: any Sendable]]? {
+        guard let tools, !tools.isEmpty else { return nil }
+        return tools.map { spec in
+            [
+                "type": "function",
+                "function": [
+                    "name": spec.name,
+                    "description": spec.description,
+                    "parameters": spec.parameters.anyValue,
+                ] as [String: Any],
+            ] as [String: any Sendable]
+        }
+    }
+
+    /// The `GateDimension` this example contributes to, or nil for an unknown label.
+    var gateDimension: GateDimension? {
+        GateDimension(rawValue: dimension)
+    }
+}
+
+/// A JSON value that round-trips arbitrary tool-parameter schemas through Codable.
+/// (`[String: Any]` is not Codable; tool parameter schemas are nested/arbitrary.)
+enum JSONValue: Sendable, Codable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { self = .null; return }
+        if let b = try? c.decode(Bool.self) { self = .bool(b); return }
+        if let n = try? c.decode(Double.self) { self = .number(n); return }
+        if let s = try? c.decode(String.self) { self = .string(s); return }
+        if let o = try? c.decode([String: JSONValue].self) { self = .object(o); return }
+        if let a = try? c.decode([JSONValue].self) { self = .array(a); return }
+        throw DecodingError.dataCorruptedError(
+            in: c, debugDescription: "unsupported JSON value")
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .string(let s): try c.encode(s)
+        case .number(let n): try c.encode(n)
+        case .bool(let b): try c.encode(b)
+        case .object(let o): try c.encode(o)
+        case .array(let a): try c.encode(a)
+        case .null: try c.encodeNil()
+        }
+    }
+
+    var anyValue: Any {
+        switch self {
+        case .string(let s): return s
+        case .number(let n): return n
+        case .bool(let b): return b
+        case .object(let o): return o.mapValues { $0.anyValue }
+        case .array(let a): return a.map { $0.anyValue }
+        case .null: return NSNull()
+        }
+    }
+}
+
+/// The bundled, SHA-locked held-out eval set. Loading it verifies the on-disk
+/// bytes against `lockedSHA256` so the gate is reproducible: a drifted suite is
+/// rejected rather than silently changing what a pass means.
+struct DaemonEvalSuite: Sendable {
+    let suiteVersion: String
+    let examples: [DaemonEvalExample]
+
+    /// Resource name + SHA-256 lock of the bundled eval set. A mismatch fails
+    /// closed (the evaluator reports unavailable, leaving the lane blocked).
+    static let resourceName = "daemon-ab-eval-v1"
+    static let lockedSHA256 = "49f9bec4bd9a42eb3624d9032e7e21a07000e3d2cf25106dd64291ba8def06c4"
+
+    private struct Wire: Codable {
+        let suiteVersion: String
+        let examples: [DaemonEvalExample]
+    }
+
+    /// Load + SHA-verify the bundled eval suite. Returns nil only via a thrown
+    /// `evalSuiteUnavailable` (so the caller fails closed loudly, never silently).
+    static func loadBundled() throws -> DaemonEvalSuite {
+        guard let url = Bundle.faeResources.url(
+            forResource: resourceName, withExtension: "json", subdirectory: "Models")
+        else {
+            throw DaemonABEvaluatorError.evalSuiteUnavailable("bundled resource not found: \(resourceName).json")
+        }
+        return try load(contentsOf: url)
+    }
+
+    /// Load from an explicit URL (tests point this at a temp file with a matching lock).
+    static func load(contentsOf url: URL, expectedSHA256: String = lockedSHA256) throws -> DaemonEvalSuite {
+        guard let data = FileManager.default.contents(atPath: url.path) else {
+            throw DaemonABEvaluatorError.evalSuiteUnavailable("could not read \(url.path)")
+        }
+        let digest = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+        guard digest == expectedSHA256 else {
+            throw DaemonABEvaluatorError.evalSuiteUnavailable(
+                "eval-suite SHA mismatch (expected \(expectedSHA256), got \(digest))")
+        }
+        let wire: Wire
+        do {
+            wire = try JSONDecoder().decode(Wire.self, from: data)
+        } catch {
+            throw DaemonABEvaluatorError.evalSuiteUnavailable("decode failed: \(error)")
+        }
+        guard !wire.examples.isEmpty else {
+            throw DaemonABEvaluatorError.evalSuiteUnavailable("eval suite has no examples")
+        }
+        // Every example must map to a real gate dimension and cover all four — a
+        // partial suite could never produce a COMPLETE measurement (W1 fail-closed).
+        let covered = Set(wire.examples.compactMap { $0.gateDimension })
+        guard covered == Set(GateDimension.allCases) else {
+            throw DaemonABEvaluatorError.evalSuiteUnavailable(
+                "eval suite does not cover every gate dimension (covered: \(covered.map(\.rawValue).sorted()))")
+        }
+        return DaemonEvalSuite(suiteVersion: wire.suiteVersion, examples: wire.examples)
+    }
+}
+
+// MARK: - Deterministic scorers (pure, offline)
+
+/// Rule-based pass/fail for one example given the model's inference. NO LLM
+/// re-judging — every rule is a deterministic string/JSON check so the same
+/// answer always scores the same way (reproducible gate).
+enum DaemonEvalScorer {
+    /// `true` ⇒ the model answered this example correctly under the rule.
+    static func isCorrect(_ inference: DaemonABInference, scoring: DaemonEvalExample.Scoring) -> Bool {
+        let text = inference.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = text.lowercased()
+        switch scoring.type {
+        case "expectToolCall":
+            guard let call = inference.toolCalls.first(where: { $0.name == scoring.name }) else {
+                return false
+            }
+            let required = Set(scoring.requiredArgs ?? [])
+            return required.isSubset(of: Set(call.argKeys))
+        case "expectNoToolCall":
+            return inference.toolCalls.isEmpty && !text.isEmpty
+        case "expectLinesPrefixed":
+            guard let prefix = scoring.prefix else { return false }
+            let min = scoring.minLines ?? 1
+            let matching = text.split(whereSeparator: \.isNewline)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { $0.hasPrefix(prefix) }
+            return matching.count >= min
+        case "expectJSONKeys":
+            guard let keys = scoring.keys, let obj = firstJSONObject(in: text) else { return false }
+            return Set(keys).isSubset(of: Set(obj.keys))
+        case "expectJSONArray":
+            guard let array = firstJSONArray(in: text) else { return false }
+            return array.count >= (scoring.minCount ?? 1)
+        case "expectKeywords":
+            if containsForbidden(lower, scoring.forbidden) { return false }
+            let anyOf = scoring.anyOf ?? []
+            guard !anyOf.isEmpty else { return !text.isEmpty }
+            return anyOf.contains { lower.contains($0.lowercased()) }
+        case "expectNonEmpty":
+            if containsForbidden(lower, scoring.forbidden) { return false }
+            return !text.isEmpty
+        default:
+            return false
+        }
+    }
+
+    private static func containsForbidden(_ lower: String, _ forbidden: [String]?) -> Bool {
+        guard let forbidden, !forbidden.isEmpty else { return false }
+        return forbidden.contains { lower.contains($0.lowercased()) }
+    }
+
+    /// Extract the first balanced `{...}` JSON object from possibly-fenced text.
+    static func firstJSONObject(in text: String) -> [String: Any]? {
+        firstJSON(in: text, open: "{", close: "}") as? [String: Any]
+    }
+
+    static func firstJSONArray(in text: String) -> [Any]? {
+        firstJSON(in: text, open: "[", close: "]") as? [Any]
+    }
+
+    private static func firstJSON(in text: String, open: Character, close: Character) -> Any? {
+        guard let start = text.firstIndex(of: open) else { return nil }
+        var depth = 0
+        var idx = start
+        while idx < text.endIndex {
+            let ch = text[idx]
+            if ch == open { depth += 1 } else if ch == close {
+                depth -= 1
+                if depth == 0 {
+                    let slice = String(text[start...idx])
+                    if let data = slice.data(using: .utf8),
+                       let obj = try? JSONSerialization.jsonObject(with: data) {
+                        return obj
+                    }
+                    return nil
+                }
+            }
+            idx = text.index(after: idx)
+        }
+        return nil
+    }
+
+    /// Per-dimension accuracy = correct / total (mirrors `parseBenchmarkOutput`).
+    /// Returns nil for a dimension with no examples (cannot produce an accuracy).
+    static func accuracyByDimension(
+        results: [(dimension: GateDimension, correct: Bool)]
+    ) -> [GateDimension: Double] {
+        var counts: [GateDimension: (correct: Int, total: Int)] = [:]
+        for r in results {
+            var c = counts[r.dimension] ?? (0, 0)
+            c.total += 1
+            if r.correct { c.correct += 1 }
+            counts[r.dimension] = c
+        }
+        var acc: [GateDimension: Double] = [:]
+        for (dim, c) in counts where c.total > 0 {
+            acc[dim] = Double(c.correct) / Double(c.total)
+        }
+        return acc
+    }
+}
+
+// MARK: - DaemonABEvaluator
+
+/// Evaluates a freshly-trained GGUF LoRA **candidate** against the **DEPLOYED**
+/// adapter by A/B-testing the live llama.cpp daemon over a SHA-locked held-out
+/// eval set, producing a measured `EvalDelta` (P9/C4 W7b).
+///
+/// ## Why reload-per-phase, not scale-toggle
+/// The daemon holds ONE personal adapter at a time and `scale 0` is the BASE
+/// model — NOT the deployed adapter. So the baseline (the deployed adapter) and
+/// the candidate must each be reloaded in turn:
+/// `reload(deployed) → score all → reload(candidate) → score all`. When nothing
+/// is deployed (`baselinePath == nil`) the baseline is the base model
+/// (`reload(nil)`, scale 0) — the only case scale-0 is the baseline.
+///
+/// ## Restore-on-every-exit is a SAFETY property
+/// The evaluator mutates the LIVE daemon's loaded adapter. On EVERY exit path
+/// (success, throw, timeout, cancellation) it reloads the originally-deployed
+/// adapter and CONFIRMS via `runtime.status`, so the live daemon is never left
+/// serving the un-gated candidate — the exact deploy-without-receipt hole this
+/// series closes.
+struct DaemonABEvaluator: AdapterEvaluator {
+    let client: DaemonABClient
+    let suite: DaemonEvalSuite
+    /// Wall-clock bound for the whole A/B (both phases + restore).
+    let timeoutSeconds: Int
+
+    var kind: AdapterKind { .gguf }
+    var evaluatorId: String { "DaemonABEvaluator" }
+    var evalSuiteVersion: String { suite.suiteVersion }
+
+    init(client: DaemonABClient, suite: DaemonEvalSuite, timeoutSeconds: Int = 900) {
+        self.client = client
+        self.suite = suite
+        self.timeoutSeconds = timeoutSeconds
+    }
+
+    func isAvailable() async -> Bool {
+        // The suite is loaded + SHA-verified at construction (a missing/drifted
+        // suite means the evaluator was never registered), so availability tracks
+        // the live daemon answering a status query. A throw ⇒ unavailable.
+        do {
+            _ = try await client.loadedAdapterPath()
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func evaluate(candidatePath: String, baselinePath: String?) async throws -> GateOutcome {
+        // The deployed adapter to restore to on EVERY exit. This is the baseline
+        // when one is deployed; nil ⇒ restore to base. We snapshot it up front so
+        // restore targets exactly what the daemon served before eval.
+        let deployedToRestore = baselinePath
+        do {
+            let outcome = try await withABTimeout(seconds: timeoutSeconds) {
+                try await runAB(candidatePath: candidatePath, baselinePath: baselinePath)
+            }
+            // Restore + confirm before returning the measured pass.
+            try await restoreDeployed(deployedToRestore)
+            return outcome
+        } catch {
+            // Restore on the failure path too, then surface the failure so the
+            // coordinator treats it as fail-closed (no mint, blocked).
+            await restoreDeployedBestEffort(deployedToRestore)
+            if let abError = error as? DaemonABEvaluatorError {
+                throw AdapterEvaluatorError.measurementFailed(abError.description)
+            }
+            throw AdapterEvaluatorError.measurementFailed(String(describing: error))
+        }
+    }
+
+    // MARK: - A/B core
+
+    private func runAB(candidatePath: String, baselinePath: String?) async throws -> GateOutcome {
+        // Phase 1 — baseline = the DEPLOYED adapter (or base model when none).
+        try await client.reload(path: baselinePath)
+        let baselineScores = try await scoreSuite()
+
+        // Phase 2 — candidate.
+        try await client.reload(path: candidatePath)
+        let candidateScores = try await scoreSuite()
+
+        let delta = Self.deltaPercentagePoints(
+            baseline: baselineScores, candidate: candidateScores)
+        // baseModelId records WHAT the candidate was scored against (the deployed
+        // adapter path, or a base-model marker) so a receipt can never claim a pass
+        // vs the wrong baseline.
+        let baseModelId = baselinePath ?? "daemon-base-model"
+        return GateOutcome(
+            delta: delta, baseModelId: baseModelId, evalSuiteVersion: suite.suiteVersion)
+    }
+
+    /// Run every example under the currently-loaded adapter and return per-dimension
+    /// accuracy. A partial run (any inference throws) propagates so the A/B is
+    /// fail-closed rather than scoring against missing answers.
+    private func scoreSuite() async throws -> [GateDimension: Double] {
+        var results: [(dimension: GateDimension, correct: Bool)] = []
+        for example in suite.examples {
+            guard let dimension = example.gateDimension else { continue }
+            try Task.checkCancellation()
+            let inference = try await client.infer(example)
+            let correct = DaemonEvalScorer.isCorrect(inference, scoring: example.scoring)
+            results.append((dimension, correct))
+        }
+        return DaemonEvalScorer.accuracyByDimension(results: results)
+    }
+
+    /// Candidate minus baseline, per dimension, in PERCENTAGE POINTS (matching
+    /// `EvalDelta`'s units). A dimension absent from either side yields `nil` so
+    /// the W1 gate's "complete measurement" rule blocks an incomplete A/B.
+    static func deltaPercentagePoints(
+        baseline: [GateDimension: Double], candidate: [GateDimension: Double]
+    ) -> EvalDelta {
+        func delta(_ dim: GateDimension) -> Double? {
+            guard let b = baseline[dim], let c = candidate[dim] else { return nil }
+            return (c - b) * 100.0
+        }
+        return EvalDelta(
+            toolCallingDelta: delta(.toolCalling),
+            faeCapabilityDelta: delta(.faeCapability),
+            assistantFitDelta: delta(.assistantFit),
+            serializationDelta: delta(.serialization),
+            throughputDelta: nil
+        )
+    }
+
+    // MARK: - Restore (safety property)
+
+    /// Reload the originally-deployed adapter and CONFIRM the daemon is back on it.
+    /// An unconfirmed restore is loud + fail-closed (`restoreUnconfirmed`).
+    private func restoreDeployed(_ deployed: String?) async throws {
+        if let deployed {
+            try await client.reload(path: deployed)
+        } else {
+            // Base model: scale 0 then drop the adapter (mirrors swapAdapter(nil)).
+            try await client.setScale(0.0)
+            try await client.reload(path: nil)
+        }
+        let loaded = try await client.loadedAdapterPath()
+        guard Self.restoreMatches(expected: deployed, loaded: loaded) else {
+            NSLog(
+                "DaemonABEvaluator: FAILED to restore deployed adapter after eval — expected %@, daemon reports %@ (fail-closed)",
+                deployed ?? "<base model>", loaded ?? "<base model>")
+            throw DaemonABEvaluatorError.restoreUnconfirmed(
+                expected: deployed ?? "<base model>", found: loaded ?? "<base model>")
+        }
+        NSLog("DaemonABEvaluator: restored deployed adapter after eval (%@)", deployed ?? "<base model>")
+    }
+
+    /// Best-effort restore for the failure path — we already have a failure to
+    /// surface; a restore error here is logged, not thrown (it must not mask the
+    /// original cause), but a daemon left on the candidate is logged LOUDLY.
+    private func restoreDeployedBestEffort(_ deployed: String?) async {
+        do {
+            try await restoreDeployed(deployed)
+        } catch {
+            NSLog(
+                "DaemonABEvaluator: best-effort restore after eval failure also failed (%@) — daemon may be on the un-gated candidate",
+                String(describing: error))
+        }
+    }
+
+    /// The daemon's loaded adapter matches what we deployed (both base, or same path).
+    static func restoreMatches(expected: String?, loaded: String?) -> Bool {
+        switch (expected, loaded) {
+        case (nil, nil): return true
+        case let (e?, l?): return e == l
+        default: return false
+        }
+    }
+
+    // MARK: - Timeout
+
+    /// Run `body` with a wall-clock bound. On timeout the racing body task is
+    /// cancelled (so `scoreSuite`'s `Task.checkCancellation` unwinds it) and
+    /// `timedOut` is thrown — the caller then restores the deployed adapter.
+    private func withABTimeout<T: Sendable>(
+        seconds: Int, _ body: @Sendable @escaping () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await body() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
+                throw DaemonABEvaluatorError.timedOut(seconds: seconds)
+            }
+            guard let result = try await group.next() else {
+                throw DaemonABEvaluatorError.timedOut(seconds: seconds)
+            }
+            group.cancelAll()
+            return result
+        }
+    }
+}

--- a/native/macos/Fae/Sources/Fae/Scheduler/FaeScheduler.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/FaeScheduler.swift
@@ -241,6 +241,16 @@ actor FaeScheduler {
         daemonTrainingBaseModel = baseModel
     }
 
+    /// The live daemon LLM engine, set by FaeCore when the daemon LLM lane loaded.
+    /// Used to construct the `.gguf`-lane `DaemonABEvaluator` (P9/C4 W7b) so the
+    /// nightly cycle can score a trained GGUF candidate against the deployed adapter
+    /// by A/B-testing the live daemon. `nil` ⇒ daemon lane off ⇒ `.gguf` stays blocked.
+    private var daemonLLMEngine: DaemonLLMEngine?
+
+    func setDaemonLLMEngine(_ engine: DaemonLLMEngine?) {
+        daemonLLMEngine = engine
+    }
+
     func setVisionEnabled(_ enabled: Bool) {
         visionEnabled = enabled
     }
@@ -1691,8 +1701,7 @@ actor FaeScheduler {
             // lane — but ONLY when its FaeBenchmark harness is actually configured.
             // Without a benchmark binary the evaluator can't measure, so leaving the lane
             // blocked (W6) is correct: it avoids burning a training run on a candidate that
-            // could never produce a gate receipt. The `.gguf` daemon lane stays blocked
-            // until its DaemonABEvaluator lands (W7b).
+            // could never produce a gate receipt.
             if let bridge {
                 let mlxEvaluator = FaeBenchmarkEvaluator(bridge: bridge)
                 if await mlxEvaluator.isAvailable() {
@@ -1700,6 +1709,29 @@ actor FaeScheduler {
                 } else {
                     NSLog("FaeScheduler: FaeBenchmark not configured — mlxDir lane stays blocked (no evaluator)")
                 }
+            }
+            // P9/C4 (W7b): register the daemon-lane A/B evaluator and un-block the
+            // `.gguf` lane — ONLY when the daemon LLM lane is live AND the SHA-locked
+            // held-out eval suite loads. Either missing ⇒ leave `.gguf` blocked (W6):
+            // the daemon-lane cycle produces a GGUF, and without a real evaluator a
+            // GGUF candidate could only auto-deploy un-gated — the hole this series closes.
+            if let daemonEngine = daemonLLMEngine {
+                do {
+                    let suite = try DaemonEvalSuite.loadBundled()
+                    let client = LiveDaemonABClient(engine: daemonEngine)
+                    let daemonEvaluator = DaemonABEvaluator(client: client, suite: suite)
+                    if await daemonEvaluator.isAvailable() {
+                        await coordinator.setAdapterEvaluator(daemonEvaluator)
+                    } else {
+                        NSLog("FaeScheduler: daemon unreachable for A/B eval — gguf lane stays blocked (no evaluator)")
+                    }
+                } catch {
+                    NSLog(
+                        "FaeScheduler: daemon A/B eval suite unavailable (%@) — gguf lane stays blocked (no evaluator)",
+                        error.localizedDescription)
+                }
+            } else {
+                NSLog("FaeScheduler: daemon LLM lane off — gguf lane stays blocked (no evaluator)")
             }
         } catch {
             NSLog("FaeScheduler: improvement_cycle — training bridge unavailable (%@), cycle will skip training", error.localizedDescription)

--- a/native/macos/Fae/Sources/Fae/Scheduler/FaeScheduler.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/FaeScheduler.swift
@@ -1687,6 +1687,20 @@ actor FaeScheduler {
             // P3/C3: when the daemon LLM lane is active, the cycle must produce a
             // GGUF the daemon can load (not an mlx-tune `.safetensors` adapter).
             await coordinator.setDaemonTrainingBaseModel(daemonTrainingBaseModel)
+            // P9/C4 (W7a): register the MLX-lane evaluator and un-block the `.mlxDir`
+            // lane — but ONLY when its FaeBenchmark harness is actually configured.
+            // Without a benchmark binary the evaluator can't measure, so leaving the lane
+            // blocked (W6) is correct: it avoids burning a training run on a candidate that
+            // could never produce a gate receipt. The `.gguf` daemon lane stays blocked
+            // until its DaemonABEvaluator lands (W7b).
+            if let bridge {
+                let mlxEvaluator = FaeBenchmarkEvaluator(bridge: bridge)
+                if await mlxEvaluator.isAvailable() {
+                    await coordinator.setAdapterEvaluator(mlxEvaluator)
+                } else {
+                    NSLog("FaeScheduler: FaeBenchmark not configured — mlxDir lane stays blocked (no evaluator)")
+                }
+            }
         } catch {
             NSLog("FaeScheduler: improvement_cycle — training bridge unavailable (%@), cycle will skip training", error.localizedDescription)
         }

--- a/native/macos/Fae/Sources/Fae/Scheduler/FaeScheduler.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/FaeScheduler.swift
@@ -73,6 +73,11 @@ actor FaeScheduler {
     /// Coordinator for the nightly self-improvement cycle.
     private var improvementCycleCoordinator: ImprovementCycleCoordinator?
 
+    /// The P9/C4 (W5) startup stale-state recovery task, created on first use. All callers
+    /// await the SAME task, so recovery runs exactly once and every caller waits for it to
+    /// COMPLETE before proceeding (no skip-while-suspended race).
+    private var recoveryTask: Task<Void, Never>?
+
     /// Daily proactive interjection counter, reset at midnight.
     var proactiveInterjectionCount: Int = 0
     var proactiveDigestEligibleCounts: [String: Int] = [:]
@@ -168,6 +173,28 @@ actor FaeScheduler {
         let coordinator = ImprovementCycleCoordinator(store: store)
         improvementCycleCoordinator = coordinator
         wireAdapterPatchCallback(on: coordinator)
+        // P9/C4 (W5): stale-state recovery is performed (awaited) before the first cycle
+        // runs — see `recoverImprovementStateOnce`. It is NOT a fire-and-forget Task here,
+        // so it can never race a triggered cycle or a user approval.
+    }
+
+    /// Run the P9/C4 stale-state recovery exactly once, awaited, before the first
+    /// improvement cycle of this process. Repairs a non-idle improvement state left by a
+    /// crash or a pre-P9 upgrade so an ungated in-flight candidate never survives a restart
+    /// as deployable. Guarded by `didRecoverImprovementState` so it runs once and never
+    /// clobbers a legitimately in-progress / awaiting-approval state.
+    private func recoverImprovementStateOnce() async {
+        // Already started (or done): await the SAME task so we never proceed before recovery
+        // completes, and never run it twice. (FaeScheduler is an actor, so the check + assign
+        // below is atomic — no two callers can both create a task.)
+        if let existing = recoveryTask {
+            await existing.value
+            return
+        }
+        guard let coordinator = improvementCycleCoordinator else { return }
+        let task = Task { await coordinator.recoverStaleStateIfNeeded() }
+        recoveryTask = task
+        await task.value
     }
 
     /// Connect the cycle coordinator's adapter-deploy callback to the live
@@ -1647,6 +1674,11 @@ actor FaeScheduler {
             NSLog("FaeScheduler: improvement_cycle — coordinator not available")
             return
         }
+        // P9/C4 (W5): repair any stale non-idle state ONCE, awaited, as the FIRST thing
+        // after the coordinator exists — before bridge/meta-opt wiring and the cycle — so
+        // recovery always precedes any cycle work and never races it or a user approval.
+        await recoverImprovementStateOnce()
+
         // Wire training bridge if not already set.
         var bridge: TrainingBridge?
         do {

--- a/native/macos/Fae/Sources/Fae/Scheduler/GateReceipt.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/GateReceipt.swift
@@ -1,0 +1,346 @@
+import CryptoKit
+import Foundation
+
+// MARK: - GateReceipt (P9/C4 W2)
+
+/// A tamper-evident proof that a specific adapter artifact passed a real evaluation
+/// gate. Bound to the exact artifact (content digest) and signed with a per-install
+/// HMAC key held in the Keychain.
+///
+/// ## Threat model (local, single-user)
+/// The owner already controls the machine, so the threat is NOT a motivated attacker
+/// forging a row — it is **accidental re-opening** of the deploy gate (a future code
+/// path, a stale row, a test helper leaking into prod). The controls are therefore:
+/// - **single minting path** (`GateMinter.mint`) + an **evaluator allowlist** — only an
+///   allowlisted evaluator can mint a receipt whose HMAC verifies;
+/// - **HMAC tamper-evidence** with a key stored in the Keychain (NOT in `fae.db`), so a
+///   copied/edited `.db` row cannot carry a valid signature;
+/// - **content digest** bound at mint and re-checked at verify, closing the re-point gap;
+/// - **gatePolicyVersion** so a change to the gate rule invalidates old receipts.
+///
+/// W4 makes `performDeploy` REQUIRE a verifying, unconsumed receipt; W7's evaluators are
+/// the only callers of `GateMinter.mint`. This file is the machinery; it is not yet
+/// wired into the live deploy path (that is W4).
+struct GateReceipt: Codable, Sendable, Equatable {
+    /// The cycle that produced the candidate (ties receipt → candidate).
+    let cycleId: String
+    /// The exact artifact this receipt certifies.
+    let candidatePath: String
+    /// The artifact kind — drives the digest algorithm and the deploy/engine routing.
+    let kind: AdapterKind
+    /// Content digest of the artifact at mint time (see `GateArtifactDigest`).
+    let artifactDigest: String
+    /// The measured correctness deltas that produced the pass (dimension → delta).
+    let measured: [String: Double]
+    /// The gate decision the receipt certifies. Only `"pass"` is ever persisted.
+    let decision: String
+    /// The evaluator that produced the measurement — must be on the allowlist.
+    let evaluatorId: String
+    /// The baseline the candidate was evaluated AGAINST (the deployed adapter, or the
+    /// base model if none) — guards against passing vs the wrong baseline.
+    let baseModelId: String
+    /// Version of the held-out eval set (drift guard).
+    let evalSuiteVersion: String
+    /// The gate-policy version in force at mint. A bump invalidates older receipts.
+    let gatePolicyVersion: Int
+    /// Receipt schema version (forward-compat).
+    let receiptVersion: Int
+    /// ISO-8601 mint timestamp.
+    let mintedAt: String
+    /// HMAC-SHA256 over the canonical encoding of every field above, hex-encoded.
+    let hmac: String
+}
+
+// MARK: - Errors
+
+enum GateReceiptError: Error, Equatable, CustomStringConvertible {
+    case evaluatorNotAllowed(String)
+    case artifactMissing(String)
+    case symlinkInArtifact(String)
+    case digestFailed(String)
+    case keychainUnavailable
+    case hmacMismatch
+    case digestMismatch
+    case candidateMismatch
+    case stalePolicyVersion(found: Int, expected: Int)
+    case wrongDecision(String)
+
+    var description: String {
+        switch self {
+        case .evaluatorNotAllowed(let id): return "evaluator not on allowlist: \(id)"
+        case .artifactMissing(let p): return "artifact missing: \(p)"
+        case .symlinkInArtifact(let p): return "symlink not allowed in adapter artifact: \(p)"
+        case .digestFailed(let p): return "could not digest artifact: \(p)"
+        case .keychainUnavailable: return "gate receipt HMAC key unavailable in Keychain"
+        case .hmacMismatch: return "receipt HMAC does not verify (forged or tampered)"
+        case .digestMismatch: return "artifact digest changed since mint (tampered or re-pointed)"
+        case .candidateMismatch: return "receipt is for a different candidate path"
+        case .stalePolicyVersion(let f, let e): return "receipt gatePolicyVersion \(f) != \(e)"
+        case .wrongDecision(let d): return "receipt decision is not pass: \(d)"
+        }
+    }
+}
+
+// MARK: - Policy constants
+
+enum GatePolicy {
+    /// Bump when `AdapterGate.decide` semantics change — invalidates older receipts.
+    static let policyVersion = 1
+    /// Receipt schema version.
+    static let receiptVersion = 1
+    /// Only these evaluators can mint a verifying receipt (the loss-proxy is absent by
+    /// design, so it can never gate a deploy).
+    static let allowedEvaluators: Set<String> = ["DaemonABEvaluator", "FaeBenchmarkEvaluator"]
+}
+
+// MARK: - Artifact digest
+
+/// Computes a content digest for an adapter artifact. The digest is bound into the
+/// receipt and re-checked at deploy, so a swapped/edited artifact fails verification.
+enum GateArtifactDigest {
+    static func digest(forPath path: String, kind: AdapterKind) throws -> String {
+        switch kind {
+        case .gguf: return try fileSHA256(path)
+        case .mlxDir: return try directoryManifestSHA256(path)
+        }
+    }
+
+    /// SHA-256 of a file's bytes, hex-encoded.
+    static func fileSHA256(_ path: String) throws -> String {
+        guard let data = FileManager.default.contents(atPath: path) else {
+            throw GateReceiptError.artifactMissing(path)
+        }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Canonical content manifest for an MLX adapter directory: every regular file's
+    /// relative POSIX path + SHA-256, sorted by path, hashed together. Stable under
+    /// directory-walk order; changes when any file changes. Symlinks are rejected (an
+    /// adapter directory is plain files; a symlink could point outside the tree).
+    static func directoryManifestSHA256(_ dirPath: String) throws -> String {
+        let fm = FileManager.default
+        let root = URL(fileURLWithPath: dirPath).standardizedFileURL
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: root.path, isDirectory: &isDir), isDir.boolValue else {
+            throw GateReceiptError.artifactMissing(dirPath)
+        }
+        guard let enumerator = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: []
+        ) else {
+            throw GateReceiptError.digestFailed(dirPath)
+        }
+
+        var entries: [(rel: String, sha: String)] = []
+        let prefixCount = root.path.count + 1
+        for case let url as URL in enumerator {
+            let values = try url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+            if values.isSymbolicLink == true {
+                throw GateReceiptError.symlinkInArtifact(url.path)
+            }
+            guard values.isRegularFile == true else { continue }
+            let standardized = url.standardizedFileURL.path
+            guard standardized.count > prefixCount else { continue }
+            let rel = String(standardized.dropFirst(prefixCount))
+            entries.append((rel, try fileSHA256(standardized)))
+        }
+        entries.sort { $0.rel < $1.rel }
+
+        // NUL is the field separator; POSIX filenames cannot contain NUL, so a relpath
+        // can never inject a separator and forge a different manifest with the same bytes.
+        var hasher = SHA256()
+        for entry in entries {
+            hasher.update(data: Data("\(entry.rel)\u{0}\(entry.sha)\u{0}".utf8))
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - Signing payload + crypto
+
+/// Every field of `GateReceipt` EXCEPT the hmac, in a Codable form whose canonical
+/// (sorted-keys) JSON is the signed message.
+private struct GateReceiptPayload: Codable {
+    let cycleId: String
+    let candidatePath: String
+    let kind: String
+    let artifactDigest: String
+    let measured: [String: Double]
+    let decision: String
+    let evaluatorId: String
+    let baseModelId: String
+    let evalSuiteVersion: String
+    let gatePolicyVersion: Int
+    let receiptVersion: Int
+    let mintedAt: String
+
+    init(from receipt: GateReceipt) {
+        cycleId = receipt.cycleId
+        candidatePath = receipt.candidatePath
+        kind = receipt.kind.rawValue
+        artifactDigest = receipt.artifactDigest
+        measured = receipt.measured
+        decision = receipt.decision
+        evaluatorId = receipt.evaluatorId
+        baseModelId = receipt.baseModelId
+        evalSuiteVersion = receipt.evalSuiteVersion
+        gatePolicyVersion = receipt.gatePolicyVersion
+        receiptVersion = receipt.receiptVersion
+        mintedAt = receipt.mintedAt
+    }
+}
+
+enum GateReceiptCrypto {
+    /// Keychain item name for the per-install HMAC key.
+    private static let keychainItem = "p9.gate_receipt.hmac_key.v1"
+
+    /// Fetch (or lazily create + store) the per-install HMAC key. The key lives in the
+    /// Keychain, never in `fae.db`, so a copied/edited database row cannot carry a valid
+    /// signature. Production callers (W4/W7) resolve the key once; unit tests pass a
+    /// fixed key to the `using:` overloads to avoid Keychain access.
+    static func keychainKey() throws -> SymmetricKey {
+        if let b64 = CredentialManager.retrieve(key: keychainItem),
+           let data = Data(base64Encoded: b64), data.count == 32 {
+            return SymmetricKey(data: data)
+        }
+        let key = SymmetricKey(size: .bits256)
+        let raw = key.withUnsafeBytes { Data($0) }
+        do {
+            try CredentialManager.store(key: keychainItem, value: raw.base64EncodedString())
+        } catch {
+            throw GateReceiptError.keychainUnavailable
+        }
+        return key
+    }
+
+    /// HMAC-SHA256 over the canonical (sorted-keys) encoding of a payload, hex-encoded.
+    fileprivate static func sign(_ payload: GateReceiptPayload, using key: SymmetricKey) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let message = try encoder.encode(payload)
+        let mac = HMAC<SHA256>.authenticationCode(for: message, using: key)
+        return Data(mac).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - Minter (single privileged path)
+
+/// The ONLY path that produces a verifying `GateReceipt`. Callers must be
+/// `AdapterEvaluator` conformers (W7); the allowlist enforces that a receipt minted for
+/// a non-allowlisted evaluator (e.g. the loss-proxy) can never verify.
+///
+/// > NOTE (threat model): the **allowlist is the privilege boundary, not a module
+/// > boundary** — any in-process code that supplies an allowlisted `evaluatorId` can mint.
+/// > This is acceptable for the stated threat model (accidental re-opening of the gate,
+/// > NOT a motivated in-process attacker, who already controls the machine). W7 makes the
+/// > real evaluators the only callers; W4 makes a verifying + unconsumed receipt mandatory
+/// > at the deploy boundary. The HMAC (Keychain key) + content digest are the
+/// > tamper-evidence layer against an edited `fae.db` row.
+enum GateMinter {
+    /// Mint a signed pass-receipt for an evaluated candidate, using the per-install
+    /// Keychain key. Production convenience (W7).
+    static func mint(
+        cycleId: String,
+        candidatePath: String,
+        kind: AdapterKind,
+        measured: [GateDimension: Double],
+        evaluatorId: String,
+        baseModelId: String,
+        evalSuiteVersion: String,
+        mintedAt: String
+    ) throws -> GateReceipt {
+        try mint(
+            cycleId: cycleId, candidatePath: candidatePath, kind: kind, measured: measured,
+            evaluatorId: evaluatorId, baseModelId: baseModelId,
+            evalSuiteVersion: evalSuiteVersion, mintedAt: mintedAt,
+            using: try GateReceiptCrypto.keychainKey()
+        )
+    }
+
+    /// Mint with an explicit HMAC key (unit tests pass a fixed key; production uses the
+    /// Keychain convenience above).
+    static func mint(
+        cycleId: String,
+        candidatePath: String,
+        kind: AdapterKind,
+        measured: [GateDimension: Double],
+        evaluatorId: String,
+        baseModelId: String,
+        evalSuiteVersion: String,
+        mintedAt: String,
+        using key: SymmetricKey
+    ) throws -> GateReceipt {
+        guard GatePolicy.allowedEvaluators.contains(evaluatorId) else {
+            throw GateReceiptError.evaluatorNotAllowed(evaluatorId)
+        }
+        let digest = try GateArtifactDigest.digest(forPath: candidatePath, kind: kind)
+        let measuredStrings = Dictionary(
+            uniqueKeysWithValues: measured.map { ($0.key.rawValue, $0.value) }
+        )
+        func receipt(hmac: String) -> GateReceipt {
+            GateReceipt(
+                cycleId: cycleId, candidatePath: candidatePath, kind: kind,
+                artifactDigest: digest, measured: measuredStrings, decision: "pass",
+                evaluatorId: evaluatorId, baseModelId: baseModelId,
+                evalSuiteVersion: evalSuiteVersion,
+                gatePolicyVersion: GatePolicy.policyVersion,
+                receiptVersion: GatePolicy.receiptVersion,
+                mintedAt: mintedAt, hmac: hmac
+            )
+        }
+        let hmac = try GateReceiptCrypto.sign(GateReceiptPayload(from: receipt(hmac: "")), using: key)
+        return receipt(hmac: hmac)
+    }
+}
+
+// MARK: - Verifier
+
+/// Verifies a receipt at the deploy boundary (used by W4). All checks fail closed.
+enum GateReceiptVerifier {
+    /// Verify that `receipt` authorizes deploying the artifact at `expectedCandidatePath`.
+    /// Checks (in order): decision is pass, evaluator allowlist, gate-policy version,
+    /// candidate-path match, HMAC signature, and the on-disk artifact digest.
+    /// Single-use (consumed) enforcement is done against the store by the caller (W4).
+    static func verify(_ receipt: GateReceipt, expectedCandidatePath: String) throws {
+        try verify(receipt, expectedCandidatePath: expectedCandidatePath, using: try GateReceiptCrypto.keychainKey())
+    }
+
+    /// Verify with an explicit HMAC key (unit tests pass a fixed key).
+    static func verify(_ receipt: GateReceipt, expectedCandidatePath: String, using key: SymmetricKey) throws {
+        guard receipt.decision == "pass" else {
+            throw GateReceiptError.wrongDecision(receipt.decision)
+        }
+        guard GatePolicy.allowedEvaluators.contains(receipt.evaluatorId) else {
+            throw GateReceiptError.evaluatorNotAllowed(receipt.evaluatorId)
+        }
+        guard receipt.gatePolicyVersion == GatePolicy.policyVersion else {
+            throw GateReceiptError.stalePolicyVersion(
+                found: receipt.gatePolicyVersion, expected: GatePolicy.policyVersion
+            )
+        }
+        guard receipt.candidatePath == expectedCandidatePath else {
+            throw GateReceiptError.candidateMismatch
+        }
+        let expectedHmac = try GateReceiptCrypto.sign(GateReceiptPayload(from: receipt), using: key)
+        // Constant-time-ish compare over equal-length hex strings.
+        guard constantTimeEquals(expectedHmac, receipt.hmac) else {
+            throw GateReceiptError.hmacMismatch
+        }
+        let onDiskDigest = try GateArtifactDigest.digest(
+            forPath: receipt.candidatePath, kind: receipt.kind
+        )
+        guard onDiskDigest == receipt.artifactDigest else {
+            throw GateReceiptError.digestMismatch
+        }
+    }
+
+    private static func constantTimeEquals(_ a: String, _ b: String) -> Bool {
+        let aBytes = Array(a.utf8)
+        let bBytes = Array(b.utf8)
+        guard aBytes.count == bBytes.count else { return false }
+        var diff: UInt8 = 0
+        for i in 0..<aBytes.count { diff |= aBytes[i] ^ bBytes[i] }
+        return diff == 0
+    }
+}

--- a/native/macos/Fae/Sources/Fae/Scheduler/GateReceipt.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/GateReceipt.swift
@@ -64,6 +64,7 @@ enum GateReceiptError: Error, Equatable, CustomStringConvertible {
     case candidateMismatch
     case stalePolicyVersion(found: Int, expected: Int)
     case wrongDecision(String)
+    case alreadyConsumed(String)
 
     var description: String {
         switch self {
@@ -77,6 +78,7 @@ enum GateReceiptError: Error, Equatable, CustomStringConvertible {
         case .candidateMismatch: return "receipt is for a different candidate path"
         case .stalePolicyVersion(let f, let e): return "receipt gatePolicyVersion \(f) != \(e)"
         case .wrongDecision(let d): return "receipt decision is not pass: \(d)"
+        case .alreadyConsumed(let c): return "gate receipt already consumed for cycle \(c)"
         }
     }
 }

--- a/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
@@ -47,6 +47,8 @@ enum ImprovementCycleError: Error, Sendable {
     case insufficientData(feedbackCount: Int, correctionCount: Int)
     /// The training cycle appears stuck (started more than maxDuration ago).
     case stuckDetected(startedAt: String)
+    /// A deploy was attempted with no pending candidate to promote (P9/C4 W3).
+    case noPendingCandidate
 }
 
 // MARK: - ImprovementCycleCoordinator
@@ -137,6 +139,14 @@ actor ImprovementCycleCoordinator {
     /// layout matches at reload.
     private var daemonTrainingBaseModel: String?
 
+    /// Interim evaluation seam (P9/C4). When set, supplies the **measured**
+    /// `EvalDelta` for the evaluating phase in place of the FaeBenchmark bridge.
+    /// W7's `AdapterEvaluator` becomes the production implementation behind this
+    /// seam; until then it lets the gate + verdict handling be exercised with a
+    /// real measured delta without a FaeBenchmark binary. `nil` ⇒ fall through to
+    /// the bridge benchmark, else `.unmeasured` (fail-closed).
+    private var injectedMeasuredDelta: EvalDelta?
+
     /// Minimum SFT examples required before training proceeds.
     static let minSFTExamples = 10
 
@@ -184,6 +194,13 @@ actor ImprovementCycleCoordinator {
     /// Passing `nil` reverts to the legacy mlx-tune (`.safetensors`) path.
     func setDaemonTrainingBaseModel(_ baseModel: String?) {
         daemonTrainingBaseModel = baseModel
+    }
+
+    /// Inject a measured `EvalDelta` for the evaluating phase (P9/C4 interim seam;
+    /// see `injectedMeasuredDelta`). Used by tests until W7 wires the real
+    /// `AdapterEvaluator`. Passing `nil` clears it (fall through to the bridge).
+    func setInjectedMeasuredDelta(_ delta: EvalDelta?) {
+        injectedMeasuredDelta = delta
     }
 
     /// Set the meta-optimizer. Called by FaeScheduler after wiring.
@@ -372,6 +389,11 @@ actor ImprovementCycleCoordinator {
             resetState.cycleState = CycleState.idle.rawValue
             resetState.trainingStartedAt = nil
             resetState.lastCycleError = "stuck_detected"
+            // P9/C4 (W3): discard any candidate from the wedged cycle. The deployed
+            // `currentAdapterPath` is untouched (training only writes pending), so a
+            // crash/stuck mid-cycle can never leave an un-evaluated candidate live.
+            resetState.pendingAdapterPath = nil
+            resetState.pendingAdapterKind = nil
             try await store.writeState(resetState)
         }
 
@@ -383,6 +405,19 @@ actor ImprovementCycleCoordinator {
                 current.rawValue
             )
             return
+        }
+
+        // P9/C4 (W3): a fresh cycle starts from idle, which must never carry a stale
+        // pending candidate (invariant: idle ⇒ pendingAdapterPath == nil). Discard any
+        // leftover from a prior interrupted cycle BEFORE proceeding, so every early
+        // exit below (insufficient data, meta-opt-only) preserves the invariant.
+        let startState = try await store.readState()
+        if startState.pendingAdapterPath != nil || startState.pendingAdapterKind != nil {
+            var cleared = startState
+            cleared.pendingAdapterPath = nil
+            cleared.pendingAdapterKind = nil
+            try await store.writeState(cleared)
+            NSLog("ImprovementCycleCoordinator: cleared stale pending candidate at cycle start")
         }
 
         // Step 3: Check minimum data thresholds.
@@ -512,10 +547,15 @@ actor ImprovementCycleCoordinator {
                 "ImprovementCycleCoordinator: training complete — adapter at %@ (kind=%@)",
                 adapterPath, candidate.kind.rawValue)
 
-            // 5d. Store adapter path in improvement state.
+            // 5d. Store the candidate as the PENDING adapter (P9/C4 W3).
+            // Training NEVER writes the deployed `currentAdapterPath`; the candidate
+            // lives in `pendingAdapterPath` until a gated deploy promotes it. This is
+            // what keeps an un-evaluated candidate from ever polluting the live
+            // adapter — on the block/reject/abort paths, or after a crash mid-cycle.
             try await store.ensureStateRow()
             var state = try await store.readState()
-            state.currentAdapterPath = adapterPath
+            state.pendingAdapterPath = adapterPath
+            state.pendingAdapterKind = candidate.kind.rawValue
             try await store.writeState(state)
         } catch let error as ImprovementCycleError {
             // Rethrown from the bridge-nil path above — not a real failure.
@@ -552,41 +592,61 @@ actor ImprovementCycleCoordinator {
             }
             NSLog("ImprovementCycleCoordinator: evaluating phase")
 
-            // Build EvalDelta: prefer FaeBenchmark (real accuracy), fall back to loss-based proxy.
-            // When no adapter was produced, deltas are zero (neutral — no regression, no gain).
+            // P9/C4 (W1): the gate certifies ONLY real, measured deltas. A
+            // non-measurement (no FaeBenchmark evaluator configured, or a
+            // benchmark failure) is fail-closed — it yields `.unmeasured`, never a
+            // synthetic zero-delta "pass". The loss-based proxy is advisory only
+            // and never gates (it cannot populate measured dimensions).
             let evalDelta: EvalDelta
-            if let bridge = trainingBridge, let adapterPath = producedAdapterPath {
-                // Try real benchmark evaluation first (if FaeBenchmark binary is configured).
-                if await bridge.isBenchmarkAvailable {
-                    do {
-                        NSLog("ImprovementCycleCoordinator: running FaeBenchmark baseline")
-                        let baseline = try await bridge.runBenchmark(adapterPath: nil)
-                        // Store baseline for historical comparison.
-                        let pendingCount = (try? await store.pendingFeedbackEvents().count) ?? 0
-                        try? await store.insertBaseline(baseline.toBaseline(feedbackEventCount: pendingCount))
+            if let injected = injectedMeasuredDelta {
+                NSLog("ImprovementCycleCoordinator: using injected measured eval delta (P9/C4 interim seam)")
+                evalDelta = injected
+            } else if let bridge = trainingBridge, let adapterPath = producedAdapterPath,
+               await bridge.isBenchmarkAvailable {
+                do {
+                    NSLog("ImprovementCycleCoordinator: running FaeBenchmark baseline")
+                    let baseline = try await bridge.runBenchmark(adapterPath: nil)
+                    // Store baseline for historical comparison.
+                    let pendingCount = (try? await store.pendingFeedbackEvents().count) ?? 0
+                    try? await store.insertBaseline(baseline.toBaseline(feedbackEventCount: pendingCount))
 
-                        NSLog("ImprovementCycleCoordinator: running FaeBenchmark with adapter")
-                        let adapterResult = try await bridge.runBenchmark(adapterPath: adapterPath)
+                    NSLog("ImprovementCycleCoordinator: running FaeBenchmark with adapter")
+                    let adapterResult = try await bridge.runBenchmark(adapterPath: adapterPath)
 
-                        evalDelta = adapterResult.delta(from: baseline)
+                    evalDelta = adapterResult.delta(from: baseline)
+                    NSLog(
+                        "ImprovementCycleCoordinator: benchmark delta — tools=%.1f%% fae=%.1f%% fit=%.1f%% ser=%.1f%%",
+                        evalDelta.toolCallingDelta ?? 0, evalDelta.faeCapabilityDelta ?? 0,
+                        evalDelta.assistantFitDelta ?? 0, evalDelta.serializationDelta ?? 0
+                    )
+                } catch {
+                    // Loss-proxy is advisory-only (logged, never gates). Eval is unmeasured.
+                    if let advisory = try? await lossBasedEvalDelta(bridge: bridge, adapterPath: adapterPath) {
                         NSLog(
-                            "ImprovementCycleCoordinator: benchmark delta — tools=%.1f%% fae=%.1f%% fit=%.1f%% ser=%.1f%%",
-                            evalDelta.toolCallingDelta ?? 0, evalDelta.faeCapabilityDelta ?? 0,
-                            evalDelta.assistantFitDelta ?? 0, evalDelta.serializationDelta ?? 0
+                            "ImprovementCycleCoordinator: benchmark failed (%@); loss-proxy advisory only (does NOT gate): tools=%.1f%%",
+                            error.localizedDescription, advisory.toolCallingDelta ?? 0
                         )
-                    } catch {
-                        NSLog("ImprovementCycleCoordinator: benchmark failed (%@), falling back to loss-based eval", error.localizedDescription)
-                        evalDelta = try await lossBasedEvalDelta(bridge: bridge, adapterPath: adapterPath)
+                    } else {
+                        NSLog("ImprovementCycleCoordinator: benchmark failed (%@); eval unmeasured", error.localizedDescription)
                     }
-                } else {
-                    // No benchmark binary — use loss-based proxy.
-                    evalDelta = try await lossBasedEvalDelta(bridge: bridge, adapterPath: adapterPath)
+                    evalDelta = .unmeasured
                 }
             } else {
-                evalDelta = EvalDelta(
-                    toolCallingDelta: 0.0, faeCapabilityDelta: 0.0,
-                    assistantFitDelta: 0.0, serializationDelta: 0.0, throughputDelta: nil
-                )
+                NSLog("ImprovementCycleCoordinator: no FaeBenchmark evaluator available — eval unmeasured (fail-closed)")
+                evalDelta = .unmeasured
+            }
+
+            // P9/C4 (W1, F1/F2/F16): fail-closed gate. A candidate with no COMPLETE
+            // measurement (any correctness dimension unmeasured, or nothing
+            // improved) is blocked BEFORE the external review gate — the external
+            // providers must never get a chance to PASS an un-evaluated candidate.
+            // `failClosed` discards the pending candidate; the deployed
+            // `currentAdapterPath` is untouched (W3). (The audited `candidate_blocked`
+            // security event + the receipt deploy gate land in W4.)
+            if AdapterGate.decide(evalDelta.measuredDeltas) == .blockedNoMeasurement {
+                NSLog("ImprovementCycleCoordinator: candidate_blocked — no measured improvement; fail-closed (no review, no deploy)")
+                await failClosed(reason: "candidate_blocked: no_measured_improvement")
+                return
             }
 
             // Run external review gate.
@@ -601,7 +661,7 @@ actor ImprovementCycleCoordinator {
                 if case .maxDeferralsReached = error {
                     NSLog("ImprovementCycleCoordinator: max deferrals reached, aborting cycle")
                     try await store.resetDeferrals()
-                    try? await forceIdle(error: "max_deferrals_reached")
+                    await failClosed(reason: "max_deferrals_reached")
                     return
                 }
                 throw error
@@ -622,7 +682,7 @@ actor ImprovementCycleCoordinator {
                                 "ImprovementCycleCoordinator: shadow eval gate FAILED (%.1f%% win rate)",
                                 evalResult.adapterWinRate * 100
                             )
-                            try? await forceIdle(error: "shadow_eval_gate_failed")
+                            await failClosed(reason: "shadow_eval_gate_failed")
                             return
                         }
                         NSLog(
@@ -648,17 +708,17 @@ actor ImprovementCycleCoordinator {
                 NSLog("ImprovementCycleCoordinator: review CONCERN — deferring cycle")
                 let newCount = try await store.incrementDeferral()
                 NSLog("ImprovementCycleCoordinator: deferral count now %d", newCount)
-                try? await forceIdle(error: "review_concern_deferred")
+                await failClosed(reason: "review_concern_deferred")
                 return
             case .fail:
                 NSLog("ImprovementCycleCoordinator: review FAIL — aborting cycle")
                 try await store.resetDeferrals()
-                try? await forceIdle(error: "review_failed: \(reviewResult.summary)")
+                await failClosed(reason: "review_failed: \(reviewResult.summary)")
                 return
             }
         } catch {
             NSLog("ImprovementCycleCoordinator: evaluating failed: %@", error.localizedDescription)
-            try? await forceIdle(error: "evaluating_failed: \(error.localizedDescription)")
+            await failClosed(reason: "evaluating_failed: \(error.localizedDescription)")
             return
         }
 
@@ -688,7 +748,7 @@ actor ImprovementCycleCoordinator {
                 try await performDeploy(approved: true)
             } catch {
                 NSLog("ImprovementCycleCoordinator: auto-deploy failed: %@", error.localizedDescription)
-                try? await forceIdle(error: "auto_deploy_failed: \(error.localizedDescription)")
+                await failClosed(reason: "auto_deploy_failed: \(error.localizedDescription)")
                 return
             }
         } else {
@@ -699,7 +759,7 @@ actor ImprovementCycleCoordinator {
                 // runCycle() returns here. approveDeployment() / rejectDeployment() resume it.
             } catch {
                 NSLog("ImprovementCycleCoordinator: proposing failed: %@", error.localizedDescription)
-                try? await forceIdle(error: "proposing_failed: \(error.localizedDescription)")
+                await failClosed(reason: "proposing_failed: \(error.localizedDescription)")
             }
             return
         }
@@ -723,6 +783,12 @@ actor ImprovementCycleCoordinator {
         guard current == .proposing else {
             throw ImprovementCycleError.invalidTransition(from: current, to: .deploying)
         }
+        // P9/C4 (W3): validate the candidate BEFORE moving to .deploying, so a
+        // missing candidate leaves the machine in .proposing (recoverable by a later
+        // approve/reject) rather than stuck in .deploying.
+        guard try await store.readState().pendingAdapterPath != nil else {
+            throw ImprovementCycleError.noPendingCandidate
+        }
         try await transition(to: .deploying)
         try await performDeploy(approved: true)
         try await transition(to: .idle)
@@ -742,12 +808,17 @@ actor ImprovementCycleCoordinator {
         }
         try await store.ensureStateRow()
         var state = try await store.readState()
+        // P9/C4 (W3): discard the candidate. `currentAdapterPath` (the deployed
+        // adapter) is untouched — training only ever wrote `pendingAdapterPath` — so
+        // a rejected candidate simply never deploys.
+        state.pendingAdapterPath = nil
+        state.pendingAdapterKind = nil
         state.cycleState = CycleState.idle.rawValue
         state.completedCycles += 1
         state.lastCycleAt = ISO8601DateFormatter().string(from: Date())
         state.trainingStartedAt = nil
         try await store.writeState(state)
-        NSLog("ImprovementCycleCoordinator: deployment rejected — returned to idle")
+        NSLog("ImprovementCycleCoordinator: deployment rejected — discarded pending candidate, returned to idle")
     }
 
     /// Roll back the current adapter to the previous one.
@@ -782,9 +853,21 @@ actor ImprovementCycleCoordinator {
         try await store.ensureStateRow()
         var state = try await store.readState()
 
-        // Track rollback path: current → previous before updating.
-        // currentAdapterPath was set during the training step with the real adapter directory.
+        // P9/C4 (W3): promote the gated candidate. The candidate lives in
+        // `pendingAdapterPath`; deploy is the ONLY place `currentAdapterPath` is
+        // written. current → previous (the real rollback target), pending → current,
+        // then clear pending. This also fixes the prior rollback-lineage bug where
+        // `previousAdapterPath` was set to the candidate itself.
+        guard let candidate = state.pendingAdapterPath else {
+            // Fail-closed: a deploy with no gated candidate is an error, not a silent
+            // no-op — surfacing it prevents a caller from treating it as a success.
+            NSLog("ImprovementCycleCoordinator: performDeploy called with no pending candidate — refusing")
+            throw ImprovementCycleError.noPendingCandidate
+        }
         state.previousAdapterPath = state.currentAdapterPath
+        state.currentAdapterPath = candidate
+        state.pendingAdapterPath = nil
+        state.pendingAdapterKind = nil
         state.userApprovedCycles += 1
         try await store.writeState(state)
 
@@ -835,6 +918,33 @@ actor ImprovementCycleCoordinator {
         state.cycleState = CycleState.idle.rawValue
         state.trainingStartedAt = nil
         state.lastCycleError = message
+        // P9/C4 (W3): returning to idle always discards any pending candidate, so an
+        // idle state can never coexist with a stale candidate that a later path
+        // might deploy. (Invariant: idle ⇒ pendingAdapterPath == nil.)
+        state.pendingAdapterPath = nil
+        state.pendingAdapterKind = nil
         try await store.writeState(state)
+    }
+
+    /// Persist a terminal "blocked / not deployed" outcome for this cycle (P9/C4 W3).
+    ///
+    /// Discards the un-deployed candidate by clearing `pendingAdapterPath`. Because
+    /// the training step writes the candidate ONLY to the pending pointer (never the
+    /// deployed `currentAdapterPath`), clearing it is sufficient — no path or crash
+    /// can leave an un-evaluated candidate advertised as the live adapter. Preserves
+    /// all other state fields (e.g. a just-incremented/just-reset `deferralCount`).
+    private func failClosed(reason: String) async {
+        do {
+            try await store.ensureStateRow()
+            var state = try await store.readState()
+            state.pendingAdapterPath = nil
+            state.pendingAdapterKind = nil
+            state.cycleState = CycleState.idle.rawValue
+            state.trainingStartedAt = nil
+            state.lastCycleError = reason
+            try await store.writeState(state)
+        } catch {
+            NSLog("ImprovementCycleCoordinator: failClosed persist failed: %@", error.localizedDescription)
+        }
     }
 }

--- a/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
@@ -151,6 +151,13 @@ actor ImprovementCycleCoordinator {
     /// the bridge benchmark, else `.unmeasured` (fail-closed).
     private var injectedMeasuredDelta: EvalDelta?
 
+    /// Test seam (P9/C4 W7) reproducing the LEGACY no-receipt eval path: a measured delta
+    /// from the bridge-benchmark / loss-proxy branch, which never sets `receiptMint`. Lets
+    /// a test prove the fail-closed "gate pass ⇒ minted receipt" invariant — a passing delta
+    /// with no receipt must NOT reach review/deploy. Never set in production. Takes priority
+    /// over `injectedMeasuredDelta` when both are set (it models the path being guarded).
+    private var injectedLegacyMeasuredDelta: EvalDelta?
+
     /// Test override of the gate-receipt HMAC key (P9/C4 W4). When set, the deploy gate
     /// verifies receipts with this key instead of the per-install Keychain key, so unit
     /// tests can mint + verify receipts without Keychain access. `nil` in production.
@@ -162,6 +169,13 @@ actor ImprovementCycleCoordinator {
     /// Populated by W7 when the `AdapterEvaluator`s are wired; empty until then (so the loop
     /// refuses to train, the intended conservative state).
     private var availableEvaluatorKinds: Set<AdapterKind> = []
+
+    /// The real `AdapterEvaluator`s, keyed by the adapter kind they score (P9/C4 W7).
+    /// The eval phase picks the evaluator for the trained lane, scores the candidate
+    /// against the DEPLOYED adapter, and (on a measured pass) mints the gate receipt the
+    /// deploy gate (W4) requires. Empty until FaeScheduler/W7 wires an evaluator; absence
+    /// for a lane keeps that lane's eval fail-closed (`.unmeasured`).
+    private var adapterEvaluators: [AdapterKind: AdapterEvaluator] = [:]
 
     /// Minimum SFT examples required before training proceeds.
     static let minSFTExamples = 10
@@ -215,6 +229,13 @@ actor ImprovementCycleCoordinator {
     /// Inject a measured `EvalDelta` for the evaluating phase (P9/C4 interim seam;
     /// see `injectedMeasuredDelta`). Used by tests until W7 wires the real
     /// `AdapterEvaluator`. Passing `nil` clears it (fall through to the bridge).
+    /// Inject a LEGACY-path measured delta (no receipt) for tests (P9/C4 W7; see
+    /// `injectedLegacyMeasuredDelta`). Models the bridge-benchmark / loss-proxy branch
+    /// to exercise the fail-closed "gate pass ⇒ minted receipt" guard.
+    func setInjectedLegacyMeasuredDelta(_ delta: EvalDelta?) {
+        injectedLegacyMeasuredDelta = delta
+    }
+
     func setInjectedMeasuredDelta(_ delta: EvalDelta?) {
         injectedMeasuredDelta = delta
     }
@@ -229,6 +250,18 @@ actor ImprovementCycleCoordinator {
     func setAvailableEvaluatorKinds(_ kinds: Set<AdapterKind>) {
         availableEvaluatorKinds = kinds
     }
+
+    /// Register the real `AdapterEvaluator` for a lane (P9/C4 W7). Called by
+    /// FaeScheduler when an evaluator with a working backing harness is configured.
+    /// Registering also un-blocks the lane (mirrors `setAvailableEvaluatorKinds`) so the
+    /// two can never drift apart — a lane with an evaluator is trainable, one without is not.
+    func setAdapterEvaluator(_ evaluator: AdapterEvaluator) {
+        adapterEvaluators[evaluator.kind] = evaluator
+        availableEvaluatorKinds.insert(evaluator.kind)
+    }
+
+    /// Read-only view of the un-blocked lanes, for tests (P9/C4 W7).
+    var availableEvaluatorKindsForTest: Set<AdapterKind> { availableEvaluatorKinds }
 
     /// Set the meta-optimizer. Called by FaeScheduler after wiring.
     ///
@@ -651,9 +684,39 @@ actor ImprovementCycleCoordinator {
             // synthetic zero-delta "pass". The loss-based proxy is advisory only
             // and never gates (it cannot populate measured dimensions).
             let evalDelta: EvalDelta
-            if let injected = injectedMeasuredDelta {
+            // The provenance for the gate receipt minted on a measured pass (P9/C4 W7).
+            // Set ONLY by a real `AdapterEvaluator`; the injected/inline paths leave it nil
+            // (the injected path is a pure test seam, the inline path predates the evaluator
+            // seam and is fail-closed without a receipt at deploy).
+            var receiptMint: ReceiptMintContext?
+            if let legacy = injectedLegacyMeasuredDelta {
+                // Test seam modelling the LEGACY bridge-benchmark / loss-proxy branch: a
+                // measured delta that does NOT mint a receipt. The fail-closed guard below
+                // must reject it even when it would otherwise pass the gate (W7 invariant).
+                NSLog("ImprovementCycleCoordinator: using injected LEGACY measured delta (no receipt; P9/C4 W7 guard test)")
+                evalDelta = legacy
+            } else if let injected = injectedMeasuredDelta {
+                // The injected seam STANDS IN for a real `AdapterEvaluator` (see
+                // `injectedMeasuredDelta`, a test-only seam never set in production): it must
+                // therefore behave exactly as a real evaluator — produce the measured delta
+                // AND back a gate pass with a minted receipt — or it would trip the W7
+                // fail-closed "gate pass ⇒ minted receipt" invariant below. Since training
+                // produced no real candidate on this seam's path, provision a synthetic
+                // pending candidate (gated entirely behind `injectedMeasuredDelta`) so the
+                // mint has a real artifact + cycle id to bind to.
                 NSLog("ImprovementCycleCoordinator: using injected measured eval delta (P9/C4 interim seam)")
                 evalDelta = injected
+                receiptMint = try await provisionInjectedSeamCandidate()
+            } else if let adapterPath = producedAdapterPath,
+                      let pendingKind = (try? await store.readState())?.pendingAdapterKind
+                          .flatMap(AdapterKind.init(rawValue:)),
+                      adapterEvaluators[pendingKind] != nil {
+                // P9/C4 (W7): a real evaluator scores the candidate against the DEPLOYED
+                // adapter (not the base model). A measured pass mints the gate receipt the
+                // deploy gate (W4) requires; a throw / non-measurement is fail-closed.
+                let result = await evaluateViaAdapterEvaluator(adapterPath: adapterPath, kind: pendingKind)
+                evalDelta = result.delta
+                receiptMint = result.mint
             } else if let bridge = trainingBridge, let adapterPath = producedAdapterPath,
                await bridge.isBenchmarkAvailable {
                 do {
@@ -699,6 +762,30 @@ actor ImprovementCycleCoordinator {
             if AdapterGate.decide(evalDelta.measuredDeltas) == .blockedNoMeasurement {
                 NSLog("ImprovementCycleCoordinator: candidate_blocked — no measured improvement; fail-closed (no review, no deploy)")
                 await failClosed(reason: "candidate_blocked: no_measured_improvement")
+                return
+            }
+
+            // P9/C4 (W7): ONLY a real `AdapterEvaluator` may pass the gate. It is the sole
+            // producer of `receiptMint` AND the only path that can mint a receipt. A delta
+            // that cleared the gate but carries NO mint context came through the legacy
+            // bridge-benchmark / loss-proxy branch (which never mints) or the injected test
+            // seam — neither is a real evaluator, so it must FAIL CLOSED here, immediately,
+            // rather than proceed to external review and rely on the W4 deploy gate blocking
+            // it late. Invariant: a gate pass ⇒ a minted receipt, or no review/deploy at all.
+            guard let mint = receiptMint else {
+                NSLog("ImprovementCycleCoordinator: gate passed but no real-evaluator receipt — fail-closed (no review, no deploy)")
+                await failClosed(reason: "gate_pass_but_no_receipt")
+                return
+            }
+            // Mint + persist the gate receipt NOW (bound to this cycle's pending candidate +
+            // digest), so the deploy gate (W4) has a verifying, unconsumed receipt to spend.
+            // A mint/persist failure is fail-closed — a passing eval that cannot produce a
+            // receipt must not slip into review/deploy.
+            do {
+                try await mintAndStoreGateReceipt(context: mint, measured: evalDelta.measuredDeltas)
+            } catch {
+                NSLog("ImprovementCycleCoordinator: gate receipt mint failed (%@) — fail-closed", error.localizedDescription)
+                await failClosed(reason: "gate_receipt_mint_failed: \(error.localizedDescription)")
                 return
             }
 
@@ -908,6 +995,44 @@ actor ImprovementCycleCoordinator {
         )
     }
 
+    /// Provision a synthetic pending candidate for the injected-delta TEST seam (P9/C4 W7).
+    ///
+    /// Only ever reached when `injectedMeasuredDelta` is set (a test-only seam never set in
+    /// production), so this writes no files on any real run. The candidate must be created
+    /// HERE in the eval phase — not pre-staged by the test — because a fresh `runCycle`
+    /// clears any pending candidate at cycle start (the W3 `idle ⇒ no pending` invariant),
+    /// and a real cycle's candidate is likewise produced only after that, during training.
+    /// Returns the receipt-mint context so the injected seam mints a receipt exactly like a
+    /// real evaluator (preserving the W7 "gate pass ⇒ minted receipt" invariant).
+    private func provisionInjectedSeamCandidate() async throws -> ReceiptMintContext {
+        try await store.ensureStateRow()
+        var state = try await store.readState()
+        // Reuse an already-present pending candidate (a test may have produced a real one);
+        // otherwise synthesise a minimal on-disk mlxDir artifact so the receipt digests.
+        if state.pendingAdapterPath == nil {
+            let dir = FaeDirectories.trainingDirectory
+                .appendingPathComponent("injected-seam-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try Data("injected-seam".utf8).write(
+                to: dir.appendingPathComponent("adapters.safetensors")
+            )
+            state.pendingAdapterPath = dir.path
+            state.pendingAdapterKind = "mlxDir"
+            state.pendingCycleId = UUID().uuidString
+            try await store.writeState(state)
+        } else if state.pendingCycleId == nil {
+            state.pendingCycleId = UUID().uuidString
+            if state.pendingAdapterKind == nil { state.pendingAdapterKind = "mlxDir" }
+            try await store.writeState(state)
+        }
+        let kind = state.pendingAdapterKind.flatMap(AdapterKind.init(rawValue:)) ?? .mlxDir
+        return ReceiptMintContext(
+            kind: kind, evaluatorId: "FaeBenchmarkEvaluator",
+            baseModelId: state.currentAdapterPath ?? "injected-baseline",
+            evalSuiteVersion: "injected-seam"
+        )
+    }
+
     // MARK: - Internal Deploy Helper
 
     /// Perform the actual adapter deployment: track rollback path, increment approved counter,
@@ -978,6 +1103,103 @@ actor ImprovementCycleCoordinator {
         NSLog(
             "ImprovementCycleCoordinator: adapter deployed (userApprovedCycles=%d)",
             state.userApprovedCycles
+        )
+    }
+
+    /// Provenance the eval phase carries from a real `AdapterEvaluator` to the receipt
+    /// mint (P9/C4 W7) — everything `GateMinter.mint` needs beyond the candidate path,
+    /// cycle id, and measured deltas (those come from current state + the gate result).
+    struct ReceiptMintContext {
+        let kind: AdapterKind
+        let evaluatorId: String
+        let baseModelId: String
+        let evalSuiteVersion: String
+    }
+
+    /// Score `adapterPath` (the pending candidate) for lane `kind` via its registered
+    /// `AdapterEvaluator`, against the DEPLOYED adapter as baseline (P9/C4 W7).
+    ///
+    /// Returns the measured `EvalDelta` plus the receipt provenance to mint on a pass.
+    /// Fail-closed: a missing evaluator or any evaluation error yields `.unmeasured` with
+    /// no mint context, so the gate blocks the candidate (it can never reach deploy).
+    /// `internal` so the loop integration test can drive it after staging pending state.
+    func evaluateViaAdapterEvaluator(
+        adapterPath: String, kind: AdapterKind
+    ) async -> (delta: EvalDelta, mint: ReceiptMintContext?) {
+        guard let evaluator = adapterEvaluators[kind] else {
+            NSLog("ImprovementCycleCoordinator: no evaluator for %@ lane — eval unmeasured", kind.rawValue)
+            return (.unmeasured, nil)
+        }
+        // Baseline = the DEPLOYED adapter (or base model when none deployed). This makes
+        // the delta measure improvement over WHAT IS LIVE, not over the untrained base —
+        // a candidate that beats base but regresses against the deployed adapter must fail.
+        let deployedBaseline = (try? await store.readState())?.currentAdapterPath
+        do {
+            NSLog(
+                "ImprovementCycleCoordinator: evaluating candidate via %@ (baseline=%@)",
+                evaluator.evaluatorId, deployedBaseline ?? "<base model>"
+            )
+            let outcome = try await evaluator.evaluate(
+                candidatePath: adapterPath, baselinePath: deployedBaseline
+            )
+            NSLog(
+                "ImprovementCycleCoordinator: evaluator delta — tools=%.1f%% fae=%.1f%% fit=%.1f%% ser=%.1f%%",
+                outcome.delta.toolCallingDelta ?? 0, outcome.delta.faeCapabilityDelta ?? 0,
+                outcome.delta.assistantFitDelta ?? 0, outcome.delta.serializationDelta ?? 0
+            )
+            return (
+                outcome.delta,
+                ReceiptMintContext(
+                    kind: kind, evaluatorId: evaluator.evaluatorId,
+                    baseModelId: outcome.baseModelId, evalSuiteVersion: outcome.evalSuiteVersion
+                )
+            )
+        } catch {
+            NSLog(
+                "ImprovementCycleCoordinator: evaluator %@ failed (%@) — eval unmeasured (fail-closed)",
+                evaluator.evaluatorId, error.localizedDescription
+            )
+            return (.unmeasured, nil)
+        }
+    }
+
+    /// Mint a gate receipt for the current pending candidate and persist it (P9/C4 W7).
+    ///
+    /// Binds the receipt to the live `pendingCycleId` + `pendingAdapterPath` so the deploy
+    /// gate (W4) can verify path, digest, and single-use. Uses the injected test key when
+    /// set (so unit tests mint without Keychain access), else the per-install Keychain key.
+    /// `internal` so the loop integration test can drive the REAL mint → deploy chain.
+    func mintAndStoreGateReceipt(
+        context: ReceiptMintContext, measured: MeasuredDeltas
+    ) async throws {
+        let state = try await store.readState()
+        guard let cycleId = state.pendingCycleId else {
+            throw ImprovementCycleError.gateReceiptRejected("no_pending_cycle_id")
+        }
+        guard let candidate = state.pendingAdapterPath else {
+            throw ImprovementCycleError.noPendingCandidate
+        }
+        let mintedAt = ISO8601DateFormatter().string(from: Date())
+        let receipt: GateReceipt
+        if let key = injectedGateKey {
+            receipt = try GateMinter.mint(
+                cycleId: cycleId, candidatePath: candidate, kind: context.kind,
+                measured: measured.measured, evaluatorId: context.evaluatorId,
+                baseModelId: context.baseModelId, evalSuiteVersion: context.evalSuiteVersion,
+                mintedAt: mintedAt, using: key
+            )
+        } else {
+            receipt = try GateMinter.mint(
+                cycleId: cycleId, candidatePath: candidate, kind: context.kind,
+                measured: measured.measured, evaluatorId: context.evaluatorId,
+                baseModelId: context.baseModelId, evalSuiteVersion: context.evalSuiteVersion,
+                mintedAt: mintedAt
+            )
+        }
+        try await store.insertGateReceipt(receipt)
+        NSLog(
+            "ImprovementCycleCoordinator: gate receipt minted by %@ for cycle %@ (kind=%@)",
+            context.evaluatorId, cycleId, context.kind.rawValue
         )
     }
 

--- a/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
@@ -694,6 +694,11 @@ actor ImprovementCycleCoordinator {
                 // Run shadow evaluation if this is a shadow eval night.
                 if try await isShadowEvalNight() {
                     NSLog("ImprovementCycleCoordinator: running shadow evaluation")
+                    // P9/C4 (W5, F5): shadow eval A/Bs the DEPLOYED adapter vs base — never
+                    // the pending candidate. Pin it to the deployed `currentAdapterPath`
+                    // explicitly so the state split can never re-point it at pending.
+                    let deployedForShadow = (try? await store.readState())?.currentAdapterPath
+                    await shadowEvaluator.setCurrentAdapterPath(deployedForShadow)
                     do {
                         let evalResult = try await shadowEvaluator.runEvaluation(ignoreWindow: true)
                         if !evalResult.promotionGatePassed {
@@ -1037,6 +1042,92 @@ actor ImprovementCycleCoordinator {
             try await store.writeState(state)
         } catch {
             NSLog("ImprovementCycleCoordinator: failClosed persist failed: %@", error.localizedDescription)
+        }
+    }
+
+    /// P9/C4 (W5, F11): repair a stale non-idle state left by a crash or a pre-P9 upgrade.
+    ///
+    /// A `.proposing`/`.deploying` state whose pending candidate still has a STORED,
+    /// unconsumed, verifying gate receipt is legitimately resumable (the user can still
+    /// approve/reject it) and is kept. Any other non-idle state — an interrupted
+    /// collecting/training/evaluating cycle, or a proposing/deploying state WITHOUT a valid
+    /// receipt (incl. pre-P9 rows where the candidate was written to currentAdapterPath
+    /// pre-eval) — is reset to idle, its pending candidate discarded, and the event audited.
+    /// Fail-closed: an ungated in-flight candidate never survives a restart as deployable.
+    func recoverStaleStateIfNeeded() async {
+        do {
+            try await store.ensureStateRow()
+            let state = try await store.readState()
+            guard let cycle = CycleState(rawValue: state.cycleState), cycle != .idle else { return }
+
+            // Only a `.proposing` state is resumable after a restart — the user can still
+            // approve/reject it. A `.deploying` state is NOT resumable (no path advances it),
+            // so it falls through to a fail-closed reset. Resumable requires a stored,
+            // unconsumed, verifying receipt for the pending candidate.
+            if cycle == .proposing,
+               let candidate = state.pendingAdapterPath,
+               let cycleId = state.pendingCycleId,
+               await hasResumableReceipt(cycleId: cycleId, candidate: candidate) {
+                NSLog("ImprovementCycleCoordinator: recovered resumable proposing (valid receipt) — keeping")
+                return
+            }
+
+            var repaired = state
+            repaired.cycleState = CycleState.idle.rawValue
+            repaired.trainingStartedAt = nil
+            repaired.pendingAdapterPath = nil
+            repaired.pendingAdapterKind = nil
+            repaired.pendingCycleId = nil
+            // A pre-P9 row wrote the candidate to currentAdapterPath BEFORE eval and has no
+            // gate receipt at all. A post-P9 deployed currentAdapterPath ALWAYS has a
+            // consumed receipt (from promoteAndConsumeReceipt) — including the crash window
+            // after a promote commits but before the .idle transition, where current is the
+            // just-promoted (legit) candidate and pending is already cleared. So roll the
+            // current pointer back ONLY when it has NO consumed-receipt provenance (the
+            // pre-P9 un-gated case); a deployed/promoted current is always kept.
+            // Only when NO pending candidate is recorded (so currentAdapterPath might itself
+            // be a candidate, not the deployed adapter) AND current has no consumed-receipt
+            // provenance (⇒ pre-P9 un-gated, not a just-promoted post-P9 candidate).
+            // INTENDED TRADEOFF: a pre-P9 LEGITIMATELY-deployed current also has no receipt,
+            // so a crash mid-cycle on the first post-upgrade run rolls it back to the previous
+            // adapter. That is fail-closed (we cannot distinguish a pre-P9 deployed adapter
+            // from a pre-P9 un-gated candidate — neither has a receipt — so we prefer the
+            // known-prior adapter). The user keeps a working personalized adapter; the next
+            // cycle re-evaluates. This only affects the narrow first-upgrade crash window.
+            if state.pendingAdapterPath == nil,
+               let current = state.currentAdapterPath,
+               cycle == .evaluating || cycle == .proposing || cycle == .deploying,
+               (try? await store.hasConsumedReceipt(forCandidatePath: current)) != true {
+                repaired.currentAdapterPath = state.previousAdapterPath
+            }
+            repaired.lastCycleError = "recovered_stale_\(cycle.rawValue)"
+            try await store.writeState(repaired)
+            NSLog(
+                "ImprovementCycleCoordinator: recovered stale %@ → idle (discarded pending candidate)",
+                cycle.rawValue
+            )
+        } catch {
+            NSLog("ImprovementCycleCoordinator: recoverStaleStateIfNeeded failed: %@", error.localizedDescription)
+        }
+    }
+
+    /// Whether the pending candidate for `cycleId` has a stored, unconsumed, verifying
+    /// receipt (i.e. a `.proposing` state is safe to resume after a restart).
+    private func hasResumableReceipt(cycleId: String, candidate: String) async -> Bool {
+        guard let receipt = try? await store.gateReceipt(forCycleId: cycleId) else { return false }
+        // Fail-closed: any store error reading the consumed flag ⇒ not resumable.
+        guard let consumed = try? await store.isGateReceiptConsumed(cycleId: cycleId), !consumed else {
+            return false
+        }
+        do {
+            if let key = injectedGateKey {
+                try GateReceiptVerifier.verify(receipt, expectedCandidatePath: candidate, using: key)
+            } else {
+                try GateReceiptVerifier.verify(receipt, expectedCandidatePath: candidate)
+            }
+            return true
+        } catch {
+            return false
         }
     }
 }

--- a/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
@@ -156,6 +156,13 @@ actor ImprovementCycleCoordinator {
     /// tests can mint + verify receipts without Keychain access. `nil` in production.
     private var injectedGateKey: SymmetricKey?
 
+    /// The adapter kinds for which a real evaluator is available (P9/C4 W6). The training
+    /// step refuses to train a lane whose kind is absent here — without an evaluator the
+    /// candidate could never pass the deploy gate (W4), so training would only burn a run.
+    /// Populated by W7 when the `AdapterEvaluator`s are wired; empty until then (so the loop
+    /// refuses to train, the intended conservative state).
+    private var availableEvaluatorKinds: Set<AdapterKind> = []
+
     /// Minimum SFT examples required before training proceeds.
     static let minSFTExamples = 10
 
@@ -215,6 +222,12 @@ actor ImprovementCycleCoordinator {
     /// Inject the gate-receipt HMAC key for tests (P9/C4 W4; see `injectedGateKey`).
     func setInjectedGateKey(_ key: SymmetricKey?) {
         injectedGateKey = key
+    }
+
+    /// Declare which adapter kinds have a real evaluator available (P9/C4 W6). Called by
+    /// FaeScheduler/W7 when the evaluators are wired. Empty ⇒ refuse to train any lane.
+    func setAvailableEvaluatorKinds(_ kinds: Set<AdapterKind>) {
+        availableEvaluatorKinds = kinds
     }
 
     /// Set the meta-optimizer. Called by FaeScheduler after wiring.
@@ -525,6 +538,27 @@ actor ImprovementCycleCoordinator {
                 try await transition(to: .evaluating)
                 // Jump past the training block.
                 throw ImprovementCycleError.storeNotAvailable // caught below, triggers eval-only path
+            }
+
+            // P9/C4 (W6, F14): refuse to train a lane that has no available evaluator —
+            // without one the candidate could never pass the deploy gate (W4), so training
+            // would only burn a run. (Q4: refuse-to-train, not train-then-block.) The lane
+            // is the daemon/gguf lane when a daemon base model is set, else the mlx-dir lane.
+            // availableEvaluatorKinds is populated by W7; empty ⇒ refuse (conservative).
+            let laneKind: AdapterKind = daemonTrainingBaseModel != nil ? .gguf : .mlxDir
+            guard availableEvaluatorKinds.contains(laneKind) else {
+                NSLog(
+                    "ImprovementCycleCoordinator: no evaluator for %@ lane — refusing to train (lane_no_evaluator)",
+                    laneKind.rawValue
+                )
+                // Surface the refusal in the morning briefing (companion language), in
+                // addition to the audited lastCycleError that health reporting reads.
+                let refuseNote = "I held off on training this time — I don't have an evaluator for " +
+                    "the \(laneKind.rawValue) model lane yet, so I couldn't safely check a new version."
+                pendingMetaOptNarrative = [pendingMetaOptNarrative, refuseNote]
+                    .compactMap { $0 }.joined(separator: " ")
+                try? await forceIdle(error: "lane_no_evaluator:\(laneKind.rawValue)")
+                return
             }
 
             // 5a. Export training data from fae.db.

--- a/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 // MARK: - CycleState
@@ -49,6 +50,9 @@ enum ImprovementCycleError: Error, Sendable {
     case stuckDetected(startedAt: String)
     /// A deploy was attempted with no pending candidate to promote (P9/C4 W3).
     case noPendingCandidate
+    /// A deploy was attempted with no verifying gate receipt for the candidate (P9/C4 W4).
+    /// Carries a short reason for the audit trail.
+    case gateReceiptRejected(String)
 }
 
 // MARK: - ImprovementCycleCoordinator
@@ -147,6 +151,11 @@ actor ImprovementCycleCoordinator {
     /// the bridge benchmark, else `.unmeasured` (fail-closed).
     private var injectedMeasuredDelta: EvalDelta?
 
+    /// Test override of the gate-receipt HMAC key (P9/C4 W4). When set, the deploy gate
+    /// verifies receipts with this key instead of the per-install Keychain key, so unit
+    /// tests can mint + verify receipts without Keychain access. `nil` in production.
+    private var injectedGateKey: SymmetricKey?
+
     /// Minimum SFT examples required before training proceeds.
     static let minSFTExamples = 10
 
@@ -201,6 +210,11 @@ actor ImprovementCycleCoordinator {
     /// `AdapterEvaluator`. Passing `nil` clears it (fall through to the bridge).
     func setInjectedMeasuredDelta(_ delta: EvalDelta?) {
         injectedMeasuredDelta = delta
+    }
+
+    /// Inject the gate-receipt HMAC key for tests (P9/C4 W4; see `injectedGateKey`).
+    func setInjectedGateKey(_ key: SymmetricKey?) {
+        injectedGateKey = key
     }
 
     /// Set the meta-optimizer. Called by FaeScheduler after wiring.
@@ -394,6 +408,7 @@ actor ImprovementCycleCoordinator {
             // crash/stuck mid-cycle can never leave an un-evaluated candidate live.
             resetState.pendingAdapterPath = nil
             resetState.pendingAdapterKind = nil
+            resetState.pendingCycleId = nil
             try await store.writeState(resetState)
         }
 
@@ -416,6 +431,7 @@ actor ImprovementCycleCoordinator {
             var cleared = startState
             cleared.pendingAdapterPath = nil
             cleared.pendingAdapterKind = nil
+            cleared.pendingCycleId = nil
             try await store.writeState(cleared)
             NSLog("ImprovementCycleCoordinator: cleared stale pending candidate at cycle start")
         }
@@ -556,6 +572,9 @@ actor ImprovementCycleCoordinator {
             var state = try await store.readState()
             state.pendingAdapterPath = adapterPath
             state.pendingAdapterKind = candidate.kind.rawValue
+            // P9/C4 (W4): bind this candidate to a cycle id. The evaluator (W7) mints a
+            // gate receipt keyed by this id; the deploy gate requires that receipt.
+            state.pendingCycleId = UUID().uuidString
             try await store.writeState(state)
         } catch let error as ImprovementCycleError {
             // Rethrown from the bridge-nil path above — not a real failure.
@@ -790,7 +809,15 @@ actor ImprovementCycleCoordinator {
             throw ImprovementCycleError.noPendingCandidate
         }
         try await transition(to: .deploying)
-        try await performDeploy(approved: true)
+        do {
+            try await performDeploy(approved: true)
+        } catch {
+            // P9/C4 (W4): the deploy was refused (e.g. no/invalid gate receipt). Fail
+            // closed — discard the candidate and return to idle, then surface the error
+            // to the caller (UI) rather than leaving the machine stuck in .deploying.
+            await failClosed(reason: "deploy_rejected: \(error)")
+            throw error
+        }
         try await transition(to: .idle)
         NSLog("ImprovementCycleCoordinator: deployment approved — cycle complete")
     }
@@ -813,6 +840,7 @@ actor ImprovementCycleCoordinator {
         // a rejected candidate simply never deploys.
         state.pendingAdapterPath = nil
         state.pendingAdapterKind = nil
+        state.pendingCycleId = nil
         state.cycleState = CycleState.idle.rawValue
         state.completedCycles += 1
         state.lastCycleAt = ISO8601DateFormatter().string(from: Date())
@@ -864,12 +892,47 @@ actor ImprovementCycleCoordinator {
             NSLog("ImprovementCycleCoordinator: performDeploy called with no pending candidate — refusing")
             throw ImprovementCycleError.noPendingCandidate
         }
+
+        // P9/C4 (W4): REQUIRE a verifying, unconsumed gate receipt for THIS exact
+        // candidate before promoting it. No receipt ⇒ no deploy (fail-closed). Receipts
+        // are minted by the evaluator (W7); without an evaluator the loop blocks here,
+        // which is the intended conservative behaviour (no auto-deploy until a real eval
+        // gate exists).
+        let receipt = try await requireGateReceipt(for: state, candidate: candidate)
+
+        // Receipt ↔ candidate consistency: the receipt's kind must match what the training
+        // step recorded for this pending candidate.
+        if let pendingKind = state.pendingAdapterKind, receipt.kind.rawValue != pendingKind {
+            throw ImprovementCycleError.gateReceiptRejected(
+                "receipt_kind_mismatch: receipt=\(receipt.kind.rawValue) pending=\(pendingKind)"
+            )
+        }
+        // Kind ↔ engine consistency: the daemon lane loads a GGUF; the MLX lane loads an
+        // adapter directory. A mismatch means the candidate cannot load on the active
+        // engine — block rather than ship a dead adapter.
+        let expectedKind: AdapterKind = daemonTrainingBaseModel != nil ? .gguf : .mlxDir
+        guard receipt.kind == expectedKind else {
+            throw ImprovementCycleError.gateReceiptRejected(
+                "kind_engine_mismatch: receipt=\(receipt.kind.rawValue) expected=\(expectedKind.rawValue)"
+            )
+        }
+
+        guard let cycleId = state.pendingCycleId else {
+            throw ImprovementCycleError.gateReceiptRejected("no_pending_cycle_id")
+        }
         state.previousAdapterPath = state.currentAdapterPath
         state.currentAdapterPath = candidate
         state.pendingAdapterPath = nil
         state.pendingAdapterKind = nil
+        state.pendingCycleId = nil
         state.userApprovedCycles += 1
-        try await store.writeState(state)
+        // P9/C4 (W4): promote + consume ATOMICALLY. The consume requires a stored,
+        // unconsumed receipt (UPDATE … WHERE consumed_at IS NULL, exactly one row) or the
+        // whole transaction rolls back — so the deploy can never commit without spending a
+        // real receipt, and the receipt can never be double-spent.
+        try await store.promoteAndConsumeReceipt(
+            state: state, cycleId: cycleId, at: ISO8601DateFormatter().string(from: Date())
+        )
 
         // Notify pipeline — nil until FaeCore wires it in.
         adapterPatchCallback?(state.currentAdapterPath)
@@ -877,6 +940,33 @@ actor ImprovementCycleCoordinator {
             "ImprovementCycleCoordinator: adapter deployed (userApprovedCycles=%d)",
             state.userApprovedCycles
         )
+    }
+
+    /// Fetch + verify the gate receipt that authorizes deploying `candidate` (P9/C4 W4).
+    /// Fail-closed: throws `gateReceiptRejected` if there is no bound cycle id, no receipt,
+    /// the receipt is already consumed, or it fails cryptographic/digest verification.
+    private func requireGateReceipt(
+        for state: ImprovementState, candidate: String
+    ) async throws -> GateReceipt {
+        guard let cycleId = state.pendingCycleId else {
+            throw ImprovementCycleError.gateReceiptRejected("no_pending_cycle_id")
+        }
+        guard let receipt = try await store.gateReceipt(forCycleId: cycleId) else {
+            throw ImprovementCycleError.gateReceiptRejected("no_receipt")
+        }
+        if try await store.isGateReceiptConsumed(cycleId: cycleId) {
+            throw ImprovementCycleError.gateReceiptRejected("receipt_already_consumed")
+        }
+        do {
+            if let key = injectedGateKey {
+                try GateReceiptVerifier.verify(receipt, expectedCandidatePath: candidate, using: key)
+            } else {
+                try GateReceiptVerifier.verify(receipt, expectedCandidatePath: candidate)
+            }
+        } catch {
+            throw ImprovementCycleError.gateReceiptRejected("verify_failed: \(error)")
+        }
+        return receipt
     }
 
     // MARK: - Loss-Based Eval Fallback
@@ -923,6 +1013,7 @@ actor ImprovementCycleCoordinator {
         // might deploy. (Invariant: idle ⇒ pendingAdapterPath == nil.)
         state.pendingAdapterPath = nil
         state.pendingAdapterKind = nil
+        state.pendingCycleId = nil
         try await store.writeState(state)
     }
 
@@ -939,6 +1030,7 @@ actor ImprovementCycleCoordinator {
             var state = try await store.readState()
             state.pendingAdapterPath = nil
             state.pendingAdapterKind = nil
+            state.pendingCycleId = nil
             state.cycleState = CycleState.idle.rawValue
             state.trainingStartedAt = nil
             state.lastCycleError = reason

--- a/native/macos/Fae/Sources/FaeBenchmark/main.swift
+++ b/native/macos/Fae/Sources/FaeBenchmark/main.swift
@@ -252,6 +252,22 @@ func systemRAMGB() -> Int {
     Int(ProcessInfo.processInfo.physicalMemory / (1024 * 1024 * 1024))
 }
 
+/// Resolve `--model auto` to a RAM-appropriate registry entry, mirroring the app's
+/// `voiceModelPreset: "auto"` fallback (Qwen3.5 lane: 9B ≥16 GB, 4B ≥8 GB, 2B below).
+/// Returns nil only if the expected short name is missing from `models` (it isn't).
+func autoSelectedModel() -> ModelEntry? {
+    let ram = systemRAMGB()
+    let shortName: String
+    if ram >= 16 {
+        shortName = "qwen3.5-9b"
+    } else if ram >= 8 {
+        shortName = "qwen3.5-4b"
+    } else {
+        shortName = "qwen3.5-2b"
+    }
+    return models.first(where: { $0.shortName == shortName })
+}
+
 func buildFillerText(targetWords: Int) -> String {
     let sentences = [
         "The history of artificial intelligence is a fascinating journey through decades of research and development.",
@@ -1616,7 +1632,21 @@ func run() async throws {
     // Determine models to benchmark
     let modelList: [ModelEntry]
     if let shortName = args.modelShortName {
-        if let entry = models.first(where: { $0.shortName == shortName }) {
+        if shortName == "auto" {
+            // Resolve `--model auto` to a RAM-appropriate default so the training
+            // bridge can ask for the same preset the app's auto path would pick,
+            // without hardcoding a model name at the call site (P9/C4 W7a). If the
+            // expected Qwen3.5 short name is somehow absent from the registry, fail
+            // LOUD (matching the file's print + exit convention) — never silently fall
+            // through to a wrong model or the generic "unknown model" path.
+            guard let entry = autoSelectedModel() else {
+                print("Error: --model auto could not resolve — expected Qwen3.5 short name not in registry (\(systemRAMGB()) GB RAM)")
+                print("Available: \(models.map(\.shortName).joined(separator: ", "))")
+                exit(1)
+            }
+            print("Auto-selected model: \(entry.shortName) (\(systemRAMGB()) GB RAM)")
+            modelList = [entry]
+        } else if let entry = models.first(where: { $0.shortName == shortName }) {
             modelList = [entry]
         } else if let entry = models.first(where: { $0.modelID == shortName }) {
             modelList = [entry]

--- a/native/macos/Fae/Tests/HandoffTests/AdapterDeploymentManagerTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/AdapterDeploymentManagerTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import XCTest
 @testable import Fae
 
@@ -116,28 +117,71 @@ final class AdapterDeploymentManagerTests: XCTestCase {
 
     // MARK: - Deploy
 
-    func testDeployUpdatesAdapterPaths() async throws {
-        let store = try await makeTempStore()
+    /// P9/C4 (W4): deploy now requires a verifying gate receipt — mint one for a real
+    /// candidate file and deploy that.
+    private func makeReceiptCandidate(cycleId: String, key: SymmetricKey) throws -> (String, GateReceipt) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-adm-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("adapter.gguf").path
+        try "weights".write(toFile: path, atomically: true, encoding: .utf8)
+        let receipt = try GateMinter.mint(
+            cycleId: cycleId, candidatePath: path, kind: .gguf,
+            measured: [.toolCalling: 3.0, .faeCapability: 1.0, .assistantFit: 2.0, .serialization: 0.0],
+            evaluatorId: "DaemonABEvaluator", baseModelId: "gemma-test",
+            evalSuiteVersion: "v1", mintedAt: "2026-06-22T00:00:00Z", using: key
+        )
+        return (path, receipt)
+    }
 
+    func testDeployPromotesReceiptCandidateAndConsumes() async throws {
+        let store = try await makeTempStore()
+        let key = SymmetricKey(data: Data(repeating: 0x42, count: 32))
         var state = try await store.readState()
         state.currentAdapterPath = "/old/adapter"
         try await store.writeState(state)
 
-        try await AdapterDeploymentManager.deploy(adapterPath: "/new/adapter", store: store)
+        let (path, receipt) = try makeReceiptCandidate(cycleId: "adm-1", key: key)
+        try await store.insertGateReceipt(receipt)
+        try await AdapterDeploymentManager.deploy(receipt: receipt, store: store, verifyingWith: key)
 
         let updated = try await store.readState()
-        XCTAssertEqual(updated.currentAdapterPath, "/new/adapter")
+        XCTAssertEqual(updated.currentAdapterPath, path)
         XCTAssertEqual(updated.previousAdapterPath, "/old/adapter")
+        let consumed = try await store.isGateReceiptConsumed(cycleId: "adm-1")
+        XCTAssertTrue(consumed, "receipt consumed after deploy")
     }
 
-    func testDeployFromBaseModel() async throws {
+    func testDeployRejectsConsumedReceipt() async throws {
         let store = try await makeTempStore()
+        let key = SymmetricKey(data: Data(repeating: 0x42, count: 32))
+        let (_, receipt) = try makeReceiptCandidate(cycleId: "adm-2", key: key)
+        try await store.insertGateReceipt(receipt)
+        try await store.consumeGateReceipt(cycleId: "adm-2", at: "2026-06-22T00:00:00Z")
 
-        try await AdapterDeploymentManager.deploy(adapterPath: "/first/adapter", store: store)
+        do {
+            try await AdapterDeploymentManager.deploy(receipt: receipt, store: store, verifyingWith: key)
+            XCTFail("deploy must reject an already-consumed receipt")
+        } catch ImprovementStoreError.receiptNotConsumable {
+            // expected — atomic consume affected 0 rows (already consumed)
+        }
+    }
 
-        let updated = try await store.readState()
-        XCTAssertEqual(updated.currentAdapterPath, "/first/adapter")
-        XCTAssertNil(updated.previousAdapterPath)
+    /// A validly-signed receipt that was never STORED cannot deploy (closes the
+    /// "signed offline, never evaluated" loophole) — P9/C4 W4.
+    func testDeployRejectsUnstoredReceipt() async throws {
+        let store = try await makeTempStore()
+        let key = SymmetricKey(data: Data(repeating: 0x42, count: 32))
+        let (_, receipt) = try makeReceiptCandidate(cycleId: "adm-3", key: key)
+        // Do NOT insert the receipt into the store.
+        do {
+            try await AdapterDeploymentManager.deploy(receipt: receipt, store: store, verifyingWith: key)
+            XCTFail("deploy must reject a receipt that was never stored")
+        } catch ImprovementStoreError.receiptNotConsumable {
+            // expected — atomic consume found no row to consume
+        }
+        let after = try await store.readState()
+        XCTAssertNil(after.currentAdapterPath, "Nothing deployed")
     }
 
     // MARK: - Rollback

--- a/native/macos/Fae/Tests/HandoffTests/AdapterEvaluatorTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/AdapterEvaluatorTests.swift
@@ -1,0 +1,273 @@
+import CryptoKit
+import XCTest
+@testable import Fae
+
+/// P9/C4 W7a — the `AdapterEvaluator` seam (mlxDir lane) and the receipt it produces.
+///
+/// These tests encode WHY the evaluator gates the way it does:
+/// - the baseline MUST be the DEPLOYED adapter, so a delta measures improvement over
+///   what is LIVE today (a candidate that beats base but regresses against the
+///   deployed adapter must not pass);
+/// - a passing measurement MUST mint a gate receipt the W4 deploy gate accepts, end to
+///   end through the real `GateReceiptVerifier` (no test-only bypass);
+/// - a non-measurement / evaluator failure MUST be fail-closed (no receipt, blocked).
+final class AdapterEvaluatorTests: XCTestCase {
+
+    private let gateTestKey = SymmetricKey(data: Data(repeating: 0x42, count: 32))
+
+    // MARK: - Recording fake evaluator
+
+    /// A fake `AdapterEvaluator` that records the baseline it was asked to score against
+    /// and returns a caller-supplied outcome. Lets us assert the coordinator passes the
+    /// DEPLOYED adapter as baseline and mints the receipt from the evaluator's deltas.
+    private actor RecordingEvaluator: AdapterEvaluator {
+        let kind: AdapterKind
+        let evaluatorId: String
+        private let outcome: GateOutcome?
+        private(set) var lastBaseline: String?
+        private(set) var lastCandidate: String?
+        private(set) var evaluateCalls = 0
+
+        init(kind: AdapterKind, evaluatorId: String, outcome: GateOutcome?) {
+            self.kind = kind
+            self.evaluatorId = evaluatorId
+            self.outcome = outcome
+        }
+
+        func isAvailable() async -> Bool { true }
+
+        func evaluate(candidatePath: String, baselinePath: String?) async throws -> GateOutcome {
+            evaluateCalls += 1
+            lastCandidate = candidatePath
+            lastBaseline = baselinePath
+            guard let outcome else {
+                throw AdapterEvaluatorError.measurementFailed("forced failure")
+            }
+            return outcome
+        }
+    }
+
+    private func makeTempStore() async throws -> ImprovementStore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-eval-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = ImprovementStore()
+        try await store.open(at: dir.appendingPathComponent("improvement.db"))
+        return store
+    }
+
+    /// Create a real on-disk mlxDir candidate (a directory with one file) so the receipt
+    /// digest can be computed + later verified against the same bytes.
+    private func makeMlxCandidateDir() throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-cand-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "weights".write(
+            toFile: dir.appendingPathComponent("adapters.safetensors").path,
+            atomically: true, encoding: .utf8
+        )
+        return dir.path
+    }
+
+    private func improvementOutcome() -> GateOutcome {
+        GateOutcome(
+            delta: EvalDelta(
+                toolCallingDelta: 4.0, faeCapabilityDelta: 2.0,
+                assistantFitDelta: 3.0, serializationDelta: 1.0, throughputDelta: 5.0
+            ),
+            baseModelId: "/tmp/deployed_mlx", evalSuiteVersion: "faebench-v1"
+        )
+    }
+
+    // MARK: - Baseline = deployed adapter
+
+    /// The coordinator must hand the evaluator the DEPLOYED `currentAdapterPath` as the
+    /// baseline — NOT the base model — so the delta measures improvement over what is live.
+    func testEvaluatorScoresAgainstDeployedAdapterBaseline() async throws {
+        let store = try await makeTempStore()
+        let candidate = try makeMlxCandidateDir()
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.currentAdapterPath = "/tmp/deployed_mlx"   // what is LIVE today
+        s.pendingAdapterPath = candidate
+        s.pendingAdapterKind = "mlxDir"
+        s.pendingCycleId = "cyc-baseline"
+        try await store.writeState(s)
+
+        let evaluator = RecordingEvaluator(
+            kind: .mlxDir, evaluatorId: "FaeBenchmarkEvaluator", outcome: improvementOutcome()
+        )
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setAdapterEvaluator(evaluator)
+
+        let result = await coordinator.evaluateViaAdapterEvaluator(adapterPath: candidate, kind: .mlxDir)
+
+        let baseline = await evaluator.lastBaseline
+        XCTAssertEqual(
+            baseline, "/tmp/deployed_mlx",
+            "Baseline must be the DEPLOYED adapter so the delta measures improvement over what is live"
+        )
+        XCTAssertEqual(result.delta.toolCallingDelta, 4.0, "Returns the evaluator's measured delta")
+        XCTAssertEqual(result.mint?.evaluatorId, "FaeBenchmarkEvaluator")
+        XCTAssertEqual(result.mint?.kind, .mlxDir)
+    }
+
+    /// With nothing deployed, the baseline is nil (base model) — the first adapter
+    /// legitimately competes against the untrained base.
+    func testEvaluatorBaselineIsBaseModelWhenNoneDeployed() async throws {
+        let store = try await makeTempStore()
+        let candidate = try makeMlxCandidateDir()
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.currentAdapterPath = nil
+        s.pendingAdapterKind = "mlxDir"
+        try await store.writeState(s)
+
+        let evaluator = RecordingEvaluator(
+            kind: .mlxDir, evaluatorId: "FaeBenchmarkEvaluator", outcome: improvementOutcome()
+        )
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setAdapterEvaluator(evaluator)
+
+        _ = await coordinator.evaluateViaAdapterEvaluator(adapterPath: candidate, kind: .mlxDir)
+
+        let baseline = await evaluator.lastBaseline
+        XCTAssertNil(baseline, "No deployed adapter ⇒ baseline is the base model (nil)")
+    }
+
+    // MARK: - Fail-closed
+
+    /// A throwing evaluator yields `.unmeasured` with no mint context — the gate then
+    /// blocks the candidate (it can never reach deploy).
+    func testEvaluatorFailureIsFailClosed() async throws {
+        let store = try await makeTempStore()
+        let candidate = try makeMlxCandidateDir()
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.pendingAdapterKind = "mlxDir"
+        try await store.writeState(s)
+
+        let evaluator = RecordingEvaluator(
+            kind: .mlxDir, evaluatorId: "FaeBenchmarkEvaluator", outcome: nil   // forces throw
+        )
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setAdapterEvaluator(evaluator)
+
+        let result = await coordinator.evaluateViaAdapterEvaluator(adapterPath: candidate, kind: .mlxDir)
+
+        XCTAssertNil(result.delta.toolCallingDelta, "A failed evaluation is unmeasured")
+        XCTAssertEqual(
+            AdapterGate.decide(result.delta.measuredDeltas), .blockedNoMeasurement,
+            "Unmeasured ⇒ fail-closed block"
+        )
+        XCTAssertNil(result.mint, "No receipt provenance on a failed evaluation")
+    }
+
+    /// A lane with no registered evaluator is fail-closed (no measurement, no mint).
+    func testNoEvaluatorForLaneIsUnmeasured() async throws {
+        let store = try await makeTempStore()
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        // No evaluator registered for .mlxDir.
+        let result = await coordinator.evaluateViaAdapterEvaluator(adapterPath: "/tmp/x", kind: .mlxDir)
+        XCTAssertNil(result.delta.toolCallingDelta)
+        XCTAssertNil(result.mint)
+    }
+
+    // MARK: - Un-block + registration
+
+    /// Registering an evaluator un-blocks ITS lane (and only its lane), so the W6
+    /// refuse-to-train gate and the evaluator wiring can never drift apart.
+    func testRegisteringEvaluatorUnblocksOnlyItsLane() async throws {
+        let store = try await makeTempStore()
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        let evaluator = RecordingEvaluator(
+            kind: .mlxDir, evaluatorId: "FaeBenchmarkEvaluator", outcome: improvementOutcome()
+        )
+        await coordinator.setAdapterEvaluator(evaluator)
+        let kinds = await coordinator.availableEvaluatorKindsForTest
+        XCTAssertTrue(kinds.contains(.mlxDir), "mlxDir lane un-blocked by registering its evaluator")
+        XCTAssertFalse(kinds.contains(.gguf), "gguf lane stays blocked (no evaluator) — W7b")
+    }
+
+    // MARK: - FaeBenchmarkEvaluator availability (fail-closed without a binary)
+
+    /// Without a configured FaeBenchmark binary the evaluator reports unavailable and
+    /// throws `notAvailable` — it never silently produces a fabricated measurement.
+    func testFaeBenchmarkEvaluatorUnavailableWithoutBinary() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-bench-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let bridge = TrainingBridge(uvPath: "/usr/bin/false", orchestratorScriptsDir: tmp, dataBridgeScriptsDir: tmp)
+        let evaluator = FaeBenchmarkEvaluator(bridge: bridge)
+
+        let available = await evaluator.isAvailable()
+        XCTAssertFalse(available, "No benchmark binary configured ⇒ unavailable")
+
+        do {
+            _ = try await evaluator.evaluate(candidatePath: "/tmp/cand", baselinePath: "/tmp/base")
+            XCTFail("evaluate must throw when the harness is unavailable")
+        } catch let error as AdapterEvaluatorError {
+            if case .notAvailable = error { return }
+            XCTFail("Expected .notAvailable, got \(error)")
+        }
+    }
+
+    // MARK: - FIX 1: baseModelId reflects the BASELINE run, not the candidate
+
+    /// When NO adapter is deployed (baseline = base model), the receipt's `baseModelId`
+    /// must reflect the BASELINE benchmark run's model id — NOT the candidate's. Otherwise
+    /// a future verifier would misread a base-model baseline as "evaluated against a
+    /// deployed adapter". Driven through a scripted FaeBenchmark binary that stamps a
+    /// distinct model_id for the baseline (no --adapter) vs the candidate (--adapter) run.
+    func testFaeBenchmarkEvaluatorBaseModelIdReflectsBaselineRun() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-stub-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+
+        // Scripted benchmark: writes valid BenchmarkOutput JSON to the --output path,
+        // stamping model_id = CANDIDATE_MODEL when --adapter is present, else BASELINE_MODEL.
+        // Candidate scores strictly higher so the delta is a measured improvement.
+        let script = """
+        #!/bin/bash
+        out=""; adapter=""
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --output) out="$2"; shift 2;;
+            --adapter) adapter="1"; shift 2;;
+            *) shift;;
+          esac
+        done
+        if [ -n "$adapter" ]; then
+          mid="CANDIDATE_MODEL"; tc=true
+        else
+          mid="BASELINE_MODEL"; tc=false
+        fi
+        cat > "$out" <<JSON
+        {"models":[{"model_id":"$mid",
+          "tool_calling":[{"correct":$tc}],
+          "fae_capability_eval":[{"correct":$tc}],
+          "assistant_fit_eval":[{"correct":$tc}],
+          "serialization_eval":[{"valid":true,"correct":$tc}]}]}
+        JSON
+        """
+        let binPath = tmp.appendingPathComponent("FaeBenchmarkStub").path
+        try script.write(toFile: binPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binPath)
+
+        let bridge = TrainingBridge(uvPath: "/usr/bin/false", orchestratorScriptsDir: tmp, dataBridgeScriptsDir: tmp)
+        await bridge.setBenchmarkPath(binPath)
+        let evaluator = FaeBenchmarkEvaluator(bridge: bridge)
+
+        // No deployed adapter ⇒ baselinePath nil ⇒ baseModelId must come from the baseline run.
+        let outcome = try await evaluator.evaluate(candidatePath: "/tmp/candidate_dir", baselinePath: nil)
+
+        XCTAssertEqual(
+            outcome.baseModelId, "BASELINE_MODEL",
+            "baseModelId must reflect the BASELINE benchmark run, not the candidate"
+        )
+        XCTAssertNotEqual(outcome.baseModelId, "CANDIDATE_MODEL", "Must not record the candidate's model id")
+        // Candidate scored higher across all four dims ⇒ a measured improvement.
+        XCTAssertEqual(try XCTUnwrap(outcome.delta.toolCallingDelta), 100.0, accuracy: 0.001)
+        XCTAssertEqual(AdapterGate.decide(outcome.delta.measuredDeltas), .pass)
+    }
+}

--- a/native/macos/Fae/Tests/HandoffTests/DaemonABEvaluatorTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/DaemonABEvaluatorTests.swift
@@ -1,0 +1,453 @@
+import CryptoKit
+import XCTest
+@testable import Fae
+
+/// P9/C4 W7b — the daemon-lane A/B evaluator (`.gguf`) and the receipt it produces.
+///
+/// These tests encode WHY the daemon A/B gates the way it does:
+/// - the baseline MUST be the DEPLOYED adapter via reload-per-phase (NOT scale-0,
+///   which is the base model) so the delta measures improvement over what is live;
+/// - the LIVE daemon MUST be restored to the deployed adapter on EVERY exit path
+///   (success, throw, timeout) — a daemon left on the un-gated candidate is the
+///   deploy-without-receipt hole this series closes;
+/// - scoring is purely deterministic (NO LLM re-judging) so the gate is reproducible;
+/// - a passing measurement MUST mint a `.gguf` gate receipt the W4 deploy gate accepts.
+final class DaemonABEvaluatorTests: XCTestCase {
+
+    private let gateTestKey = SymmetricKey(data: Data(repeating: 0x42, count: 32))
+
+    // MARK: - Recording fake daemon client
+
+    /// A fake `DaemonABClient` that records the reload/scale/infer call sequence and
+    /// returns canned per-(adapter, exampleId) inferences. `loadedAdapterPath`
+    /// reflects the LAST reload so restore-confirmation can be asserted (or forced
+    /// to mismatch). The ONLY way to test the A/B orchestration without a live daemon.
+    private actor FakeDaemonABClient: DaemonABClient {
+        enum Call: Equatable {
+            case reload(String?)
+            case setScale(Float)
+            case infer(String)            // exampleId
+            case status
+        }
+
+        private(set) var calls: [Call] = []
+        private var loaded: String?
+        /// exampleId → text answer under the CANDIDATE adapter; baseline answers
+        /// are wrong unless listed in `baselineCorrect`.
+        private let candidateText: [String: String]
+        private let candidateToolCalls: [String: [DaemonABInference.ToolCallSummary]]
+        private let baselineText: [String: String]
+        private let baselineToolCalls: [String: [DaemonABInference.ToolCallSummary]]
+        /// When set, `infer` throws on this exampleId (models a mid-A/B failure).
+        private let throwOnInferExampleId: String?
+        /// When true, `loadedAdapterPath` lies (reports nil) so restore can't confirm.
+        private let breakRestoreConfirmation: Bool
+        private let candidatePath: String
+
+        init(
+            candidatePath: String,
+            candidateText: [String: String] = [:],
+            candidateToolCalls: [String: [DaemonABInference.ToolCallSummary]] = [:],
+            baselineText: [String: String] = [:],
+            baselineToolCalls: [String: [DaemonABInference.ToolCallSummary]] = [:],
+            throwOnInferExampleId: String? = nil,
+            breakRestoreConfirmation: Bool = false
+        ) {
+            self.candidatePath = candidatePath
+            self.candidateText = candidateText
+            self.candidateToolCalls = candidateToolCalls
+            self.baselineText = baselineText
+            self.baselineToolCalls = baselineToolCalls
+            self.throwOnInferExampleId = throwOnInferExampleId
+            self.breakRestoreConfirmation = breakRestoreConfirmation
+        }
+
+        func reload(path: String?) async throws {
+            calls.append(.reload(path))
+            loaded = path
+        }
+
+        func setScale(_ scale: Float) async throws {
+            calls.append(.setScale(scale))
+        }
+
+        func infer(_ example: DaemonEvalExample) async throws -> DaemonABInference {
+            calls.append(.infer(example.id))
+            if let id = throwOnInferExampleId, id == example.id {
+                throw DaemonABEvaluatorError.evalSuiteUnavailable("forced infer failure")
+            }
+            let onCandidate = loaded == candidatePath
+            let text = onCandidate ? (candidateText[example.id] ?? "") : (baselineText[example.id] ?? "")
+            let calls = onCandidate
+                ? (candidateToolCalls[example.id] ?? [])
+                : (baselineToolCalls[example.id] ?? [])
+            return DaemonABInference(text: text, toolCalls: calls)
+        }
+
+        func loadedAdapterPath() async throws -> String? {
+            calls.append(.status)
+            return breakRestoreConfirmation ? nil : loaded
+        }
+
+        var recordedCalls: [Call] { calls }
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempStore() async throws -> ImprovementStore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-dab-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = ImprovementStore()
+        try await store.open(at: dir.appendingPathComponent("improvement.db"))
+        return store
+    }
+
+    private func makeGgufCandidate() throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-gguf-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("personal.gguf").path
+        try "gguf-bytes".write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    /// The real bundled suite (SHA-locked) — proves the production resource loads.
+    private func loadRealSuite() throws -> DaemonEvalSuite {
+        try DaemonEvalSuite.loadBundled()
+    }
+
+    /// Build canned answers so the CANDIDATE scores 100% on every example and the
+    /// BASELINE scores 0%, yielding a clean measured improvement on all four dims.
+    private func perfectCandidateZeroBaseline(
+        suite: DaemonEvalSuite
+    ) -> (text: [String: String], tools: [String: [DaemonABInference.ToolCallSummary]]) {
+        var text: [String: String] = [:]
+        var tools: [String: [DaemonABInference.ToolCallSummary]] = [:]
+        for ex in suite.examples {
+            switch ex.scoring.type {
+            case "expectToolCall":
+                tools[ex.id] = [.init(name: ex.scoring.name ?? "", argKeys: ex.scoring.requiredArgs ?? [])]
+                text[ex.id] = ""
+            case "expectNoToolCall":
+                text[ex.id] = "Sure, happy to help."
+            case "expectLinesPrefixed":
+                text[ex.id] = "\(ex.scoring.prefix ?? "STORE:") key = value"
+            case "expectJSONKeys":
+                let obj = Dictionary(uniqueKeysWithValues: (ex.scoring.keys ?? []).map { ($0, "x") })
+                text[ex.id] = (try? String(
+                    data: JSONSerialization.data(withJSONObject: obj), encoding: .utf8)) ?? "{}"
+            case "expectJSONArray":
+                text[ex.id] = "[\"red\",\"yellow\",\"blue\"]"
+            case "expectKeywords":
+                text[ex.id] = (ex.scoring.anyOf?.first) ?? "ok"
+            case "expectNonEmpty":
+                text[ex.id] = "Here is a reply."
+            default:
+                text[ex.id] = ""
+            }
+        }
+        return (text, tools)
+    }
+
+    // MARK: - Deterministic scorers (offline)
+
+    func testScorerExpectToolCall() {
+        let scoring = DaemonEvalExample.Scoring(
+            type: "expectToolCall", name: "get_weather", requiredArgs: ["location"],
+            prefix: nil, minLines: nil, keys: nil, minCount: nil, anyOf: nil, forbidden: nil)
+        let hit = DaemonABInference(text: "", toolCalls: [.init(name: "get_weather", argKeys: ["location"])])
+        let wrongName = DaemonABInference(text: "", toolCalls: [.init(name: "set_timer", argKeys: ["seconds"])])
+        let missingArg = DaemonABInference(text: "", toolCalls: [.init(name: "get_weather", argKeys: [])])
+        XCTAssertTrue(DaemonEvalScorer.isCorrect(hit, scoring: scoring))
+        XCTAssertFalse(DaemonEvalScorer.isCorrect(wrongName, scoring: scoring))
+        XCTAssertFalse(DaemonEvalScorer.isCorrect(missingArg, scoring: scoring),
+                       "Missing a required arg key ⇒ not a correct tool call")
+    }
+
+    func testScorerExpectNoToolCall() {
+        let scoring = DaemonEvalExample.Scoring(
+            type: "expectNoToolCall", name: nil, requiredArgs: nil, prefix: nil,
+            minLines: nil, keys: nil, minCount: nil, anyOf: nil, forbidden: nil)
+        let answered = DaemonABInference(text: "My favourite colour is teal.", toolCalls: [])
+        let calledTool = DaemonABInference(text: "", toolCalls: [.init(name: "get_weather", argKeys: ["location"])])
+        let empty = DaemonABInference(text: "", toolCalls: [])
+        XCTAssertTrue(DaemonEvalScorer.isCorrect(answered, scoring: scoring))
+        XCTAssertFalse(DaemonEvalScorer.isCorrect(calledTool, scoring: scoring),
+                       "Calling a tool when none should be ⇒ wrong")
+        XCTAssertFalse(DaemonEvalScorer.isCorrect(empty, scoring: scoring),
+                       "Empty answer with no tool ⇒ not a correct refusal")
+    }
+
+    func testScorerExpectLinesPrefixed() {
+        let scoring = DaemonEvalExample.Scoring(
+            type: "expectLinesPrefixed", name: nil, requiredArgs: nil, prefix: "STORE:",
+            minLines: 1, keys: nil, minCount: nil, anyOf: nil, forbidden: nil)
+        let ok = DaemonABInference(text: "STORE: name = Ada\nSTORE: born = 1815", toolCalls: [])
+        let prose = DaemonABInference(text: "Ada Lovelace was born in 1815.", toolCalls: [])
+        XCTAssertTrue(DaemonEvalScorer.isCorrect(ok, scoring: scoring))
+        XCTAssertFalse(DaemonEvalScorer.isCorrect(prose, scoring: scoring))
+    }
+
+    func testScorerExpectJSONKeysAndArray() {
+        let keysScoring = DaemonEvalExample.Scoring(
+            type: "expectJSONKeys", name: nil, requiredArgs: nil, prefix: nil, minLines: nil,
+            keys: ["name", "age"], minCount: nil, anyOf: nil, forbidden: nil)
+        let okObj = DaemonABInference(text: "Here: {\"name\":\"Mira\",\"age\":34}", toolCalls: [])
+        let badObj = DaemonABInference(text: "{\"name\":\"Mira\"}", toolCalls: [])
+        XCTAssertTrue(DaemonEvalScorer.isCorrect(okObj, scoring: keysScoring),
+                      "Embedded JSON object with all keys is extracted + accepted")
+        XCTAssertFalse(DaemonEvalScorer.isCorrect(badObj, scoring: keysScoring))
+
+        let arrScoring = DaemonEvalExample.Scoring(
+            type: "expectJSONArray", name: nil, requiredArgs: nil, prefix: nil, minLines: nil,
+            keys: nil, minCount: 3, anyOf: nil, forbidden: nil)
+        let okArr = DaemonABInference(text: "[\"red\",\"yellow\",\"blue\"]", toolCalls: [])
+        let shortArr = DaemonABInference(text: "[\"red\",\"blue\"]", toolCalls: [])
+        XCTAssertTrue(DaemonEvalScorer.isCorrect(okArr, scoring: arrScoring))
+        XCTAssertFalse(DaemonEvalScorer.isCorrect(shortArr, scoring: arrScoring))
+    }
+
+    func testScorerExpectKeywordsWithForbidden() {
+        let scoring = DaemonEvalExample.Scoring(
+            type: "expectKeywords", name: nil, requiredArgs: nil, prefix: nil, minLines: nil,
+            keys: nil, minCount: nil, anyOf: ["tokyo"], forbidden: ["as an ai"])
+        let right = DaemonABInference(text: "The capital is Tokyo.", toolCalls: [])
+        let forbidden = DaemonABInference(text: "As an AI, the capital is Tokyo.", toolCalls: [])
+        let wrong = DaemonABInference(text: "The capital is Kyoto.", toolCalls: [])
+        XCTAssertTrue(DaemonEvalScorer.isCorrect(right, scoring: scoring))
+        XCTAssertFalse(DaemonEvalScorer.isCorrect(forbidden, scoring: scoring),
+                       "A forbidden phrase fails the example even with the right keyword")
+        XCTAssertFalse(DaemonEvalScorer.isCorrect(wrong, scoring: scoring))
+    }
+
+    func testAccuracyAndDeltaMath() {
+        let acc = DaemonEvalScorer.accuracyByDimension(results: [
+            (.toolCalling, true), (.toolCalling, false),   // 0.5
+            (.faeCapability, true), (.faeCapability, true), // 1.0
+        ])
+        XCTAssertEqual(try XCTUnwrap(acc[.toolCalling]), 0.5, accuracy: 1e-9)
+        XCTAssertEqual(try XCTUnwrap(acc[.faeCapability]), 1.0, accuracy: 1e-9)
+
+        let delta = DaemonABEvaluator.deltaPercentagePoints(
+            baseline: [.toolCalling: 0.5, .faeCapability: 0.5, .assistantFit: 0.5, .serialization: 0.5],
+            candidate: [.toolCalling: 1.0, .faeCapability: 0.5, .assistantFit: 0.5, .serialization: 0.5])
+        XCTAssertEqual(try XCTUnwrap(delta.toolCallingDelta), 50.0, accuracy: 1e-9,
+                       "Candidate − baseline in PERCENTAGE POINTS")
+        XCTAssertEqual(try XCTUnwrap(delta.faeCapabilityDelta), 0.0, accuracy: 1e-9)
+    }
+
+    func testIncompleteCoverageYieldsNilDelta() {
+        // A dimension missing from EITHER side ⇒ nil delta ⇒ W1 gate blocks (incomplete).
+        let delta = DaemonABEvaluator.deltaPercentagePoints(
+            baseline: [.toolCalling: 0.5],
+            candidate: [.toolCalling: 1.0])
+        XCTAssertEqual(try XCTUnwrap(delta.toolCallingDelta), 50.0, accuracy: 1e-9)
+        XCTAssertNil(delta.faeCapabilityDelta)
+        XCTAssertEqual(AdapterGate.decide(delta.measuredDeltas), .blockedNoMeasurement)
+    }
+
+    // MARK: - Eval-suite loading (SHA lock + coverage)
+
+    func testBundledSuiteLoadsAndCoversAllDimensions() throws {
+        let suite = try loadRealSuite()
+        XCTAssertEqual(suite.suiteVersion, "daemon-ab-v1")
+        let covered = Set(suite.examples.compactMap { $0.gateDimension })
+        XCTAssertEqual(covered, Set(GateDimension.allCases),
+                       "The held-out suite must cover every gate dimension")
+    }
+
+    func testSuiteShaMismatchFailsClosed() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("fae-suite-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("suite.json")
+        try "{\"suiteVersion\":\"x\",\"examples\":[]}".write(to: url, atomically: true, encoding: .utf8)
+        // Lock expects a different SHA ⇒ load must throw, never silently accept drift.
+        XCTAssertThrowsError(try DaemonEvalSuite.load(contentsOf: url, expectedSHA256: String(repeating: "0", count: 64))) { error in
+            guard case DaemonABEvaluatorError.evalSuiteUnavailable = error else {
+                return XCTFail("Expected evalSuiteUnavailable, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - A/B orchestration sequence
+
+    /// Baseline MUST be reloaded first (the DEPLOYED adapter), then the candidate,
+    /// then the deployed adapter restored — proving reload-per-phase, not scale-toggle.
+    func testABReloadsDeployedThenCandidateThenRestores() async throws {
+        let suite = try loadRealSuite()
+        let candidate = try makeGgufCandidate()
+        let canned = perfectCandidateZeroBaseline(suite: suite)
+        let client = FakeDaemonABClient(
+            candidatePath: candidate,
+            candidateText: canned.text, candidateToolCalls: canned.tools)
+        let evaluator = DaemonABEvaluator(client: client, suite: suite)
+
+        let outcome = try await evaluator.evaluate(candidatePath: candidate, baselinePath: "/deployed/adapter.gguf")
+
+        let calls = await client.recordedCalls
+        let reloads = calls.compactMap { call -> String?? in
+            if case .reload(let p) = call { return .some(p) }
+            return nil
+        }
+        XCTAssertEqual(reloads.first, .some("/deployed/adapter.gguf"),
+                       "Phase 1 reloads the DEPLOYED adapter as baseline (NOT scale-0)")
+        XCTAssertTrue(reloads.contains(.some(candidate)), "Phase 2 reloads the candidate")
+        XCTAssertEqual(reloads.last, .some("/deployed/adapter.gguf"),
+                       "Final reload restores the deployed adapter")
+        // Candidate beat baseline on every dimension ⇒ a measured pass.
+        XCTAssertEqual(AdapterGate.decide(outcome.delta.measuredDeltas), .pass)
+        XCTAssertEqual(outcome.baseModelId, "/deployed/adapter.gguf")
+        XCTAssertEqual(outcome.evalSuiteVersion, "daemon-ab-v1")
+    }
+
+    /// With nothing deployed the baseline is the base model (`reload(nil)`); restore
+    /// drops back to base via scale-0 + reload(nil).
+    func testABBaselineIsBaseModelWhenNoneDeployed() async throws {
+        let suite = try loadRealSuite()
+        let candidate = try makeGgufCandidate()
+        let canned = perfectCandidateZeroBaseline(suite: suite)
+        let client = FakeDaemonABClient(
+            candidatePath: candidate, candidateText: canned.text, candidateToolCalls: canned.tools)
+        let evaluator = DaemonABEvaluator(client: client, suite: suite)
+
+        let outcome = try await evaluator.evaluate(candidatePath: candidate, baselinePath: nil)
+
+        let calls = await client.recordedCalls
+        if case .reload(let first)? = calls.first {
+            XCTAssertNil(first, "No deployed adapter ⇒ baseline is the base model (reload nil)")
+        } else {
+            XCTFail("First call must be a reload")
+        }
+        XCTAssertTrue(calls.contains(.setScale(0.0)), "Restore to base drops the scale to 0")
+        XCTAssertEqual(calls.last, .status, "Restore is confirmed via runtime.status")
+        XCTAssertEqual(outcome.baseModelId, "daemon-base-model")
+    }
+
+    // MARK: - Restore-on-every-exit (SAFETY property)
+
+    /// An infer failure mid-A/B is fail-closed (throws measurementFailed) AND still
+    /// restores the deployed adapter — the daemon is never left on the candidate.
+    func testInferFailureRestoresDeployedAndFailsClosed() async throws {
+        let suite = try loadRealSuite()
+        let candidate = try makeGgufCandidate()
+        // Throw on the FIRST example so the failure happens while the candidate (or
+        // baseline) is loaded, before the natural restore.
+        let firstId = suite.examples[0].id
+        let client = FakeDaemonABClient(
+            candidatePath: candidate, throwOnInferExampleId: firstId)
+        let evaluator = DaemonABEvaluator(client: client, suite: suite)
+
+        do {
+            _ = try await evaluator.evaluate(candidatePath: candidate, baselinePath: "/deployed/adapter.gguf")
+            XCTFail("A mid-A/B infer failure must throw")
+        } catch let error as AdapterEvaluatorError {
+            guard case .measurementFailed = error else {
+                return XCTFail("Expected measurementFailed, got \(error)")
+            }
+        }
+
+        let calls = await client.recordedCalls
+        let reloads = calls.compactMap { call -> String?? in
+            if case .reload(let p) = call { return .some(p) }
+            return nil
+        }
+        XCTAssertEqual(reloads.last, .some("/deployed/adapter.gguf"),
+                       "Even on the failure path the deployed adapter is restored last")
+    }
+
+    /// If restore cannot be CONFIRMED (status disagrees with what we reloaded), the
+    /// evaluator fails closed loudly — a daemon possibly left on the candidate must
+    /// never read as a clean measurement.
+    func testUnconfirmedRestoreFailsClosed() async throws {
+        let suite = try loadRealSuite()
+        let candidate = try makeGgufCandidate()
+        let canned = perfectCandidateZeroBaseline(suite: suite)
+        let client = FakeDaemonABClient(
+            candidatePath: candidate, candidateText: canned.text, candidateToolCalls: canned.tools,
+            breakRestoreConfirmation: true)
+        let evaluator = DaemonABEvaluator(client: client, suite: suite)
+
+        do {
+            _ = try await evaluator.evaluate(candidatePath: candidate, baselinePath: "/deployed/adapter.gguf")
+            XCTFail("An unconfirmed restore must fail closed")
+        } catch let error as AdapterEvaluatorError {
+            guard case .measurementFailed(let why) = error else {
+                return XCTFail("Expected measurementFailed, got \(error)")
+            }
+            XCTAssertTrue(why.contains("restore"), "Failure names the restore problem: \(why)")
+        }
+    }
+
+    /// A measured regression on a dimension does NOT pass the gate (the A/B math +
+    /// gate rule agree): candidate worse than baseline ⇒ concern/fail, never pass.
+    func testRegressionDoesNotPass() async throws {
+        let suite = try loadRealSuite()
+        let candidate = try makeGgufCandidate()
+        // Baseline scores 100% everywhere; candidate scores 0% ⇒ −100pt regression.
+        let perfect = perfectCandidateZeroBaseline(suite: suite)
+        let client = FakeDaemonABClient(
+            candidatePath: candidate,
+            candidateText: [:], candidateToolCalls: [:],     // candidate answers wrong
+            baselineText: perfect.text, baselineToolCalls: perfect.tools) // baseline perfect
+        let evaluator = DaemonABEvaluator(client: client, suite: suite)
+
+        let outcome = try await evaluator.evaluate(candidatePath: candidate, baselinePath: "/deployed/adapter.gguf")
+        XCTAssertEqual(AdapterGate.decide(outcome.delta.measuredDeltas), .fail,
+                       "A large regression vs the deployed adapter must fail the gate")
+    }
+
+    // MARK: - End-to-end: gguf receipt mints + deploys through the REAL gate
+
+    /// The full W7b path: a real `DaemonABEvaluator` (fake client, perfect candidate)
+    /// drives the coordinator's REAL `evaluateViaAdapterEvaluator` → `mintAndStoreGateReceipt`,
+    /// and the minted `.gguf` receipt deploys end to end through the W4 gate's REAL
+    /// `GateReceiptVerifier`. Proves W7b un-blocks gated GGUF deploys (and only such).
+    func testGgufEvaluatorMintedReceiptDeploysThroughRealGate() async throws {
+        let store = try await makeTempStore()
+        let suite = try loadRealSuite()
+        let candidate = try makeGgufCandidate()   // a real on-disk gguf so the digest verifies
+
+        try await store.ensureStateRow()
+        var state = try await store.readState()
+        state.currentAdapterPath = "/deployed/adapter.gguf"  // the live baseline
+        state.pendingAdapterPath = candidate
+        state.pendingAdapterKind = "gguf"
+        state.pendingCycleId = "w7b-cyc"
+        try await store.writeState(state)
+
+        let canned = perfectCandidateZeroBaseline(suite: suite)
+        let client = FakeDaemonABClient(
+            candidatePath: candidate, candidateText: canned.text, candidateToolCalls: canned.tools)
+        let evaluator = DaemonABEvaluator(client: client, suite: suite)
+
+        var patchedPath: String? = "not-called"
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setAdapterEvaluator(evaluator)
+        await coordinator.setAdapterPatchCallback { path in patchedPath = path }
+        await coordinator.setInjectedGateKey(gateTestKey)
+        await coordinator.setDaemonTrainingBaseModel("gemma-test")  // gguf lane ⇒ deploy expects .gguf
+
+        // Drive the REAL eval phase + mint (exactly what the cycle runs).
+        let result = await coordinator.evaluateViaAdapterEvaluator(adapterPath: candidate, kind: .gguf)
+        XCTAssertEqual(AdapterGate.decide(result.delta.measuredDeltas), .pass, "Perfect candidate passes")
+        let mint = try XCTUnwrap(result.mint, "A measured pass carries receipt provenance")
+        XCTAssertEqual(mint.evaluatorId, "DaemonABEvaluator")
+        XCTAssertEqual(mint.kind, .gguf)
+        try await coordinator.mintAndStoreGateReceipt(context: mint, measured: result.delta.measuredDeltas)
+
+        // Walk to proposing, approve — performDeploy verifies through the REAL gate.
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+        try await coordinator.approveDeployment()
+
+        let deployed = try await store.readState()
+        XCTAssertEqual(deployed.currentAdapterPath, candidate, "gguf candidate promoted through the real gate")
+        XCTAssertEqual(deployed.previousAdapterPath, "/deployed/adapter.gguf", "Prior deployed is the rollback target")
+        XCTAssertNil(deployed.pendingAdapterPath, "Pending cleared after deploy")
+        XCTAssertEqual(patchedPath, candidate, "Pipeline notified of the deployed gguf adapter")
+        let consumed = try await store.isGateReceiptConsumed(cycleId: "w7b-cyc")
+        XCTAssertTrue(consumed, "Evaluator-minted gguf receipt consumed exactly once on deploy")
+    }
+}

--- a/native/macos/Fae/Tests/HandoffTests/ExternalReviewGateTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/ExternalReviewGateTests.swift
@@ -40,13 +40,15 @@ final class ExternalReviewGateTests: XCTestCase {
         XCTAssertEqual(result.verdict, .pass)
     }
 
-    func testInternalReviewPassesWhenNeutral() async throws {
+    func testInternalReviewBlocksWhenNeutralNoImprovement() async throws {
+        // P9/C4 (W1): an all-flat (all-zero) measured result is indistinguishable
+        // from a non-measurement and must NOT certify a deploy. Fail-closed.
         let gate = makeGate()
         let result = try await gate.review(
             evalDelta: makeEvalDelta(toolCalling: 0.0, faeCapability: 0.0, assistantFit: 0.0, serialization: 0.0),
             currentDeferralCount: 0
         )
-        XCTAssertEqual(result.verdict, .pass, "Zero delta = stable = PASS")
+        XCTAssertEqual(result.verdict, .fail, "Zero delta = no measured improvement = fail-closed")
     }
 
     func testInternalReviewConcernForMinorRegression() async throws {
@@ -67,14 +69,15 @@ final class ExternalReviewGateTests: XCTestCase {
         XCTAssertEqual(result.verdict, .fail, "Regression > 5% should yield FAIL")
     }
 
-    func testInternalReviewHandlesNilMetrics() async throws {
+    func testInternalReviewFailsWhenNoMetricsMeasured() async throws {
+        // P9/C4 (W1): all-nil deltas mean nothing was measured. The previous
+        // behaviour folded nils into zero and PASSED — the F1 crack. Fail-closed now.
         let gate = makeGate()
-        // All deltas nil → treated as 0 → PASS.
         let result = try await gate.review(
             evalDelta: makeEvalDelta(toolCalling: nil, faeCapability: nil, assistantFit: nil, serialization: nil),
             currentDeferralCount: 0
         )
-        XCTAssertEqual(result.verdict, .pass, "Nil metrics → no regression → PASS")
+        XCTAssertEqual(result.verdict, .fail, "Nil metrics → nothing measured → fail-closed")
     }
 
     // MARK: - Deferral Counting
@@ -276,7 +279,8 @@ final class ExternalReviewGateTests: XCTestCase {
 
     // MARK: - EvalDelta
 
-    func testEvalDeltaAllNilNoRegression() async throws {
+    func testEvalDeltaAllNilFailsClosed() async throws {
+        // P9/C4 (W1): all-nil = nothing measured ⇒ fail-closed (was the F1 crack).
         let gate = makeGate()
         let delta = EvalDelta(
             toolCallingDelta: nil, faeCapabilityDelta: nil,
@@ -284,7 +288,7 @@ final class ExternalReviewGateTests: XCTestCase {
             throughputDelta: nil
         )
         let result = try await gate.review(evalDelta: delta, currentDeferralCount: 0)
-        XCTAssertEqual(result.verdict, .pass)
+        XCTAssertEqual(result.verdict, .fail)
     }
 
     func testEvalDeltaExactly5PercentRegressionIsConcernNotFail() async throws {

--- a/native/macos/Fae/Tests/HandoffTests/GateGoldenWiringTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/GateGoldenWiringTests.swift
@@ -1,0 +1,577 @@
+import CryptoKit
+import XCTest
+@testable import Fae
+
+/// P9/C4 W8 — golden production-wiring + adversarial gate tests.
+///
+/// These close the Definition-of-Done for the "training-seam + mandatory eval gate"
+/// series. The unsafe hole the series shuts: the nightly self-improvement loop could
+/// promote a freshly trained LoRA adapter into the live `currentAdapterPath` with NO
+/// real evaluation. W1–W7 made a deploy require a *verifying, unconsumed, tamper-evident*
+/// `GateReceipt` minted by a real `AdapterEvaluator`.
+///
+/// The master invariant these tests defend:
+/// **no path writes `currentAdapterPath` without a verifying, unconsumed receipt.**
+///
+/// Tests are written to fail the moment someone re-opens the un-gated path — each one
+/// encodes WHY the behaviour matters, not merely WHAT it does (Rule 9).
+final class GateGoldenWiringTests: XCTestCase {
+
+    // MARK: - Shared helpers
+
+    /// Fixed HMAC key so mint + verify run without Keychain access (matches the
+    /// `gateTestKey` used across the suite). Production uses a per-install Keychain key.
+    private let gateTestKey = SymmetricKey(data: Data(repeating: 0x42, count: 32))
+
+    private func makeTempStore() async throws -> ImprovementStore {
+        let store = ImprovementStore()
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gate_golden_\(UUID().uuidString).db")
+        try await store.open(at: url)
+        try await store.ensureStateRow()
+        return store
+    }
+
+    /// A real on-disk mlxDir candidate (directory + weights file) so the artifact
+    /// digest can be recomputed at the deploy boundary.
+    private func makeMlxCandidate() throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gate-cand-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "weights-v1".write(
+            toFile: dir.appendingPathComponent("adapters.safetensors").path,
+            atomically: true, encoding: .utf8
+        )
+        return dir.path
+    }
+
+    /// Seed enough feedback events to clear the cycle-start thresholds (≥20 events, ≥5
+    /// corrections) so `runCycle()` proceeds past the data gate.
+    private func seedSufficientData(store: ImprovementStore) async throws {
+        for i in 0..<15 {
+            _ = try await store.appendFeedbackEvent(FeedbackEvent(
+                id: nil, recordedAt: ISO8601DateFormatter().string(from: Date()),
+                signalType: "correction", turnFingerprint: "corr-\(UUID().uuidString)-\(i)",
+                userInput: "u", assistantOutput: "a", sentimentScore: nil, consumed: false
+            ))
+        }
+        for i in 0..<10 {
+            _ = try await store.appendFeedbackEvent(FeedbackEvent(
+                id: nil, recordedAt: ISO8601DateFormatter().string(from: Date()),
+                signalType: "re_ask", turnFingerprint: "reask-\(UUID().uuidString)-\(i)",
+                userInput: "u", assistantOutput: "a", sentimentScore: nil, consumed: false
+            ))
+        }
+    }
+
+    // MARK: - Golden production-wiring E2E (T-golden — F15, F16, F20; exercises F1–F4)
+
+    /// GOLDEN (a): with NO evaluator registered for the trained lane, a full cycle must
+    /// fail closed BEFORE external review. WHY: the external review providers must never
+    /// get the chance to PASS an un-evaluated candidate — if they did, an adapter with no
+    /// measured improvement could deploy. The review-spy (the gate's own audit closure,
+    /// the same seam production wires to `SecurityEventLogger`) proves `review()` was
+    /// never entered, and `currentAdapterPath` proves nothing was promoted.
+    func testGoldenProductionWiring_noEvaluator_blocksBeforeReviewAndNeverDeploys() async throws {
+        let store = try await makeTempStore()
+
+        // A live baseline that must remain untouched.
+        var seed = try await store.readState()
+        seed.currentAdapterPath = "/tmp/live_deployed_adapter"
+        try await store.writeState(seed)
+
+        // Real review gate + a review SPY: production logs every completed review via the
+        // security-log closure (`logResult`). If the closure never fires, `review()` was
+        // never reached. A delegate runner that would PASS is also installed so a leak
+        // would be loud (it would flip both flags and try to deploy).
+        let gate = ExternalReviewGate()
+        var reviewCallCount = 0
+        await gate.setSecurityLogClosure { event, _, _, _, _, _ in
+            // Production logs EVERY completed review via this closure (`logResult` ⇒
+            // "external_review_gate"). Counting it is how we prove review was reached.
+            if event == "external_review_gate" { reviewCallCount += 1 }
+        }
+        var delegateConsulted = false
+        await gate.setDelegateAgentRunner { _ in
+            delegateConsulted = true
+            return "PASS: looks great."
+        }
+
+        let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
+        // No `setAdapterEvaluator` / no `setInjectedMeasuredDelta`: the real eval phase has
+        // no measurement source ⇒ `.unmeasured` ⇒ `candidate_blocked`.
+        try await seedSufficientData(store: store)
+
+        try await coordinator.runCycle()
+
+        let finalState = try await coordinator.currentState()
+        XCTAssertEqual(finalState, .idle, "An un-evaluated candidate must end at idle, never proposing")
+        let persisted = try await store.readState()
+        XCTAssertEqual(
+            persisted.currentAdapterPath, "/tmp/live_deployed_adapter",
+            "The live adapter must be untouched when nothing was measured"
+        )
+        XCTAssertNil(persisted.pendingAdapterPath, "Blocked cycle clears the pending candidate")
+        XCTAssertEqual(
+            persisted.lastCycleError, "candidate_blocked: no_measured_improvement",
+            "The block must be audited as a no-measurement block"
+        )
+        XCTAssertEqual(reviewCallCount, 0, "External review must NOT be consulted for an un-evaluated candidate")
+        XCTAssertFalse(delegateConsulted, "The review provider must never run when there is no measurement")
+        // No receipt may exist for a cycle that never measured anything.
+        let consumed = try? await store.isGateReceiptConsumed(cycleId: "cyc-golden-a")
+        XCTAssertNotEqual(consumed, true)
+    }
+
+    /// GOLDEN (b): with a REAL evaluator registered the same way `FaeScheduler` does
+    /// (`setAdapterEvaluator`), a measured PASS mints a verifying receipt, and approving
+    /// the proposal promotes the candidate to `currentAdapterPath` AND consumes the
+    /// receipt exactly once. WHY: this is the only path that may write the live path, and
+    /// it must go end-to-end through the real mint → real `GateReceiptVerifier` →
+    /// atomic promote-and-consume (no bypass, no manual receipt insertion).
+    func testGoldenProductionWiring_realEvaluatorPass_deploysAndConsumesReceipt() async throws {
+        let store = try await makeTempStore()
+        let candidate = try makeMlxCandidate()
+
+        // Stage the pending candidate exactly as the training step (W3) would.
+        var state = try await store.readState()
+        state.currentAdapterPath = "/tmp/deployed_before"  // the rollback target
+        state.pendingAdapterPath = candidate
+        state.pendingAdapterKind = "mlxDir"
+        state.pendingCycleId = "cyc-golden-b"
+        try await store.writeState(state)
+
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setInjectedGateKey(gateTestKey)
+        var patchedPath: String? = "<unset>"
+        await coordinator.setAdapterPatchCallback { p in patchedPath = p }
+
+        // Register a real `AdapterEvaluator` (mlxDir lane) that measures a clean PASS —
+        // the SAME registration API FaeScheduler uses at runtime.
+        let evaluator = StubMlxEvaluator(
+            outcome: GateOutcome(
+                delta: EvalDelta(
+                    toolCallingDelta: 3.0, faeCapabilityDelta: 2.0,
+                    assistantFitDelta: 1.0, serializationDelta: 1.0, throughputDelta: 4.0
+                ),
+                baseModelId: "/tmp/deployed_before",
+                evalSuiteVersion: "faebench-v1"
+            )
+        )
+        await coordinator.setAdapterEvaluator(evaluator)
+
+        // Drive the production eval → mint chain on the staged candidate (this is exactly
+        // what `runCycle`'s eval phase does internally via `evaluateViaAdapterEvaluator`).
+        let evaluated = await coordinator.evaluateViaAdapterEvaluator(adapterPath: candidate, kind: .mlxDir)
+        XCTAssertEqual(
+            AdapterGate.decide(evaluated.delta.measuredDeltas), .pass,
+            "A measured improvement with no regression must pass the gate"
+        )
+        let mint = try XCTUnwrap(evaluated.mint, "A real evaluator must carry receipt-mint provenance on a pass")
+        XCTAssertEqual(mint.evaluatorId, "FaeBenchmarkEvaluator", "Receipt is stamped with the allowlisted evaluator id")
+        try await coordinator.mintAndStoreGateReceipt(context: mint, measured: evaluated.delta.measuredDeltas)
+
+        // Walk to proposing, then approve — `performDeploy` verifies through the REAL
+        // `GateReceiptVerifier` and promotes + consumes atomically.
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+        try await coordinator.approveDeployment()
+
+        let deployed = try await store.readState()
+        XCTAssertEqual(deployed.currentAdapterPath, candidate, "The measured-PASS candidate is promoted to live")
+        XCTAssertEqual(deployed.previousAdapterPath, "/tmp/deployed_before", "Prior live adapter becomes the rollback target")
+        XCTAssertNil(deployed.pendingAdapterPath, "Pending candidate cleared after deploy")
+        XCTAssertEqual(patchedPath, candidate, "Pipeline is notified of the deployed adapter")
+        let consumed = try await store.isGateReceiptConsumed(cycleId: "cyc-golden-b")
+        XCTAssertTrue(consumed, "The receipt is consumed exactly once on deploy (single-use)")
+    }
+
+    // MARK: - Tamper (T-tamper — F9), coordinator-level
+
+    /// The candidate artifact is mutated AFTER the receipt is minted, so the on-disk digest
+    /// no longer matches what the receipt attests. `performDeploy` must refuse and leave the
+    /// live path untouched. WHY: the receipt is a promise about a SPECIFIC artifact; trusting
+    /// a mismatched artifact would re-open the un-gated-deploy hole (deploy something the
+    /// evaluator never scored).
+    func testTamperedCandidateAfterMintIsRejectedAtDeploy() async throws {
+        let store = try await makeTempStore()
+        let candidate = try makeMlxCandidate()
+
+        var state = try await store.readState()
+        state.currentAdapterPath = "/tmp/live_before_tamper"
+        state.pendingAdapterPath = candidate
+        state.pendingAdapterKind = "mlxDir"
+        state.pendingCycleId = "cyc-tamper"
+        try await store.writeState(state)
+
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setInjectedGateKey(gateTestKey)
+        try await coordinator.mintAndStoreGateReceipt(
+            context: ImprovementCycleCoordinator.ReceiptMintContext(
+                kind: .mlxDir, evaluatorId: "FaeBenchmarkEvaluator",
+                baseModelId: "/tmp/live_before_tamper", evalSuiteVersion: "faebench-v1"
+            ),
+            measured: MeasuredDeltas(
+                measured: [.toolCalling: 2.0, .faeCapability: 1.0, .assistantFit: 1.0, .serialization: 1.0],
+                throughputDelta: nil
+            )
+        )
+
+        // TAMPER: change the candidate's bytes after the receipt was minted.
+        try "weights-TAMPERED".write(
+            toFile: URL(fileURLWithPath: candidate).appendingPathComponent("adapters.safetensors").path,
+            atomically: true, encoding: .utf8
+        )
+
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+        await XCTAssertThrowsErrorAsync(
+            try await coordinator.approveDeployment(),
+            "A tampered artifact must not deploy"
+        ) { error in
+            guard case ImprovementCycleError.gateReceiptRejected = error else {
+                return XCTFail("Expected gateReceiptRejected, got \(error)")
+            }
+        }
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.currentAdapterPath, "/tmp/live_before_tamper", "Tampered candidate must not reach the live path")
+        let consumed = try await store.isGateReceiptConsumed(cycleId: "cyc-tamper")
+        XCTAssertFalse(consumed, "A rejected deploy must not consume the receipt")
+    }
+
+    // MARK: - Forgery (T-forgery — F3)
+
+    /// A receipt persisted with a tampered HMAC (signed with the wrong key) can never
+    /// verify, so the deploy boundary rejects it. WHY: the HMAC is the tamper-evidence
+    /// binding evaluator-id + path + digest together; a forged signature must not be
+    /// honoured or any code could hand-craft a deployable receipt.
+    func testForgedReceiptHmacIsRejectedAtDeploy() async throws {
+        let store = try await makeTempStore()
+        let candidate = try makeMlxCandidate()
+
+        var state = try await store.readState()
+        state.currentAdapterPath = "/tmp/live_before_forgery"
+        state.pendingAdapterPath = candidate
+        state.pendingAdapterKind = "mlxDir"
+        state.pendingCycleId = "cyc-forge"
+        try await store.writeState(state)
+
+        // Mint with the WRONG key, then persist — the coordinator verifies with `gateTestKey`.
+        let wrongKey = SymmetricKey(data: Data(repeating: 0x99, count: 32))
+        let forged = try GateMinter.mint(
+            cycleId: "cyc-forge", candidatePath: candidate, kind: .mlxDir,
+            measured: [.toolCalling: 2.0, .faeCapability: 1.0, .assistantFit: 1.0, .serialization: 1.0],
+            evaluatorId: "FaeBenchmarkEvaluator", baseModelId: "/tmp/live_before_forgery",
+            evalSuiteVersion: "faebench-v1", mintedAt: "2026-06-22T00:00:00Z", using: wrongKey
+        )
+        try await store.insertGateReceipt(forged)
+
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setInjectedGateKey(gateTestKey)  // verifies with the RIGHT key ⇒ mismatch
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+        await XCTAssertThrowsErrorAsync(
+            try await coordinator.approveDeployment(),
+            "A forged-HMAC receipt must not deploy"
+        ) { error in
+            guard case ImprovementCycleError.gateReceiptRejected = error else {
+                return XCTFail("Expected gateReceiptRejected, got \(error)")
+            }
+        }
+        let after = try await store.readState()
+        XCTAssertEqual(after.currentAdapterPath, "/tmp/live_before_forgery", "Forged receipt must not touch the live path")
+    }
+
+    /// Minting with an evaluator id that is NOT on `GatePolicy.allowedEvaluators` throws —
+    /// the loss-proxy (or any future non-evaluator) can never forge a deployable receipt.
+    /// WHY: the allowlist is the privilege boundary; only the two real evaluators may
+    /// produce a receipt the verifier will honour.
+    func testReceiptFromNonAllowlistedEvaluatorCannotBeMinted() async throws {
+        let store = try await makeTempStore()
+        let candidate = try makeMlxCandidate()
+        var state = try await store.readState()
+        state.pendingAdapterPath = candidate
+        state.pendingAdapterKind = "mlxDir"
+        state.pendingCycleId = "cyc-allow"
+        try await store.writeState(state)
+
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setInjectedGateKey(gateTestKey)
+        await XCTAssertThrowsErrorAsync(
+            try await coordinator.mintAndStoreGateReceipt(
+                context: ImprovementCycleCoordinator.ReceiptMintContext(
+                    kind: .mlxDir, evaluatorId: "loss-proxy",  // NOT allowlisted
+                    baseModelId: "x", evalSuiteVersion: "v1"
+                ),
+                measured: MeasuredDeltas(
+                    measured: [.toolCalling: 1.0, .faeCapability: 1.0, .assistantFit: 1.0, .serialization: 1.0],
+                    throughputDelta: nil
+                )
+            ),
+            "A non-allowlisted evaluator must not be able to mint a receipt"
+        ) { error in
+            guard case GateReceiptError.evaluatorNotAllowed = error else {
+                return XCTFail("Expected evaluatorNotAllowed, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Replay (T-replay — F4, F13)
+
+    /// A receipt that has already authorized one successful deploy cannot authorize a
+    /// second. WHY: `promoteAndConsumeReceipt`'s `changesCount == 1` guard makes the
+    /// receipt single-use; a replay would deploy a stale candidate the evaluator scored
+    /// once and let the loop double-spend a single measurement.
+    func testConsumedReceiptCannotDeployAgain() async throws {
+        let store = try await makeTempStore()
+        let candidate = try makeMlxCandidate()
+
+        var state = try await store.readState()
+        state.currentAdapterPath = "/tmp/live_before_replay"
+        state.pendingAdapterPath = candidate
+        state.pendingAdapterKind = "mlxDir"
+        state.pendingCycleId = "cyc-replay"
+        try await store.writeState(state)
+
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setInjectedGateKey(gateTestKey)
+        try await coordinator.mintAndStoreGateReceipt(
+            context: ImprovementCycleCoordinator.ReceiptMintContext(
+                kind: .mlxDir, evaluatorId: "FaeBenchmarkEvaluator",
+                baseModelId: "/tmp/live_before_replay", evalSuiteVersion: "faebench-v1"
+            ),
+            measured: MeasuredDeltas(
+                measured: [.toolCalling: 2.0, .faeCapability: 1.0, .assistantFit: 1.0, .serialization: 1.0],
+                throughputDelta: nil
+            )
+        )
+
+        // First deploy succeeds and consumes the receipt.
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+        try await coordinator.approveDeployment()
+        let afterFirst = try await store.readState().currentAdapterPath
+        XCTAssertEqual(afterFirst, candidate, "First deploy promotes the candidate")
+        let firstConsumed = try await store.isGateReceiptConsumed(cycleId: "cyc-replay")
+        XCTAssertTrue(firstConsumed, "Receipt consumed by the first deploy")
+
+        // Replay: re-stage the SAME consumed receipt's cycle as pending and try to deploy again.
+        var replay = try await store.readState()
+        replay.pendingAdapterPath = candidate
+        replay.pendingAdapterKind = "mlxDir"
+        replay.pendingCycleId = "cyc-replay"
+        try await store.writeState(replay)
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+        await XCTAssertThrowsErrorAsync(
+            try await coordinator.approveDeployment(),
+            "A consumed receipt must not authorize a second deploy"
+        ) { error in
+            guard case ImprovementCycleError.gateReceiptRejected = error else {
+                return XCTFail("Expected gateReceiptRejected, got \(error)")
+            }
+        }
+    }
+
+    /// A receipt minted for cycle A cannot deploy cycle B's candidate. WHY: the receipt is
+    /// bound to a specific `cycleId`; if cycle B's pending candidate could be promoted with
+    /// A's receipt, an un-evaluated candidate would inherit a different candidate's evaluation.
+    func testReceiptBoundToCycleACannotDeployCycleB() async throws {
+        let store = try await makeTempStore()
+        let candidateA = try makeMlxCandidate()
+        let candidateB = try makeMlxCandidate()
+
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setInjectedGateKey(gateTestKey)
+
+        // Mint a receipt for cycle A's candidate (path A).
+        var state = try await store.readState()
+        state.pendingAdapterPath = candidateA
+        state.pendingAdapterKind = "mlxDir"
+        state.pendingCycleId = "cyc-A"
+        try await store.writeState(state)
+        try await coordinator.mintAndStoreGateReceipt(
+            context: ImprovementCycleCoordinator.ReceiptMintContext(
+                kind: .mlxDir, evaluatorId: "FaeBenchmarkEvaluator",
+                baseModelId: "base", evalSuiteVersion: "faebench-v1"
+            ),
+            measured: MeasuredDeltas(
+                measured: [.toolCalling: 2.0, .faeCapability: 1.0, .assistantFit: 1.0, .serialization: 1.0],
+                throughputDelta: nil
+            )
+        )
+
+        // Now the pending candidate is B's path but the cycle id still points at A's receipt.
+        // The receipt's candidatePath (A) cannot match the candidate being deployed (B).
+        var crossed = try await store.readState()
+        crossed.currentAdapterPath = "/tmp/live_before_cross"
+        crossed.pendingAdapterPath = candidateB
+        crossed.pendingAdapterKind = "mlxDir"
+        crossed.pendingCycleId = "cyc-A"  // A's receipt, B's candidate
+        try await store.writeState(crossed)
+
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+        await XCTAssertThrowsErrorAsync(
+            try await coordinator.approveDeployment(),
+            "A receipt bound to cycle A must not deploy cycle B's candidate"
+        ) { error in
+            guard case ImprovementCycleError.gateReceiptRejected = error else {
+                return XCTFail("Expected gateReceiptRejected, got \(error)")
+            }
+        }
+        let afterCross = try await store.readState().currentAdapterPath
+        XCTAssertEqual(
+            afterCross, "/tmp/live_before_cross",
+            "Cross-bound receipt must not touch the live path"
+        )
+    }
+
+    // MARK: - Gate rule truth table (T-unit-decide — F1, F2)
+
+    /// The fail-closed gate rule, exhaustively. WHY: every previously-deployable crack
+    /// lived here — all-nil (`compactMap`/`min() ?? 0.0` once passed it) and all-zero
+    /// (a synthetic "no regression" pass). The rule must treat both as
+    /// `.blockedNoMeasurement`, never a deploy.
+    func testGateDecideTruthTable() {
+        // Nothing measured at all ⇒ blocked.
+        XCTAssertEqual(
+            AdapterGate.decide(MeasuredDeltas(measured: [:], throughputDelta: nil)),
+            .blockedNoMeasurement,
+            "An empty measurement is indistinguishable from no eval and must block"
+        )
+        // Incomplete measurement (a dimension missing) ⇒ blocked.
+        XCTAssertEqual(
+            AdapterGate.decide(MeasuredDeltas(
+                measured: [.toolCalling: 5.0, .faeCapability: 5.0, .assistantFit: 5.0],
+                throughputDelta: nil
+            )),
+            .blockedNoMeasurement,
+            "A partial measurement means the evaluator malfunctioned and cannot certify a deploy"
+        )
+        // All dimensions flat (zero) ⇒ blocked (NOT pass): a measured all-zero is
+        // indistinguishable from a non-measurement.
+        XCTAssertEqual(
+            AdapterGate.decide(MeasuredDeltas(
+                measured: [.toolCalling: 0.0, .faeCapability: 0.0, .assistantFit: 0.0, .serialization: 0.0],
+                throughputDelta: nil
+            )),
+            .blockedNoMeasurement,
+            "An all-zero result must not auto-deploy — nothing improved"
+        )
+        // Any dimension regressed > 5% ⇒ fail.
+        XCTAssertEqual(
+            AdapterGate.decide(MeasuredDeltas(
+                measured: [.toolCalling: 3.0, .faeCapability: -6.0, .assistantFit: 1.0, .serialization: 1.0],
+                throughputDelta: nil
+            )),
+            .fail,
+            "A >5% regression is a hard fail"
+        )
+        // A small regression (≤5%) ⇒ concern.
+        XCTAssertEqual(
+            AdapterGate.decide(MeasuredDeltas(
+                measured: [.toolCalling: 3.0, .faeCapability: -2.0, .assistantFit: 1.0, .serialization: 1.0],
+                throughputDelta: nil
+            )),
+            .concern,
+            "A small regression warrants human deferral, not a silent pass"
+        )
+        // At least one improvement, no regression ⇒ pass.
+        XCTAssertEqual(
+            AdapterGate.decide(MeasuredDeltas(
+                measured: [.toolCalling: 3.0, .faeCapability: 0.0, .assistantFit: 0.0, .serialization: 0.0],
+                throughputDelta: nil
+            )),
+            .pass,
+            "One real improvement with no regression is the only thing that passes"
+        )
+        // Throughput is advisory only: a throughput gain with no correctness change blocks.
+        XCTAssertEqual(
+            AdapterGate.decide(MeasuredDeltas(
+                measured: [.toolCalling: 0.0, .faeCapability: 0.0, .assistantFit: 0.0, .serialization: 0.0],
+                throughputDelta: 50.0
+            )),
+            .blockedNoMeasurement,
+            "Throughput must never make an adapter deployable on its own"
+        )
+    }
+
+    // MARK: - Receipt write fails loud (T-receipt-write-fails-loud — F19)
+
+    /// A failure persisting the gate receipt must propagate — it must NOT be swallowed.
+    /// WHY: a passing eval that silently fails to persist its receipt would leave the deploy
+    /// boundary with no receipt to verify; the loop must fail closed loudly, not proceed.
+    /// Here the store is CLOSED before the mint, so `insertGateReceipt` throws `.notOpen`.
+    func testReceiptWriteFailsLoud() async throws {
+        let store = try await makeTempStore()
+        let candidate = try makeMlxCandidate()
+        var state = try await store.readState()
+        state.pendingAdapterPath = candidate
+        state.pendingAdapterKind = "mlxDir"
+        state.pendingCycleId = "cyc-writefail"
+        try await store.writeState(state)
+
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setInjectedGateKey(gateTestKey)
+
+        // Close the store so the persistence write fails.
+        await store.close()
+
+        await XCTAssertThrowsErrorAsync(
+            try await coordinator.mintAndStoreGateReceipt(
+                context: ImprovementCycleCoordinator.ReceiptMintContext(
+                    kind: .mlxDir, evaluatorId: "FaeBenchmarkEvaluator",
+                    baseModelId: "base", evalSuiteVersion: "faebench-v1"
+                ),
+                measured: MeasuredDeltas(
+                    measured: [.toolCalling: 2.0, .faeCapability: 1.0, .assistantFit: 1.0, .serialization: 1.0],
+                    throughputDelta: nil
+                )
+            ),
+            "A receipt-persistence failure must propagate, never be swallowed (Rule 12)"
+        ) { _ in
+            // Any thrown error satisfies "fails loud" — the point is it is NOT swallowed.
+        }
+    }
+}
+
+// MARK: - Test doubles
+
+/// A real `AdapterEvaluator` for the mlxDir lane that returns a fixed outcome. Registered
+/// via `setAdapterEvaluator` exactly like `FaeBenchmarkEvaluator` is in production, so the
+/// golden test exercises the genuine evaluator → mint path (not the test-only injected seam).
+/// `evaluatorId` is `FaeBenchmarkEvaluator` so the minted receipt is on the gate allowlist.
+private struct StubMlxEvaluator: AdapterEvaluator {
+    let outcome: GateOutcome
+    var kind: AdapterKind { .mlxDir }
+    var evaluatorId: String { "FaeBenchmarkEvaluator" }
+    func isAvailable() async -> Bool { true }
+    func evaluate(candidatePath: String, baselinePath: String?) async throws -> GateOutcome { outcome }
+}
+
+// MARK: - Async throwing assertion helper
+
+/// XCTAssertThrowsError has no async overload; this awaits the expression and routes the
+/// thrown error to the handler (or fails if nothing throws). No force-unwraps.
+func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ message: String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    _ errorHandler: (Error) -> Void = { _ in }
+) async {
+    do {
+        _ = try await expression()
+        XCTFail(message.isEmpty ? "Expected an error to be thrown" : message, file: file, line: line)
+    } catch {
+        errorHandler(error)
+    }
+}

--- a/native/macos/Fae/Tests/HandoffTests/GateReceiptTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/GateReceiptTests.swift
@@ -1,0 +1,222 @@
+import CryptoKit
+import XCTest
+@testable import Fae
+
+/// P9/C4 (W2) — gate receipt machinery: artifact digest, mint/verify (HMAC + allowlist),
+/// and persistence. Uses a fixed key via the `using:` overloads to avoid Keychain access.
+final class GateReceiptTests: XCTestCase {
+
+    private let testKey = SymmetricKey(data: Data(repeating: 0x42, count: 32))
+
+    // MARK: - Helpers
+
+    private func tempFile(_ contents: String) throws -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-gr-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("adapter.gguf").path
+        try contents.write(toFile: path, atomically: true, encoding: .utf8)
+        return path
+    }
+
+    /// Create a directory of files (keys are relative paths, possibly nested).
+    private func tempDir(files: [(String, String)]) throws -> String {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-grdir-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for (rel, contents) in files {
+            let url = root.appendingPathComponent(rel)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try contents.write(to: url, atomically: true, encoding: .utf8)
+        }
+        return root.path
+    }
+
+    private func mint(
+        cycleId: String = "cycle-1",
+        path: String,
+        kind: AdapterKind = .gguf,
+        evaluatorId: String = "DaemonABEvaluator"
+    ) throws -> GateReceipt {
+        try GateMinter.mint(
+            cycleId: cycleId, candidatePath: path, kind: kind,
+            measured: [.toolCalling: 3.0, .faeCapability: 1.0, .assistantFit: 2.0, .serialization: 0.0],
+            evaluatorId: evaluatorId, baseModelId: "gemma-4-e4b",
+            evalSuiteVersion: "suite-v1", mintedAt: "2026-06-21T00:00:00Z",
+            using: testKey
+        )
+    }
+
+    // MARK: - Artifact digest
+
+    func testFileDigestIsStableAndContentSensitive() throws {
+        let path = try tempFile("hello gguf bytes")
+        let d1 = try GateArtifactDigest.digest(forPath: path, kind: .gguf)
+        let d2 = try GateArtifactDigest.digest(forPath: path, kind: .gguf)
+        XCTAssertEqual(d1, d2, "digest is deterministic")
+        try "hello gguf bytes!".write(toFile: path, atomically: true, encoding: .utf8)
+        XCTAssertNotEqual(d1, try GateArtifactDigest.digest(forPath: path, kind: .gguf),
+                          "digest changes when bytes change")
+    }
+
+    func testDirManifestIsOrderIndependentAndContentSensitive() throws {
+        // Same content, different file-creation order → same manifest.
+        let dirA = try tempDir(files: [("a.bin", "1"), ("nested/c.bin", "2")])
+        let dirB = try tempDir(files: [("nested/c.bin", "2"), ("a.bin", "1")])
+        XCTAssertEqual(
+            try GateArtifactDigest.digest(forPath: dirA, kind: .mlxDir),
+            try GateArtifactDigest.digest(forPath: dirB, kind: .mlxDir),
+            "manifest is independent of directory-walk order"
+        )
+        // One file's content changes → different manifest.
+        let dirC = try tempDir(files: [("a.bin", "1"), ("nested/c.bin", "CHANGED")])
+        XCTAssertNotEqual(
+            try GateArtifactDigest.digest(forPath: dirA, kind: .mlxDir),
+            try GateArtifactDigest.digest(forPath: dirC, kind: .mlxDir)
+        )
+    }
+
+    func testDirManifestRejectsSymlink() throws {
+        let dir = try tempDir(files: [("a.bin", "1")])
+        let link = URL(fileURLWithPath: dir).appendingPathComponent("escape")
+        try FileManager.default.createSymbolicLink(
+            at: link, withDestinationURL: URL(fileURLWithPath: "/etc/passwd")
+        )
+        XCTAssertThrowsError(try GateArtifactDigest.digest(forPath: dir, kind: .mlxDir)) { error in
+            guard case GateReceiptError.symlinkInArtifact = error else {
+                return XCTFail("expected symlinkInArtifact, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Mint + verify
+
+    func testMintVerifyRoundtrip() throws {
+        let path = try tempFile("adapter weights")
+        let receipt = try mint(path: path)
+        XCTAssertEqual(receipt.decision, "pass")
+        XCTAssertNoThrow(try GateReceiptVerifier.verify(receipt, expectedCandidatePath: path, using: testKey))
+    }
+
+    func testMintRejectsNonAllowlistedEvaluator() throws {
+        let path = try tempFile("adapter")
+        XCTAssertThrowsError(try mint(path: path, evaluatorId: "loss_proxy")) { error in
+            guard case GateReceiptError.evaluatorNotAllowed = error else {
+                return XCTFail("expected evaluatorNotAllowed, got \(error)")
+            }
+        }
+    }
+
+    func testForgedHmacRejected() throws {
+        let path = try tempFile("adapter")
+        let receipt = try mint(path: path)
+        let forged = GateReceipt(
+            cycleId: receipt.cycleId, candidatePath: receipt.candidatePath, kind: receipt.kind,
+            artifactDigest: receipt.artifactDigest, measured: receipt.measured, decision: receipt.decision,
+            evaluatorId: receipt.evaluatorId, baseModelId: receipt.baseModelId,
+            evalSuiteVersion: receipt.evalSuiteVersion, gatePolicyVersion: receipt.gatePolicyVersion,
+            receiptVersion: receipt.receiptVersion, mintedAt: receipt.mintedAt,
+            hmac: "00000000000000000000000000000000"
+        )
+        XCTAssertThrowsError(try GateReceiptVerifier.verify(forged, expectedCandidatePath: path, using: testKey)) { error in
+            guard case GateReceiptError.hmacMismatch = error else {
+                return XCTFail("expected hmacMismatch, got \(error)")
+            }
+        }
+    }
+
+    func testWrongKeyRejected() throws {
+        let path = try tempFile("adapter")
+        let receipt = try mint(path: path)
+        let otherKey = SymmetricKey(data: Data(repeating: 0x99, count: 32))
+        XCTAssertThrowsError(try GateReceiptVerifier.verify(receipt, expectedCandidatePath: path, using: otherKey)) { error in
+            guard case GateReceiptError.hmacMismatch = error else {
+                return XCTFail("expected hmacMismatch, got \(error)")
+            }
+        }
+    }
+
+    func testCandidateMismatchRejected() throws {
+        let path = try tempFile("adapter")
+        let receipt = try mint(path: path)
+        XCTAssertThrowsError(try GateReceiptVerifier.verify(receipt, expectedCandidatePath: "/some/other/path", using: testKey)) { error in
+            guard case GateReceiptError.candidateMismatch = error else {
+                return XCTFail("expected candidateMismatch, got \(error)")
+            }
+        }
+    }
+
+    func testDigestMismatchAfterTamper() throws {
+        let path = try tempFile("adapter")
+        let receipt = try mint(path: path)
+        // Mutate the artifact AFTER minting — the re-pointed/edited file must fail verify.
+        try "tampered weights".write(toFile: path, atomically: true, encoding: .utf8)
+        XCTAssertThrowsError(try GateReceiptVerifier.verify(receipt, expectedCandidatePath: path, using: testKey)) { error in
+            guard case GateReceiptError.digestMismatch = error else {
+                return XCTFail("expected digestMismatch, got \(error)")
+            }
+        }
+    }
+
+    func testStalePolicyVersionRejected() throws {
+        let path = try tempFile("adapter")
+        let receipt = try mint(path: path)
+        // A receipt minted under a future policy version is invalid now (policy bump
+        // invalidates old receipts). Checked before HMAC, so the hmac value is irrelevant.
+        let stale = GateReceipt(
+            cycleId: receipt.cycleId, candidatePath: receipt.candidatePath, kind: receipt.kind,
+            artifactDigest: receipt.artifactDigest, measured: receipt.measured, decision: receipt.decision,
+            evaluatorId: receipt.evaluatorId, baseModelId: receipt.baseModelId,
+            evalSuiteVersion: receipt.evalSuiteVersion,
+            gatePolicyVersion: receipt.gatePolicyVersion + 1,
+            receiptVersion: receipt.receiptVersion, mintedAt: receipt.mintedAt, hmac: receipt.hmac
+        )
+        XCTAssertThrowsError(try GateReceiptVerifier.verify(stale, expectedCandidatePath: path, using: testKey)) { error in
+            guard case GateReceiptError.stalePolicyVersion = error else {
+                return XCTFail("expected stalePolicyVersion, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func makeTempStore() async throws -> ImprovementStore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = ImprovementStore()
+        try await store.open(at: dir.appendingPathComponent("improvement.db"))
+        try await store.ensureStateRow()
+        return store
+    }
+
+    func testReceiptPersistenceRoundtripAndSingleUseConsume() async throws {
+        let store = try await makeTempStore()
+        let path = try tempFile("adapter")
+        let receipt = try mint(cycleId: "cycle-42", path: path)
+
+        try await store.insertGateReceipt(receipt)
+        let fetched = try await store.gateReceipt(forCycleId: "cycle-42")
+        XCTAssertEqual(fetched, receipt, "receipt round-trips through the store unchanged")
+
+        let consumedBefore = try await store.isGateReceiptConsumed(cycleId: "cycle-42")
+        XCTAssertFalse(consumedBefore)
+        try await store.consumeGateReceipt(cycleId: "cycle-42", at: "2026-06-21T01:00:00Z")
+        let consumedAfter = try await store.isGateReceiptConsumed(cycleId: "cycle-42")
+        XCTAssertTrue(consumedAfter, "consume marks the receipt single-use")
+
+        // A fetched, consumed receipt still verifies cryptographically — single-use is
+        // enforced by the store flag, which the deploy gate (W4) checks separately.
+        XCTAssertNoThrow(try GateReceiptVerifier.verify(fetched!, expectedCandidatePath: path, using: testKey))
+    }
+
+    func testMissingReceiptReturnsNil() async throws {
+        let store = try await makeTempStore()
+        let absent = try await store.gateReceipt(forCycleId: "nope")
+        XCTAssertNil(absent)
+        let consumed = try await store.isGateReceiptConsumed(cycleId: "nope")
+        XCTAssertFalse(consumed)
+    }
+}

--- a/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
@@ -670,6 +670,73 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         )
     }
 
+    // MARK: - W6: refuse to train a lane with no evaluator
+
+    private func makeFakeBridge() throws -> TrainingBridge {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-w6-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        return TrainingBridge(
+            uvPath: "/usr/bin/false", orchestratorScriptsDir: tmpDir, dataBridgeScriptsDir: tmpDir
+        )
+    }
+
+    /// With a training bridge present but NO evaluator available for the lane, the cycle
+    /// refuses to train (it would only burn a run — the candidate could never pass the gate).
+    func testRefuseToTrainWhenNoEvaluatorForLane() async throws {
+        let store = try await makeTempStore()
+        let coordinator = makeCoordinator(store: store)
+        await coordinator.setTrainingBridge(try makeFakeBridge())
+        // availableEvaluatorKinds left empty ⇒ refuse.
+        try await seedSufficientData(store: store)
+
+        try await coordinator.runCycle()
+
+        let state = try await store.readState()
+        XCTAssertEqual(state.cycleState, "idle")
+        XCTAssertEqual(state.lastCycleError, "lane_no_evaluator:mlxDir",
+                       "mlx lane must refuse to train without an evaluator")
+        // F14: the refusal is also surfaced in the morning-briefing narrative.
+        let narrative = await coordinator.pendingMetaOptNarrative
+        XCTAssertTrue(narrative?.contains("mlxDir") ?? false, "Refusal surfaced in the briefing narrative")
+    }
+
+    /// The daemon (gguf) lane also refuses to train without a gguf evaluator.
+    func testRefuseToTrainGgufLaneWhenNoEvaluator() async throws {
+        let store = try await makeTempStore()
+        let coordinator = makeCoordinator(store: store)
+        await coordinator.setTrainingBridge(try makeFakeBridge())
+        await coordinator.setDaemonTrainingBaseModel("gemma-test") // gguf lane
+        // Only an mlxDir evaluator available — the gguf lane still refuses.
+        await coordinator.setAvailableEvaluatorKinds([.mlxDir])
+        try await seedSufficientData(store: store)
+
+        try await coordinator.runCycle()
+
+        let state = try await store.readState()
+        XCTAssertEqual(state.cycleState, "idle")
+        XCTAssertEqual(state.lastCycleError, "lane_no_evaluator:gguf",
+                       "gguf lane must refuse without a gguf evaluator")
+    }
+
+    /// With an evaluator available for the lane, the cycle gets PAST the refuse-to-train
+    /// gate (and then fails downstream on the fake bridge — not at the gate).
+    func testTrainsPastGateWhenEvaluatorAvailable() async throws {
+        let store = try await makeTempStore()
+        let coordinator = makeCoordinator(store: store)
+        await coordinator.setTrainingBridge(try makeFakeBridge())
+        await coordinator.setAvailableEvaluatorKinds([.mlxDir])
+        try await seedSufficientData(store: store)
+
+        try await coordinator.runCycle()
+
+        let state = try await store.readState()
+        XCTAssertFalse(
+            state.lastCycleError?.starts(with: "lane_no_evaluator") ?? false,
+            "With an evaluator available the cycle must pass the refuse-to-train gate, got: \(state.lastCycleError ?? "nil")"
+        )
+    }
+
     /// rejectDeployment() returns to idle without incrementing userApprovedCycles.
     func testRejectDeploymentReturnsToIdleWithoutApproval() async throws {
         let store = try await makeTempStore()

--- a/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
@@ -1,9 +1,13 @@
+import CryptoKit
 import XCTest
 @testable import Fae
 
 final class ImprovementCycleCoordinatorTests: XCTestCase {
 
     // MARK: - Helpers
+
+    /// Fixed HMAC key for gate-receipt tests (avoids Keychain access).
+    private let gateTestKey = SymmetricKey(data: Data(repeating: 0x42, count: 32))
 
     private func makeTempStore() async throws -> ImprovementStore {
         let dir = FileManager.default.temporaryDirectory
@@ -13,6 +17,49 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let store = ImprovementStore()
         try await store.open(at: url)
         return store
+    }
+
+    /// Create a temp GGUF candidate file and a valid gate receipt for it (signed with
+    /// `gateTestKey`). The file must exist on disk because verify recomputes the digest.
+    private func makeCandidateWithReceipt(cycleId: String) throws -> (path: String, receipt: GateReceipt) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fae-cand-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("adapter.gguf").path
+        try "candidate weights".write(toFile: path, atomically: true, encoding: .utf8)
+        let receipt = try GateMinter.mint(
+            cycleId: cycleId, candidatePath: path, kind: .gguf,
+            measured: [.toolCalling: 3.0, .faeCapability: 1.0, .assistantFit: 2.0, .serialization: 0.0],
+            evaluatorId: "DaemonABEvaluator", baseModelId: "gemma-test",
+            evalSuiteVersion: "v1", mintedAt: "2026-06-22T00:00:00Z", using: gateTestKey
+        )
+        return (path, receipt)
+    }
+
+    /// Drive a coordinator (daemon/gguf lane) to `.proposing` with a valid pending
+    /// candidate + an inserted gate receipt. Returns the candidate path.
+    @discardableResult
+    private func setupProposingWithValidReceipt(
+        _ coordinator: ImprovementCycleCoordinator,
+        store: ImprovementStore,
+        cycleId: String = "cyc-1",
+        priorDeployed: String? = "/tmp/prior_deployed"
+    ) async throws -> String {
+        let (path, receipt) = try makeCandidateWithReceipt(cycleId: cycleId)
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.currentAdapterPath = priorDeployed
+        s.pendingAdapterPath = path
+        s.pendingAdapterKind = "gguf"
+        s.pendingCycleId = cycleId
+        try await store.writeState(s)
+        try await store.insertGateReceipt(receipt)
+        await coordinator.setInjectedGateKey(gateTestKey)
+        await coordinator.setDaemonTrainingBaseModel("gemma-test") // gguf lane ⇒ expectedKind == .gguf
+        for st in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: st)
+        }
+        return path
     }
 
     private func makeCoordinator(store: ImprovementStore) -> ImprovementCycleCoordinator {
@@ -270,19 +317,10 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
     /// approveDeployment() increments userApprovedCycles and returns to idle.
     func testApproveDeploymentIncrementsApprovedCycles() async throws {
         let store = try await makeTempStore()
-        try await store.ensureStateRow()
-        // P9/C4 (W3): seed a pending candidate (as the training step would) so the
-        // approve path has something to promote to currentAdapterPath.
-        var seed = try await store.readState()
-        seed.currentAdapterPath = "/tmp/prior_deployed"
-        seed.pendingAdapterPath = "/tmp/candidate_adapter"
-        try await store.writeState(seed)
         let coordinator = makeCoordinator(store: store)
+        // P9/C4 (W4): a deploy now REQUIRES a verifying gate receipt for the candidate.
+        let candidate = try await setupProposingWithValidReceipt(coordinator, store: store)
 
-        // Manually drive to proposing state (simulates end of runCycle).
-        for state in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
-            try await coordinator.transition(to: state)
-        }
         let preApproveState = try await coordinator.currentState()
         XCTAssertEqual(preApproveState, .proposing)
 
@@ -296,9 +334,117 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         XCTAssertEqual(storeState.completedCycles, 1)
         XCTAssertNotNil(storeState.lastCycleAt)
         // The candidate is promoted; the prior becomes the rollback target; pending cleared.
-        XCTAssertEqual(storeState.currentAdapterPath, "/tmp/candidate_adapter", "Candidate promoted to deployed")
+        XCTAssertEqual(storeState.currentAdapterPath, candidate, "Candidate promoted to deployed")
         XCTAssertEqual(storeState.previousAdapterPath, "/tmp/prior_deployed", "Prior becomes rollback target")
         XCTAssertNil(storeState.pendingAdapterPath, "Pending cleared after deploy")
+        // The receipt is consumed (single-use).
+        let consumed = try await store.isGateReceiptConsumed(cycleId: "cyc-1")
+        XCTAssertTrue(consumed, "Receipt consumed after deploy")
+    }
+
+    // MARK: - W4: deploy requires a verifying gate receipt
+
+    /// Approve with no gate receipt for the candidate ⇒ fail closed (no deploy).
+    func testApproveWithoutReceiptIsBlocked() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        // Pending candidate present, but NO receipt inserted.
+        let (path, _) = try makeCandidateWithReceipt(cycleId: "cyc-x")
+        var s = try await store.readState()
+        s.currentAdapterPath = "/tmp/prior"
+        s.pendingAdapterPath = path
+        s.pendingAdapterKind = "gguf"
+        s.pendingCycleId = "cyc-x"
+        try await store.writeState(s)
+        let coordinator = makeCoordinator(store: store)
+        await coordinator.setInjectedGateKey(gateTestKey)
+        await coordinator.setDaemonTrainingBaseModel("gemma-test")
+        for st in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: st)
+        }
+
+        do {
+            try await coordinator.approveDeployment()
+            XCTFail("approve must throw without a gate receipt")
+        } catch ImprovementCycleError.gateReceiptRejected {
+            // expected
+        }
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle", "Fail-closed back to idle")
+        XCTAssertEqual(after.currentAdapterPath, "/tmp/prior", "Deployed pointer untouched")
+        XCTAssertNil(after.pendingAdapterPath, "Rejected candidate discarded")
+        XCTAssertEqual(after.userApprovedCycles, 0, "No deploy earned")
+    }
+
+    /// A consumed (replayed) receipt cannot deploy again.
+    func testApproveWithConsumedReceiptIsBlocked() async throws {
+        let store = try await makeTempStore()
+        let coordinator = makeCoordinator(store: store)
+        try await setupProposingWithValidReceipt(coordinator, store: store, cycleId: "cyc-r")
+        // Pre-consume the receipt.
+        try await store.consumeGateReceipt(cycleId: "cyc-r", at: "2026-06-22T00:00:00Z")
+
+        do {
+            try await coordinator.approveDeployment()
+            XCTFail("approve must throw on an already-consumed receipt")
+        } catch ImprovementCycleError.gateReceiptRejected {
+            // expected
+        }
+        let after = try await store.readState()
+        XCTAssertEqual(after.currentAdapterPath, "/tmp/prior_deployed", "Deployed pointer untouched")
+        XCTAssertNil(after.pendingAdapterPath, "Rejected candidate discarded")
+    }
+
+    /// A receipt minted for a DIFFERENT candidate path cannot deploy this candidate.
+    func testApproveWithMismatchedCandidateReceiptIsBlocked() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        let (path, _) = try makeCandidateWithReceipt(cycleId: "cyc-m")
+        // Insert a receipt for a DIFFERENT candidate path under the same cycle id.
+        let (otherPath, otherReceiptForOtherPath) = try makeCandidateWithReceipt(cycleId: "cyc-m")
+        _ = otherPath
+        try await store.insertGateReceipt(otherReceiptForOtherPath)
+        var s = try await store.readState()
+        s.pendingAdapterPath = path  // candidate is `path`, but the receipt is for `otherPath`
+        s.pendingAdapterKind = "gguf"
+        s.pendingCycleId = "cyc-m"
+        try await store.writeState(s)
+        let coordinator = makeCoordinator(store: store)
+        await coordinator.setInjectedGateKey(gateTestKey)
+        await coordinator.setDaemonTrainingBaseModel("gemma-test")
+        for st in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: st)
+        }
+
+        do {
+            try await coordinator.approveDeployment()
+            XCTFail("approve must throw when the receipt is for a different candidate")
+        } catch ImprovementCycleError.gateReceiptRejected {
+            // expected (candidateMismatch inside verify)
+        }
+        let after = try await store.readState()
+        XCTAssertNil(after.currentAdapterPath)
+    }
+
+    /// A receipt whose kind does not match the active engine lane is blocked.
+    func testApproveWithKindEngineMismatchIsBlocked() async throws {
+        let store = try await makeTempStore()
+        let coordinator = makeCoordinator(store: store)
+        // setup uses the gguf/daemon lane (expectedKind == .gguf) and a .gguf receipt...
+        try await setupProposingWithValidReceipt(coordinator, store: store, cycleId: "cyc-k")
+        // ...but flip the engine lane to MLX (expectedKind becomes .mlxDir) so the
+        // .gguf receipt now mismatches the engine.
+        await coordinator.setDaemonTrainingBaseModel(nil)
+
+        do {
+            try await coordinator.approveDeployment()
+            XCTFail("approve must throw on a kind↔engine mismatch")
+        } catch ImprovementCycleError.gateReceiptRejected {
+            // expected (kind_engine_mismatch)
+        }
+        let after = try await store.readState()
+        XCTAssertEqual(after.currentAdapterPath, "/tmp/prior_deployed", "Mismatched-kind candidate must not deploy")
     }
 
     /// rejectDeployment() returns to idle without incrementing userApprovedCycles.

--- a/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
@@ -447,6 +447,229 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         XCTAssertEqual(after.currentAdapterPath, "/tmp/prior_deployed", "Mismatched-kind candidate must not deploy")
     }
 
+    // MARK: - W5: stale-state recovery + shadow-eval source guard
+
+    /// A crashed/stale `.proposing` with no valid receipt is reset to idle, the candidate
+    /// discarded, and the deployed pointer left untouched (fail-closed).
+    func testRecoveryResetsStaleProposingWithoutReceipt() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.cycleState = "proposing"
+        s.currentAdapterPath = "/tmp/deployed"
+        s.pendingAdapterPath = "/tmp/candidate"
+        s.pendingAdapterKind = "gguf"
+        s.pendingCycleId = "stale-cyc"
+        try await store.writeState(s)
+        let coordinator = makeCoordinator(store: store)
+
+        await coordinator.recoverStaleStateIfNeeded()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle", "Stale proposing without a receipt is reset")
+        XCTAssertNil(after.pendingAdapterPath, "Pending candidate discarded")
+        XCTAssertEqual(after.lastCycleError, "recovered_stale_proposing")
+        XCTAssertEqual(after.currentAdapterPath, "/tmp/deployed", "Deployed pointer untouched")
+    }
+
+    /// A `.proposing` whose pending candidate still has a valid, unconsumed receipt is
+    /// legitimately resumable after a restart — recovery keeps it.
+    func testRecoveryKeepsResumableProposingWithValidReceipt() async throws {
+        let store = try await makeTempStore()
+        let coordinator = makeCoordinator(store: store)
+        let cycleId = "resumable-cyc"
+        let (path, receipt) = try makeCandidateWithReceipt(cycleId: cycleId)
+        try await store.insertGateReceipt(receipt)
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.cycleState = "proposing"
+        s.pendingAdapterPath = path
+        s.pendingAdapterKind = "gguf"
+        s.pendingCycleId = cycleId
+        try await store.writeState(s)
+        await coordinator.setInjectedGateKey(gateTestKey)
+
+        await coordinator.recoverStaleStateIfNeeded()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "proposing", "Resumable proposing with a valid receipt is kept")
+        XCTAssertEqual(after.pendingAdapterPath, path, "Pending candidate preserved")
+    }
+
+    /// A crashed `.training`/`.evaluating` cycle is reset to idle with its half-baked
+    /// candidate discarded.
+    func testRecoveryResetsInterruptedTraining() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.cycleState = "training"
+        s.pendingAdapterPath = "/tmp/halfbaked"
+        s.pendingCycleId = "t-cyc"
+        try await store.writeState(s)
+        let coordinator = makeCoordinator(store: store)
+
+        await coordinator.recoverStaleStateIfNeeded()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle")
+        XCTAssertNil(after.pendingAdapterPath, "Half-baked candidate discarded")
+        XCTAssertEqual(after.lastCycleError, "recovered_stale_training")
+    }
+
+    /// Recovery is a no-op when already idle.
+    func testRecoveryNoOpWhenIdle() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.currentAdapterPath = "/tmp/deployed"
+        s.lastCycleError = "previous_thing"
+        try await store.writeState(s)
+        let coordinator = makeCoordinator(store: store)
+
+        await coordinator.recoverStaleStateIfNeeded()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle")
+        XCTAssertEqual(after.currentAdapterPath, "/tmp/deployed")
+        XCTAssertEqual(after.lastCycleError, "previous_thing", "Idle state untouched")
+    }
+
+    /// Shadow eval A/Bs the DEPLOYED adapter, never the pending candidate (F5): the
+    /// coordinator pins the evaluator's adapter path to currentAdapterPath before running.
+    func testShadowEvalUsesDeployedAdapterNotPending() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        var state = try await store.readState()
+        state.completedCycles = 1 // odd ⇒ shadow eval night
+        state.currentAdapterPath = "/tmp/deployed_adapter"
+        state.pendingAdapterPath = "/tmp/pending_candidate"
+        try await store.writeState(state)
+
+        let evaluator = ShadowEvaluator(store: store)
+        await evaluator.setResponseGenerator { _, _ in "response" }
+        await evaluator.setScorer { _, _, _ in .adapterWins }
+        for i in 0..<5 {
+            _ = try await store.appendShadowEpisode(ShadowEvalEpisode(
+                id: nil, recordedAt: ISO8601DateFormatter().string(from: Date()),
+                conversationJSON: "[{\"role\":\"user\",\"content\":\"test\"}]",
+                actualResponse: "response \(i)",
+                receptionScore: nil, evaluated: false, evalOutcome: nil
+            ))
+        }
+
+        let coordinator = ImprovementCycleCoordinator(
+            store: store, reviewGate: ExternalReviewGate(), shadowEvaluator: evaluator
+        )
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        try await seedSufficientData(store: store)
+        try await coordinator.runCycle()
+
+        // The coordinator pinned the evaluator to the DEPLOYED adapter, not the pending one.
+        let pinned = await evaluator.currentAdapterPath
+        XCTAssertEqual(pinned, "/tmp/deployed_adapter", "Shadow eval must A/B the deployed adapter")
+        XCTAssertNotEqual(pinned, "/tmp/pending_candidate", "Shadow eval must never use the pending candidate")
+    }
+
+    /// A `.deploying` state is NOT resumable (no path advances it) — recovery resets it
+    /// even with a valid receipt.
+    func testRecoveryResetsDeployingEvenWithValidReceipt() async throws {
+        let store = try await makeTempStore()
+        let coordinator = makeCoordinator(store: store)
+        let cycleId = "deploy-cyc"
+        let (path, receipt) = try makeCandidateWithReceipt(cycleId: cycleId)
+        try await store.insertGateReceipt(receipt)
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.cycleState = "deploying"
+        s.currentAdapterPath = "/tmp/deployed"
+        s.pendingAdapterPath = path
+        s.pendingAdapterKind = "gguf"
+        s.pendingCycleId = cycleId
+        try await store.writeState(s)
+        await coordinator.setInjectedGateKey(gateTestKey)
+
+        await coordinator.recoverStaleStateIfNeeded()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle", ".deploying is not resumable — reset")
+        XCTAssertNil(after.pendingAdapterPath, "Pending discarded")
+        XCTAssertEqual(after.currentAdapterPath, "/tmp/deployed", "Genuine deployed pointer (pending recorded) kept")
+    }
+
+    /// A `.proposing` with a CONSUMED receipt is not resumable — reset.
+    func testRecoveryResetsProposingWithConsumedReceipt() async throws {
+        let store = try await makeTempStore()
+        let coordinator = makeCoordinator(store: store)
+        let cycleId = "consumed-cyc"
+        let (path, receipt) = try makeCandidateWithReceipt(cycleId: cycleId)
+        try await store.insertGateReceipt(receipt)
+        try await store.consumeGateReceipt(cycleId: cycleId, at: "2026-06-22T00:00:00Z")
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.cycleState = "proposing"
+        s.pendingAdapterPath = path
+        s.pendingCycleId = cycleId
+        try await store.writeState(s)
+        await coordinator.setInjectedGateKey(gateTestKey)
+
+        await coordinator.recoverStaleStateIfNeeded()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle", "Consumed receipt ⇒ not resumable ⇒ reset")
+        XCTAssertNil(after.pendingAdapterPath)
+    }
+
+    /// A PRE-P9-shaped post-eval state (candidate written to currentAdapterPath, no pending
+    /// fields) has its ungated current rolled back to the previous adapter (fail-closed).
+    func testRecoveryRollsBackPreP9UngatedCurrentAdapter() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.cycleState = "evaluating"                       // post-(old)-eval state
+        s.currentAdapterPath = "/tmp/ungated_candidate"   // pre-P9: candidate sat in current
+        s.previousAdapterPath = "/tmp/last_good"
+        s.pendingAdapterPath = nil                        // pre-P9 shape: no pending fields
+        s.pendingCycleId = nil
+        try await store.writeState(s)
+        let coordinator = makeCoordinator(store: store)
+
+        await coordinator.recoverStaleStateIfNeeded()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle")
+        XCTAssertEqual(after.currentAdapterPath, "/tmp/last_good", "Pre-P9 ungated current rolled back to previous")
+        XCTAssertEqual(after.lastCycleError, "recovered_stale_evaluating")
+    }
+
+    /// The crash window AFTER promote commits (current = just-promoted, receipt-gated
+    /// candidate; pending cleared) but BEFORE the .idle transition: recovery must KEEP the
+    /// promoted current (it has a consumed-receipt provenance), not mistake it for pre-P9.
+    func testRecoveryKeepsPromotedCurrentOnCrashAfterPromote() async throws {
+        let store = try await makeTempStore()
+        let cycleId = "promote-cyc"
+        let (path, receipt) = try makeCandidateWithReceipt(cycleId: cycleId)
+        try await store.insertGateReceipt(receipt)
+        try await store.consumeGateReceipt(cycleId: cycleId, at: "2026-06-22T00:00:00Z")
+        try await store.ensureStateRow()
+        var s = try await store.readState()
+        s.cycleState = "deploying"        // promote committed; .idle transition not yet run
+        s.currentAdapterPath = path       // the just-promoted candidate
+        s.previousAdapterPath = "/tmp/old"
+        s.pendingAdapterPath = nil        // pending was cleared by the promote
+        s.pendingCycleId = nil
+        try await store.writeState(s)
+        let coordinator = makeCoordinator(store: store)
+
+        await coordinator.recoverStaleStateIfNeeded()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle")
+        XCTAssertEqual(
+            after.currentAdapterPath, path,
+            "A promoted, receipt-gated current must NOT be rolled back"
+        )
+    }
+
     /// rejectDeployment() returns to idle without incrementing userApprovedCycles.
     func testRejectDeploymentReturnsToIdleWithoutApproval() async throws {
         let store = try await makeTempStore()

--- a/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
@@ -68,12 +68,28 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
 
     /// A measured improvement delta (all +5pp). Drives the P9/C4 gate to PASS in
     /// tests that exercise the proposing/deploy path, standing in for a real
-    /// FaeBenchmark result until W7 wires the `AdapterEvaluator`.
+    /// FaeBenchmark result.
     private func measuredImprovement() -> EvalDelta {
         EvalDelta(
             toolCallingDelta: 5.0, faeCapabilityDelta: 5.0,
             assistantFitDelta: 5.0, serializationDelta: 5.0, throughputDelta: 1.0
         )
+    }
+
+    /// Arm the injected measured-delta seam so a `runCycle()` can pass the W7 fail-closed
+    /// gate. The seam stands in for a real `AdapterEvaluator`: it provisions its own
+    /// synthetic on-disk candidate during the eval phase (a real cycle's candidate, like
+    /// this one, can only exist AFTER the cycle-start `idle ⇒ no pending` clear), then
+    /// mints a receipt for it. The injected HMAC key lets that mint + the later deploy
+    /// verify without Keychain access. Call this INSTEAD of a bare
+    /// `setInjectedMeasuredDelta` whenever a `runCycle()` must reach the review gate.
+    private func armInjectedPass(
+        _ coordinator: ImprovementCycleCoordinator,
+        store: ImprovementStore,
+        delta: EvalDelta? = nil
+    ) async {
+        await coordinator.setInjectedGateKey(gateTestKey)
+        await coordinator.setInjectedMeasuredDelta(delta ?? measuredImprovement())
     }
 
     private func makeEvent(
@@ -228,8 +244,9 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
     func testRunCycleCompletesWithSufficientData() async throws {
         let store = try await makeTempStore()
         let coordinator = makeCoordinator(store: store)
-        // P9/C4: a real measured improvement is required to pass the gate.
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // P9/C4 (W7): a real measured improvement is required to pass the gate, AND a gate
+        // pass must be backed by a minted receipt — so stage a mintable pending candidate.
+        await armInjectedPass(coordinator, store: store)
         try await seedSufficientData(store: store)
 
         try await coordinator.runCycle()
@@ -538,12 +555,6 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
     /// coordinator pins the evaluator's adapter path to currentAdapterPath before running.
     func testShadowEvalUsesDeployedAdapterNotPending() async throws {
         let store = try await makeTempStore()
-        try await store.ensureStateRow()
-        var state = try await store.readState()
-        state.completedCycles = 1 // odd ⇒ shadow eval night
-        state.currentAdapterPath = "/tmp/deployed_adapter"
-        state.pendingAdapterPath = "/tmp/pending_candidate"
-        try await store.writeState(state)
 
         let evaluator = ShadowEvaluator(store: store)
         await evaluator.setResponseGenerator { _, _ in "response" }
@@ -560,14 +571,26 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let coordinator = ImprovementCycleCoordinator(
             store: store, reviewGate: ExternalReviewGate(), shadowEvaluator: evaluator
         )
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // Arm the injected seam (it self-provisions a pending candidate during eval, W7),
+        // then pin the deployed adapter that shadow eval must A/B against.
+        await armInjectedPass(coordinator, store: store)
+        try await store.ensureStateRow()
+        var state = try await store.readState()
+        state.completedCycles = 1 // odd ⇒ shadow eval night
+        state.currentAdapterPath = "/tmp/deployed_adapter"
+        try await store.writeState(state)
+
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
-        // The coordinator pinned the evaluator to the DEPLOYED adapter, not the pending one.
+        // The coordinator pinned the evaluator to the DEPLOYED adapter, never the (self-
+        // provisioned) pending candidate.
         let pinned = await evaluator.currentAdapterPath
         XCTAssertEqual(pinned, "/tmp/deployed_adapter", "Shadow eval must A/B the deployed adapter")
-        XCTAssertNotEqual(pinned, "/tmp/pending_candidate", "Shadow eval must never use the pending candidate")
+        XCTAssertFalse(
+            pinned?.contains("injected-seam") ?? false,
+            "Shadow eval must never use the pending candidate"
+        )
     }
 
     /// A `.deploying` state is NOT resumable (no path advances it) — recovery resets it
@@ -995,9 +1018,9 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             "CONCERN: Minor regression in tool calling. Recommend human review."
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
-        // P9/C4 (W1): a measured delta is required to reach the external review gate
-        // (an unmeasured candidate is blocked before review).
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // P9/C4 (W1/W7): a measured delta is required to reach the external review gate,
+        // and the gate pass must be backed by a minted receipt — stage a candidate.
+        await armInjectedPass(coordinator, store: store)
 
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
@@ -1019,8 +1042,8 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             "FAIL: Significant regression in tool calling (-15%)."
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
-        // P9/C4 (W1): reach the external review gate with a measured delta.
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // P9/C4 (W1/W7): reach the review gate with a measured delta backed by a receipt.
+        await armInjectedPass(coordinator, store: store)
 
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
@@ -1044,8 +1067,8 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             "PASS: All metrics improved, no regressions detected."
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
-        // P9/C4 (W1): reach the external review gate with a measured delta.
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // P9/C4 (W1/W7): reach the review gate with a measured delta backed by a receipt.
+        await armInjectedPass(coordinator, store: store)
 
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
@@ -1058,6 +1081,43 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         XCTAssertEqual(storeState.deferralCount, 0, "Deferrals should be reset on PASS")
     }
 
+    /// P9/C4 (W7, Codex FIX 2): a measured delta that PASSES the gate but came through the
+    /// legacy bridge-benchmark / loss-proxy branch (no real evaluator ⇒ no minted receipt)
+    /// must FAIL CLOSED immediately — it must NOT reach external review, must NOT enter
+    /// `.proposing`/`.deploying`, and must NOT touch `currentAdapterPath`. Why: only a real
+    /// `AdapterEvaluator` (which mints a receipt) may pass the gate; relying on the late W4
+    /// deploy fence would let a non-evaluator pass run external review first.
+    func testGatePassWithoutReceiptFailsClosed() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        var seed = try await store.readState()
+        seed.currentAdapterPath = "/tmp/live_adapter"
+        try await store.writeState(seed)
+
+        // A reviewer that would PASS if it were ever consulted — it must NOT be.
+        let gate = ExternalReviewGate()
+        var reviewWasConsulted = false
+        await gate.setDelegateAgentRunner { _ in
+            reviewWasConsulted = true
+            return "PASS: looks great."
+        }
+        let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
+        // Drive the legacy no-receipt path with a clean +5pp pass.
+        await coordinator.setInjectedLegacyMeasuredDelta(measuredImprovement())
+        try await seedSufficientData(store: store)
+
+        try await coordinator.runCycle()
+
+        let finalState = try await coordinator.currentState()
+        XCTAssertEqual(finalState, .idle, "A gate pass with no receipt must end fail-closed at idle")
+        let persisted = try await store.readState()
+        XCTAssertEqual(persisted.lastCycleError, "gate_pass_but_no_receipt")
+        XCTAssertEqual(persisted.currentAdapterPath, "/tmp/live_adapter",
+                       "The live adapter must be untouched")
+        XCTAssertNil(persisted.pendingAdapterPath, "Pending candidate discarded")
+        XCTAssertFalse(reviewWasConsulted, "External review must NOT be consulted for a no-receipt pass")
+    }
+
     /// Multiple CONCERN deferrals accumulate until max is reached.
     func testDeferralsAccumulateAcrossCycles() async throws {
         let store = try await makeTempStore()
@@ -1066,8 +1126,9 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             "CONCERN: Minor issue detected."
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
-        // P9/C4 (W1): reach the external review gate with a measured delta.
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // The injected seam self-provisions a fresh candidate + receipt each cycle (a CONCERN
+        // fail-closes and clears the pending candidate), so arming once suffices (W7).
+        await armInjectedPass(coordinator, store: store)
 
         // Run 3 cycles, each should defer.
         for i in 1...3 {
@@ -1091,9 +1152,9 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         try await store.writeState(storeState)
 
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
-        // P9/C4 (W1): a measured delta is required to reach the review gate, where
-        // the max-deferrals check then fires.
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // P9/C4 (W1/W7): a measured delta backed by a receipt is required to reach the
+        // review gate, where the max-deferrals check then fires.
+        await armInjectedPass(coordinator, store: store)
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
@@ -1286,10 +1347,10 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let coordinator = ImprovementCycleCoordinator(
             store: store, reviewGate: ExternalReviewGate(), shadowEvaluator: evaluator
         )
-        // P9/C4 (W1): a real measured improvement is required to pass the review
-        // gate and reach the shadow-eval step — where the baseWins scorer then
+        // P9/C4 (W1/W7): a measured improvement backed by a receipt is required to pass
+        // the review gate and reach the shadow-eval step — where the baseWins scorer then
         // blocks the deployment.
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        await armInjectedPass(coordinator, store: store)
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
@@ -1324,9 +1385,9 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let coordinator = ImprovementCycleCoordinator(
             store: store, reviewGate: ExternalReviewGate(), shadowEvaluator: evaluator
         )
-        // P9/C4: a real measured improvement is required to pass the gate and
-        // reach the shadow-eval step.
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // P9/C4 (W7): a measured improvement backed by a receipt is required to pass the
+        // gate and reach the shadow-eval step.
+        await armInjectedPass(coordinator, store: store)
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
@@ -1350,8 +1411,8 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let coordinator = ImprovementCycleCoordinator(
             store: store, reviewGate: ExternalReviewGate(), shadowEvaluator: evaluator
         )
-        // P9/C4: a real measured improvement is required to pass the gate.
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // P9/C4 (W7): a measured improvement backed by a receipt is required to pass the gate.
+        await armInjectedPass(coordinator, store: store)
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
@@ -1387,9 +1448,9 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             logCalled = true
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
-        // P9/C4 (W1): a measured delta is required to reach the review gate (where
-        // the security-log closure fires).
-        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
+        // P9/C4 (W1/W7): a measured delta backed by a receipt is required to reach the
+        // review gate (where the security-log closure fires).
+        await armInjectedPass(coordinator, store: store)
 
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()

--- a/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/ImprovementCycleCoordinatorTests.swift
@@ -19,6 +19,16 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         ImprovementCycleCoordinator(store: store)
     }
 
+    /// A measured improvement delta (all +5pp). Drives the P9/C4 gate to PASS in
+    /// tests that exercise the proposing/deploy path, standing in for a real
+    /// FaeBenchmark result until W7 wires the `AdapterEvaluator`.
+    private func measuredImprovement() -> EvalDelta {
+        EvalDelta(
+            toolCallingDelta: 5.0, faeCapabilityDelta: 5.0,
+            assistantFitDelta: 5.0, serializationDelta: 5.0, throughputDelta: 1.0
+        )
+    }
+
     private func makeEvent(
         signalType: String = "correction",
         fingerprint: String? = nil
@@ -171,6 +181,8 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
     func testRunCycleCompletesWithSufficientData() async throws {
         let store = try await makeTempStore()
         let coordinator = makeCoordinator(store: store)
+        // P9/C4: a real measured improvement is required to pass the gate.
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
         try await seedSufficientData(store: store)
 
         try await coordinator.runCycle()
@@ -259,6 +271,12 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
     func testApproveDeploymentIncrementsApprovedCycles() async throws {
         let store = try await makeTempStore()
         try await store.ensureStateRow()
+        // P9/C4 (W3): seed a pending candidate (as the training step would) so the
+        // approve path has something to promote to currentAdapterPath.
+        var seed = try await store.readState()
+        seed.currentAdapterPath = "/tmp/prior_deployed"
+        seed.pendingAdapterPath = "/tmp/candidate_adapter"
+        try await store.writeState(seed)
         let coordinator = makeCoordinator(store: store)
 
         // Manually drive to proposing state (simulates end of runCycle).
@@ -277,6 +295,10 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         XCTAssertEqual(storeState.userApprovedCycles, 1)
         XCTAssertEqual(storeState.completedCycles, 1)
         XCTAssertNotNil(storeState.lastCycleAt)
+        // The candidate is promoted; the prior becomes the rollback target; pending cleared.
+        XCTAssertEqual(storeState.currentAdapterPath, "/tmp/candidate_adapter", "Candidate promoted to deployed")
+        XCTAssertEqual(storeState.previousAdapterPath, "/tmp/prior_deployed", "Prior becomes rollback target")
+        XCTAssertNil(storeState.pendingAdapterPath, "Pending cleared after deploy")
     }
 
     /// rejectDeployment() returns to idle without incrementing userApprovedCycles.
@@ -297,6 +319,86 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let storeState = try await store.readState()
         XCTAssertEqual(storeState.userApprovedCycles, 0, "Rejection must not increment userApprovedCycles")
         XCTAssertEqual(storeState.completedCycles, 1, "completedCycles should still increment")
+    }
+
+    /// rejectDeployment() discards the pending candidate and leaves the deployed
+    /// adapter untouched — a rejected candidate never becomes current (P9/C4 W3).
+    func testRejectDeploymentDiscardsPendingKeepsDeployed() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        // Post-training proposing state: candidate is PENDING; the deployed adapter
+        // is in currentAdapterPath (training never touched it).
+        var state = try await store.readState()
+        state.currentAdapterPath = "/tmp/deployed"
+        state.pendingAdapterPath = "/tmp/rejected_candidate"
+        try await store.writeState(state)
+
+        let coordinator = makeCoordinator(store: store)
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+
+        try await coordinator.rejectDeployment()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle")
+        XCTAssertEqual(
+            after.currentAdapterPath, "/tmp/deployed",
+            "Deployed adapter must be untouched by a rejection"
+        )
+        XCTAssertNil(after.pendingAdapterPath, "Rejected candidate must be discarded")
+        XCTAssertEqual(after.userApprovedCycles, 0, "Reject must not earn auto-deploy")
+    }
+
+    /// approveDeployment with no pending candidate fails closed (throws) rather than
+    /// silently "succeeding" with nothing deployed (P9/C4 W3).
+    func testApproveWithNoPendingCandidateThrows() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        let coordinator = makeCoordinator(store: store)
+        // Drive to proposing WITHOUT seeding a pending candidate.
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+
+        do {
+            try await coordinator.approveDeployment()
+            XCTFail("approveDeployment must throw when there is no pending candidate")
+        } catch ImprovementCycleError.noPendingCandidate {
+            // expected
+        } catch {
+            XCTFail("expected noPendingCandidate, got \(error)")
+        }
+
+        // The failed approve leaves the machine in proposing (recoverable), NOT stuck
+        // in deploying, and has no side effects.
+        let stateAfter = try await coordinator.currentState()
+        XCTAssertEqual(stateAfter, .proposing)
+        let after = try await store.readState()
+        XCTAssertNil(after.currentAdapterPath, "Nothing should be deployed")
+        XCTAssertEqual(after.userApprovedCycles, 0, "Failed approve must not earn auto-deploy")
+    }
+
+    /// A fail-closed cycle clears any (stale) pending candidate — idle never
+    /// coexists with a candidate a later path could deploy (P9/C4 W3).
+    func testFailClosedCycleClearsPendingCandidate() async throws {
+        let store = try await makeTempStore()
+        try await store.ensureStateRow()
+        // Seed a stale pending candidate (e.g. left from an earlier interrupted run).
+        var seed = try await store.readState()
+        seed.pendingAdapterPath = "/tmp/stale_candidate"
+        seed.pendingAdapterKind = "gguf"
+        try await store.writeState(seed)
+
+        let coordinator = makeCoordinator(store: store)
+        try await seedSufficientData(store: store)
+        // No bridge + no injected delta ⇒ unmeasured ⇒ fail-closed block.
+        try await coordinator.runCycle()
+
+        let after = try await store.readState()
+        XCTAssertEqual(after.cycleState, "idle")
+        XCTAssertNil(after.pendingAdapterPath, "Fail-closed must clear the stale pending candidate")
+        XCTAssertNil(after.currentAdapterPath, "Nothing deployed")
     }
 
     /// approveDeployment() throws invalidTransition when not in proposing state.
@@ -398,26 +500,39 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
 
     // MARK: - Auto-Deploy After 5 Approved Cycles (Phase 2.3)
 
-    /// runCycle() pauses in proposing when userApprovedCycles < 5.
-    func testRunCyclePausesInProposingBeforeEarningAutoDeploy() async throws {
+    // P9/C4 (W1): with no benchmark evaluator wired, a cycle cannot produce a
+    // MEASURED improvement, so the fail-closed gate rule (`AdapterGate.decide`)
+    // makes the internal review FAIL — the candidate can never reach `.proposing`
+    // or deploy. WHY: an un-evaluated adapter must never be proposed or deployed —
+    // the previous all-zero/all-nil "pass" was the hole C4 closes. The
+    // proposing-pause and auto-deploy happy paths are re-covered in W8 with a stub
+    // evaluator that returns a real measured improvement. (External-review
+    // short-circuit on unmeasured deltas — F16 — lands in W4.)
+
+    /// runCycle() with no evaluator fails closed instead of proposing.
+    func testRunCycleBlocksWhenNoEvaluatorConfigured() async throws {
         let store = try await makeTempStore()
         let coordinator = makeCoordinator(store: store)
         try await seedSufficientData(store: store)
 
         try await coordinator.runCycle()
 
-        // Should be paused in proposing (needs user approval).
+        // Fail-closed: no measured improvement ⇒ blocked BEFORE review ⇒ idle, NOT proposing.
         let state = try await coordinator.currentState()
-        XCTAssertEqual(state, .proposing, "Cycle should pause in proposing until 5 approvals earned")
+        XCTAssertEqual(state, .idle, "No evaluator ⇒ candidate is blocked, never proposed")
+        let persisted = try await store.readState()
+        XCTAssertEqual(persisted.lastCycleError, "candidate_blocked: no_measured_improvement")
+        XCTAssertNil(persisted.currentAdapterPath, "Blocked candidate must not be deployed")
     }
 
-    /// runCycle() auto-deploys when userApprovedCycles >= 5.
-    func testRunCycleAutoDeploysAfterFiveApprovedCycles() async throws {
+    /// Earned auto-deploy does NOT bypass the gate: with no measurement the
+    /// candidate is blocked before review and nothing is deployed.
+    func testRunCycleBlocksAutoDeployWhenNoMeasurement() async throws {
         let store = try await makeTempStore()
         try await store.ensureStateRow()
         let coordinator = makeCoordinator(store: store)
 
-        // Seed 5 prior approved cycles to earn auto-deploy.
+        // Seed 5 prior approved cycles to "earn" auto-deploy.
         var state = try await store.readState()
         state.userApprovedCycles = 5
         try await store.writeState(state)
@@ -425,9 +540,12 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
-        // Should complete without pausing in proposing.
+        // Earned autonomy must not deploy an un-evaluated candidate.
         let finalState = try await coordinator.currentState()
-        XCTAssertEqual(finalState, .idle, "Auto-deploy should return to idle without user input")
+        XCTAssertEqual(finalState, .idle, "Blocked candidate returns to idle")
+        let persisted = try await store.readState()
+        XCTAssertEqual(persisted.lastCycleError, "candidate_blocked: no_measured_improvement")
+        XCTAssertNil(persisted.currentAdapterPath, "Auto-deploy must not ship an un-evaluated adapter")
     }
 
     // MARK: - External Review Gate Integration
@@ -441,6 +559,9 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             "CONCERN: Minor regression in tool calling. Recommend human review."
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
+        // P9/C4 (W1): a measured delta is required to reach the external review gate
+        // (an unmeasured candidate is blocked before review).
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
 
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
@@ -462,6 +583,8 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             "FAIL: Significant regression in tool calling (-15%)."
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
+        // P9/C4 (W1): reach the external review gate with a measured delta.
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
 
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
@@ -485,6 +608,8 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             "PASS: All metrics improved, no regressions detected."
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
+        // P9/C4 (W1): reach the external review gate with a measured delta.
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
 
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
@@ -505,6 +630,8 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             "CONCERN: Minor issue detected."
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
+        // P9/C4 (W1): reach the external review gate with a measured delta.
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
 
         // Run 3 cycles, each should defer.
         for i in 1...3 {
@@ -522,13 +649,15 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let store = try await makeTempStore()
         try await store.ensureStateRow()
         let gate = ExternalReviewGate()
-        // No delegate runner → falls through to internal review with neutral deltas → PASS.
-        // But first we set deferralCount to 3 (the max) to trigger maxDeferralsReached.
+        // Set deferralCount to the max so review() throws maxDeferralsReached.
         var storeState = try await store.readState()
         storeState.deferralCount = ExternalReviewGate.maxDeferrals
         try await store.writeState(storeState)
 
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
+        // P9/C4 (W1): a measured delta is required to reach the review gate, where
+        // the max-deferrals check then fires.
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
@@ -721,6 +850,10 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let coordinator = ImprovementCycleCoordinator(
             store: store, reviewGate: ExternalReviewGate(), shadowEvaluator: evaluator
         )
+        // P9/C4 (W1): a real measured improvement is required to pass the review
+        // gate and reach the shadow-eval step — where the baseWins scorer then
+        // blocks the deployment.
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
@@ -755,6 +888,9 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let coordinator = ImprovementCycleCoordinator(
             store: store, reviewGate: ExternalReviewGate(), shadowEvaluator: evaluator
         )
+        // P9/C4: a real measured improvement is required to pass the gate and
+        // reach the shadow-eval step.
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
@@ -778,6 +914,8 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         let coordinator = ImprovementCycleCoordinator(
             store: store, reviewGate: ExternalReviewGate(), shadowEvaluator: evaluator
         )
+        // P9/C4: a real measured improvement is required to pass the gate.
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
 
@@ -813,6 +951,9 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
             logCalled = true
         }
         let coordinator = ImprovementCycleCoordinator(store: store, reviewGate: gate)
+        // P9/C4 (W1): a measured delta is required to reach the review gate (where
+        // the security-log closure fires).
+        await coordinator.setInjectedMeasuredDelta(measuredImprovement())
 
         try await seedSufficientData(store: store)
         try await coordinator.runCycle()
@@ -822,20 +963,23 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
 
     // MARK: - TrainingBridge Integration
 
-    func testRunCycleSkipsTrainingGracefullyWhenBridgeNil() async throws {
-        // When no TrainingBridge is set, the coordinator should still complete a cycle
-        // (training step logs a skip, eval uses zero deltas, cycle ends normally).
+    func testRunCycleFailsClosedWhenBridgeNil() async throws {
+        // P9/C4 (W1): when no TrainingBridge is set, the cycle still runs but the
+        // evaluation is UNMEASURED — the fail-closed gate makes review FAIL so the
+        // cycle returns to idle WITHOUT proposing or deploying. WHY: a missing
+        // training/eval path must never be treated as a passing (zero-delta) result.
         let store = try await makeTempStore()
         let coordinator = makeCoordinator(store: store)
-        // Do NOT set trainingBridge.
+        // Do NOT set trainingBridge and do NOT inject a measured delta.
         try await seedSufficientData(store: store)
 
         try await coordinator.runCycle()
 
-        // Should reach proposing (paused for approval since 0 approved cycles).
         let state = try await coordinator.currentState()
-        XCTAssertEqual(state, .proposing,
-                       "Cycle should reach proposing even without a training bridge")
+        XCTAssertEqual(state, .idle, "No bridge ⇒ unmeasured ⇒ fail-closed to idle, not proposing")
+        let persisted = try await store.readState()
+        XCTAssertEqual(persisted.lastCycleError, "candidate_blocked: no_measured_improvement")
+        XCTAssertNil(persisted.currentAdapterPath, "Nothing should be deployed")
     }
 
     func testTrainingBridgeSetterWorks() async throws {
@@ -888,9 +1032,11 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         XCTAssertEqual(delta.throughputDelta ?? 0, 2.0, accuracy: 0.01)
     }
 
-    func testNilBridgeCycleReachesProposingWithZeroDeltas() async throws {
-        // Full cycle without bridge: training is skipped, eval uses zero deltas,
-        // review passes (all zeros ≥ 0), cycle pauses in proposing.
+    func testNilBridgeCycleFailsClosedWithNoMeasurement() async throws {
+        // P9/C4 (W1): the previous "zero deltas ⇒ review passes ⇒ proposing ⇒
+        // approve ⇒ deploy" path was the unsafe hole. With no bridge the eval is
+        // UNMEASURED and the gate fails closed: the cycle returns to idle, there is
+        // no proposal, and an approve attempt is refused (no un-gated deploy).
         let store = try await makeTempStore()
         let coordinator = makeCoordinator(store: store)
         try await seedSufficientData(store: store)
@@ -898,16 +1044,17 @@ final class ImprovementCycleCoordinatorTests: XCTestCase {
         try await coordinator.runCycle()
 
         let state = try await coordinator.currentState()
-        XCTAssertEqual(state, .proposing)
+        XCTAssertEqual(state, .idle, "Unmeasured cycle fails closed to idle, never proposing")
 
-        // Approve deployment to verify the full path works.
-        try await coordinator.approveDeployment()
-        let afterApproval = try await coordinator.currentState()
-        XCTAssertEqual(afterApproval, .idle)
+        // Not in proposing ⇒ approveDeployment must refuse (no un-gated deploy).
+        do {
+            try await coordinator.approveDeployment()
+            XCTFail("approveDeployment should throw when the cycle is not in proposing")
+        } catch {
+            // expected: invalidTransition
+        }
 
-        // Check userApprovedCycles incremented.
         let storedState = try await store.readState()
-        XCTAssertEqual(storedState.userApprovedCycles, 1)
-        XCTAssertEqual(storedState.completedCycles, 1)
+        XCTAssertNil(storedState.currentAdapterPath, "Nothing should be deployed")
     }
 }

--- a/native/macos/Fae/Tests/HandoffTests/ImprovementLoopIntegrationTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/ImprovementLoopIntegrationTests.swift
@@ -80,14 +80,13 @@ final class ImprovementLoopIntegrationTests: XCTestCase {
 
         let coordinator = ImprovementCycleCoordinator(store: store)
 
-        // Observe that state machine passed through at least collecting.
-        // After runCycle with 0 approved cycles: ends in .proposing.
+        // P9/C4 (W1): with no evaluator wired, the cycle is fail-closed (unmeasured
+        // ⇒ blocked before review) and ends in .idle — NOT proposing. This exact
+        // assertion would catch a regression where an unmeasured cycle reaches
+        // proposing again.
         try await coordinator.runCycle()
         let finalState = try await coordinator.currentState()
-        XCTAssertTrue(
-            finalState == .proposing || finalState == .idle,
-            "Cycle should end in proposing or idle, got \(finalState)"
-        )
+        XCTAssertEqual(finalState, .idle, "Unmeasured cycle must fail closed to idle, not proposing")
     }
 
     // MARK: - Directive Tuning Round-Trip
@@ -216,30 +215,40 @@ final class ImprovementLoopIntegrationTests: XCTestCase {
 
     func testAdapterPathPersistedThroughApproveAndRollback() async throws {
         let store = try await makeTempStore()
-        try await seedEvents(store: store, corrections: 8, reasksAndOthers: 15)
+        try await store.ensureStateRow()
+
+        // Post-training proposing state (P9/C4 W3): a deployed adapter in
+        // currentAdapterPath + the candidate in pendingAdapterPath. A real cycle can
+        // only produce a pending via the training bridge (W7/W8), so set it up
+        // directly here and exercise the approve → rollback lineage.
+        var state = try await store.readState()
+        state.currentAdapterPath = "/tmp/old_adapter"
+        state.pendingAdapterPath = "/tmp/new_candidate"
+        try await store.writeState(state)
 
         var patchedPath: String? = "not-called"
         let coordinator = ImprovementCycleCoordinator(store: store)
         await coordinator.setAdapterPatchCallback { path in patchedPath = path }
-
-        // Seed current adapter path.
-        var state = try await store.readState()
-        state.currentAdapterPath = "/tmp/old_adapter"
-        try await store.writeState(state)
-
-        // Run cycle → should pause in proposing.
-        try await coordinator.runCycle()
-        let cycleState = try await coordinator.currentState()
-        guard cycleState == .proposing else {
-            // Cycle may have gone to idle (insufficient data in some edge cases) — skip.
-            return
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
         }
 
         try await coordinator.approveDeployment()
 
-        // After approval, state should be idle.
-        let postApproveState = try await coordinator.currentState()
-        XCTAssertEqual(postApproveState, .idle, "After approval, should return to idle")
+        // After approval: candidate promoted to current, prior is the rollback target,
+        // pending cleared, pipeline notified.
+        let deployed = try await store.readState()
+        XCTAssertEqual(deployed.currentAdapterPath, "/tmp/new_candidate", "Candidate promoted on deploy")
+        XCTAssertEqual(deployed.previousAdapterPath, "/tmp/old_adapter", "Prior is the rollback target")
+        XCTAssertNil(deployed.pendingAdapterPath, "Pending cleared after deploy")
+        XCTAssertEqual(patchedPath, "/tmp/new_candidate", "Pipeline notified of the deployed adapter")
+
+        // Rollback returns to the prior deployed adapter (lineage preserved — the W3
+        // split fixed the bug where previous was set to the candidate itself).
+        try await coordinator.rollback()
+        let rolledBack = try await store.readState()
+        XCTAssertEqual(rolledBack.currentAdapterPath, "/tmp/old_adapter", "Rollback restores the prior deployed adapter")
+        XCTAssertEqual(rolledBack.previousAdapterPath, "/tmp/new_candidate", "Swap is symmetric")
     }
 
     // MARK: - isDirectiveTuningCycle Logic

--- a/native/macos/Fae/Tests/HandoffTests/ImprovementLoopIntegrationTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/ImprovementLoopIntegrationTests.swift
@@ -271,6 +271,111 @@ final class ImprovementLoopIntegrationTests: XCTestCase {
         XCTAssertEqual(rolledBack.previousAdapterPath, candidate, "Swap is symmetric")
     }
 
+    // MARK: - W7a: evaluator-minted receipt deploys end to end (mlxDir lane)
+
+    /// The receipt the eval phase mints (via the REAL `mintAndStoreGateReceipt`) for an
+    /// mlxDir candidate must be accepted end to end by the W4 deploy gate's REAL
+    /// `GateReceiptVerifier` — proving the W7a evaluator and the W4 fence agree on path,
+    /// digest, kind, and evaluator allowlist. Why this matters: before W7 NO production
+    /// path minted a receipt, so every gated deploy blocked; W7a is the link that lets a
+    /// genuinely-evaluated mlx adapter deploy (and only such an adapter).
+    func testMlxEvaluatorMintedReceiptDeploysThroughRealGate() async throws {
+        let store = try await makeTempStore()
+        let gateTestKey = SymmetricKey(data: Data(repeating: 0x42, count: 32))
+
+        // A real on-disk mlxDir candidate (directory + file) so the digest verifies later.
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("fae-w7-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "weights".write(
+            toFile: dir.appendingPathComponent("adapters.safetensors").path,
+            atomically: true, encoding: .utf8
+        )
+        let candidate = dir.path
+
+        try await store.ensureStateRow()
+        var state = try await store.readState()
+        state.currentAdapterPath = "/tmp/deployed_mlx"   // the live baseline
+        state.pendingAdapterPath = candidate
+        state.pendingAdapterKind = "mlxDir"
+        state.pendingCycleId = "w7-cyc"
+        try await store.writeState(state)
+
+        var patchedPath: String? = "not-called"
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        await coordinator.setAdapterPatchCallback { path in patchedPath = path }
+        await coordinator.setInjectedGateKey(gateTestKey)
+        // mlx lane ⇒ no daemon base model ⇒ performDeploy expects kind == .mlxDir.
+
+        // Drive the REAL mint the eval phase uses (FaeBenchmarkEvaluator id, mlxDir kind),
+        // binding the receipt to the live pending candidate + digest.
+        let measured = MeasuredDeltas(
+            measured: [.toolCalling: 4.0, .faeCapability: 2.0, .assistantFit: 3.0, .serialization: 1.0],
+            throughputDelta: 5.0
+        )
+        try await coordinator.mintAndStoreGateReceipt(
+            context: ImprovementCycleCoordinator.ReceiptMintContext(
+                kind: .mlxDir, evaluatorId: "FaeBenchmarkEvaluator",
+                baseModelId: "/tmp/deployed_mlx", evalSuiteVersion: "faebench-v1"
+            ),
+            measured: measured
+        )
+
+        // Walk to proposing, then approve — performDeploy verifies the minted receipt
+        // through the REAL GateReceiptVerifier (no bypass).
+        for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
+            try await coordinator.transition(to: s)
+        }
+        try await coordinator.approveDeployment()
+
+        let deployed = try await store.readState()
+        XCTAssertEqual(deployed.currentAdapterPath, candidate, "mlx candidate promoted through the real gate")
+        XCTAssertEqual(deployed.previousAdapterPath, "/tmp/deployed_mlx", "Prior deployed adapter is the rollback target")
+        XCTAssertNil(deployed.pendingAdapterPath, "Pending cleared after deploy")
+        XCTAssertEqual(patchedPath, candidate, "Pipeline notified of the deployed adapter")
+        let consumed = try await store.isGateReceiptConsumed(cycleId: "w7-cyc")
+        XCTAssertTrue(consumed, "Evaluator-minted receipt consumed exactly once on deploy")
+    }
+
+    /// A receipt minted with a NON-allowlisted evaluator id can never verify — the deploy
+    /// gate rejects it. Guards the privilege boundary: the loss-proxy (or any future
+    /// non-evaluator) cannot forge a deployable receipt.
+    func testReceiptFromNonAllowlistedEvaluatorIsRejected() async throws {
+        let store = try await makeTempStore()
+        let coordinator = ImprovementCycleCoordinator(store: store)
+        let gateTestKey = SymmetricKey(data: Data(repeating: 0x42, count: 32))
+
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("fae-w7r-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try "weights".write(
+            toFile: dir.appendingPathComponent("adapters.safetensors").path,
+            atomically: true, encoding: .utf8
+        )
+        try await store.ensureStateRow()
+        var state = try await store.readState()
+        state.pendingAdapterPath = dir.path
+        state.pendingAdapterKind = "mlxDir"
+        state.pendingCycleId = "w7r-cyc"
+        try await store.writeState(state)
+        await coordinator.setInjectedGateKey(gateTestKey)
+
+        do {
+            _ = try await coordinator.mintAndStoreGateReceipt(
+                context: ImprovementCycleCoordinator.ReceiptMintContext(
+                    kind: .mlxDir, evaluatorId: "loss-proxy",   // NOT on the allowlist
+                    baseModelId: "x", evalSuiteVersion: "v1"
+                ),
+                measured: MeasuredDeltas(
+                    measured: [.toolCalling: 1.0, .faeCapability: 1.0, .assistantFit: 1.0, .serialization: 1.0],
+                    throughputDelta: nil
+                )
+            )
+            XCTFail("Minting with a non-allowlisted evaluator must throw")
+        } catch let error as GateReceiptError {
+            if case .evaluatorNotAllowed = error { return }
+            XCTFail("Expected .evaluatorNotAllowed, got \(error)")
+        }
+    }
+
     // MARK: - isDirectiveTuningCycle Logic
 
     func testDirectiveTuningCycleIntervalIsCorrect() {

--- a/native/macos/Fae/Tests/HandoffTests/ImprovementLoopIntegrationTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/ImprovementLoopIntegrationTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import XCTest
 @testable import Fae
 
@@ -217,18 +218,35 @@ final class ImprovementLoopIntegrationTests: XCTestCase {
         let store = try await makeTempStore()
         try await store.ensureStateRow()
 
-        // Post-training proposing state (P9/C4 W3): a deployed adapter in
-        // currentAdapterPath + the candidate in pendingAdapterPath. A real cycle can
-        // only produce a pending via the training bridge (W7/W8), so set it up
-        // directly here and exercise the approve → rollback lineage.
+        // Post-training proposing state (P9/C4): a deployed adapter in currentAdapterPath
+        // + a candidate in pendingAdapterPath. A deploy now REQUIRES a verifying gate
+        // receipt (W4), so mint one for a real candidate file. A real cycle produces the
+        // pending + receipt via the training bridge + evaluator (W7/W8).
+        let gateTestKey = SymmetricKey(data: Data(repeating: 0x42, count: 32))
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("fae-int-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let candidate = dir.appendingPathComponent("adapter.gguf").path
+        try "weights".write(toFile: candidate, atomically: true, encoding: .utf8)
+        let receipt = try GateMinter.mint(
+            cycleId: "int-cyc", candidatePath: candidate, kind: .gguf,
+            measured: [.toolCalling: 3.0, .faeCapability: 1.0, .assistantFit: 2.0, .serialization: 0.0],
+            evaluatorId: "DaemonABEvaluator", baseModelId: "gemma-test",
+            evalSuiteVersion: "v1", mintedAt: "2026-06-22T00:00:00Z", using: gateTestKey
+        )
+        try await store.insertGateReceipt(receipt)
+
         var state = try await store.readState()
         state.currentAdapterPath = "/tmp/old_adapter"
-        state.pendingAdapterPath = "/tmp/new_candidate"
+        state.pendingAdapterPath = candidate
+        state.pendingAdapterKind = "gguf"
+        state.pendingCycleId = "int-cyc"
         try await store.writeState(state)
 
         var patchedPath: String? = "not-called"
         let coordinator = ImprovementCycleCoordinator(store: store)
         await coordinator.setAdapterPatchCallback { path in patchedPath = path }
+        await coordinator.setInjectedGateKey(gateTestKey)
+        await coordinator.setDaemonTrainingBaseModel("gemma-test") // gguf lane
         for s in [CycleState.collecting, .metaOptimizing, .training, .evaluating, .proposing] {
             try await coordinator.transition(to: s)
         }
@@ -236,19 +254,21 @@ final class ImprovementLoopIntegrationTests: XCTestCase {
         try await coordinator.approveDeployment()
 
         // After approval: candidate promoted to current, prior is the rollback target,
-        // pending cleared, pipeline notified.
+        // pending cleared, pipeline notified, receipt consumed.
         let deployed = try await store.readState()
-        XCTAssertEqual(deployed.currentAdapterPath, "/tmp/new_candidate", "Candidate promoted on deploy")
+        XCTAssertEqual(deployed.currentAdapterPath, candidate, "Candidate promoted on deploy")
         XCTAssertEqual(deployed.previousAdapterPath, "/tmp/old_adapter", "Prior is the rollback target")
         XCTAssertNil(deployed.pendingAdapterPath, "Pending cleared after deploy")
-        XCTAssertEqual(patchedPath, "/tmp/new_candidate", "Pipeline notified of the deployed adapter")
+        XCTAssertEqual(patchedPath, candidate, "Pipeline notified of the deployed adapter")
+        let consumed = try await store.isGateReceiptConsumed(cycleId: "int-cyc")
+        XCTAssertTrue(consumed, "Receipt consumed after deploy")
 
         // Rollback returns to the prior deployed adapter (lineage preserved — the W3
         // split fixed the bug where previous was set to the candidate itself).
         try await coordinator.rollback()
         let rolledBack = try await store.readState()
         XCTAssertEqual(rolledBack.currentAdapterPath, "/tmp/old_adapter", "Rollback restores the prior deployed adapter")
-        XCTAssertEqual(rolledBack.previousAdapterPath, "/tmp/new_candidate", "Swap is symmetric")
+        XCTAssertEqual(rolledBack.previousAdapterPath, candidate, "Swap is symmetric")
     }
 
     // MARK: - isDirectiveTuningCycle Logic


### PR DESCRIPTION
## What this closes

A **real unsafe-deploy hole** in the nightly self-improvement loop: a freshly-trained LoRA adapter could be promoted into the live `currentAdapterPath` with **no real evaluation** — an all-nil/all-zero `EvalDelta` passed the gate, and training overwrote the deployed pointer before eval.

After this series: **no path writes `currentAdapterPath` without a verifying, unconsumed, tamper-evident `GateReceipt` minted by an allowlisted real evaluator.** Both adapter lanes (MLX `.mlxDir` and daemon `.gguf`) now have real evaluators.

## Stages (each gated through external review)

**Safety series (W1–W6)** — fail-closed gate rule + tamper-evident receipts:
- **W1+W3** — fail-closed `AdapterGate.decide` (all-nil/all-flat/partial → block); pending/current state split so training writes `pendingAdapterPath` only and `performDeploy` is the sole writer of `currentAdapterPath`.
- **W2** — `GateReceipt` (Codable, HMAC-signed via Keychain), `GateArtifactDigest` (gguf=file SHA, mlxDir=content manifest), `GateMinter` (evaluator allowlist), `GateReceiptVerifier`, `gate_receipts` table.
- **W4** — deploy fencing: `performDeploy` requires a verifying+unconsumed receipt; atomic `promoteAndConsumeReceipt` (single-use, TOCTOU-safe); manual override routed to an audited out-of-gate hatch.
- **W5** — stale-state recovery on upgrade/crash; shadow-eval pinned to the deployed adapter (not the pending candidate).
- **W6** — refuse to train a lane that has no evaluator.

**Capability series (W7) — real evaluators that let the gate pass again:**
- **W7a** (`4699e43d`) — `AdapterEvaluator` seam + `FaeBenchmarkEvaluator` (MLX lane): scores the candidate against the **deployed** adapter (not base), mints the receipt only after the fail-closed gate accepts; a gate pass with no minted receipt now fail-closes immediately. Fixes FaeBenchmark `--model auto`.
- **W7b** (`a91d9e6d`) — `DaemonABEvaluator` (gguf lane): A/B-tests the live llama.cpp daemon (reload-per-phase: deployed → candidate) over a SHA-locked held-out eval set. **Restore-on-every-exit** safety property — the deployed adapter is restored + confirmed via `runtime.status` on every exit path, so the live daemon is never left serving the un-gated candidate. No new daemon command / no Rust changes.

**DoD (W8)** (`74c0758d`) — tests-only golden production-wiring E2E on the **real object graph** (real coordinator/store/minter/verifier + production `setAdapterEvaluator`): no-evaluator → review never entered + live path untouched; real-evaluator pass → real mint→verify→atomic promote+consume. Plus coordinator-level tamper, forgery (wrong-key HMAC + non-allowlisted evaluator), replay (consumed + cross-cycle), `AdapterGate.decide` truth table, receipt-write-fails-loud. Each test fails if the hole is reopened.

## Verification
- **176 filtered tests green** (`ImprovementCycleCoordinatorTests|ImprovementLoopIntegrationTests|ImprovementStoreTests|GateReceiptTests|AdapterDeploymentManagerTests|ShadowEvaluatorTests|AdapterEvaluatorTests|DaemonABEvaluatorTests|GateGoldenWiringTests`); `just build` green.
- Every stage reviewed by Codex (gpt-5.5 xhigh) — PASS.

## Deferred (human-in-loop, not runnable headlessly — NOT blocking merge)
- **Live daemon A/B de-risk** (gguf): real daemon + real GGUF adapters over the held-out suite (like P3/C3's `~/llama-spike`). `DaemonABEvaluator` is unit-proven via a mock client only.
- **Eval-set discrimination quality** (`daemon-ab-eval-v1.json`, 32 examples): confirm it separates a good vs bad adapter on real hardware.
- F7 (manual-override audit-emission test) + F8 (`--model auto` accepted-path, needs the benchmark binary) — Codex-confirmed legitimate out-of-gate / subprocess concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the unsafe auto-deploy hole in the nightly self-improvement loop: a freshly trained LoRA adapter can no longer be promoted to `currentAdapterPath` without a verifying, single-use, HMAC-signed `GateReceipt` minted by an allowlisted real evaluator. The core mechanism is a pending/current state split (training only writes `pendingAdapterPath`), an atomic `promoteAndConsumeReceipt` SQL transaction that prevents both missing-receipt and double-spend, and two real evaluators (`FaeBenchmarkEvaluator` for the MLX lane, `DaemonABEvaluator` with restore-on-every-exit for the GGUF lane).

- **Gate receipt system (W1–W4):** `AdapterGate.decide` fails closed on all-nil and all-flat deltas; `GateMinter`/`GateReceiptVerifier` use HMAC-SHA256 over a canonical sorted-key JSON payload with a Keychain-resident key and an on-disk artifact digest; `promoteAndConsumeReceipt` makes deploy + single-use consumption atomic in one SQL transaction.
- **Real evaluators (W7a/W7b):** `FaeBenchmarkEvaluator` scores the candidate against the deployed baseline (not base model); `DaemonABEvaluator` A/B-tests the live daemon with a SHA-locked held-out suite and restores the deployed adapter on every exit path.
- **Recovery and wiring (W5/W6/W8):** Stale-state recovery runs once before the first cycle (awaited, not fire-and-forget); lanes without a working evaluator refuse to train; E2E golden tests exercise the full mint→verify→atomic-promote chain on the real object graph.

<h3>Confidence Score: 3/5</h3>

The core gate invariant is correctly enforced through the coordinator's deploy path; two issues in the new utility and eval-scorer code need fixing before production traffic hits them.

The `DaemonABEvaluator`'s `firstJSON` bracket-counter doesn't skip characters inside quoted strings, so any model output that includes a `}` or `]` inside a string value causes the extractor to stop early, `JSONSerialization` fails, and the example is marked incorrect — good adapters get blocked at the gate. Separately, `AdapterDeploymentManager.deploy` writes the promoted state through `promoteAndConsumeReceipt` without first clearing `pendingAdapterPath`, `pendingAdapterKind`, and `pendingCycleId`, leaving stale pending state that could confuse `recoverStaleStateIfNeeded` or the next cycle start. The coordinator's own `performDeploy` nulls these fields explicitly before the same call; the utility omits the cleanup.

`DaemonABEvaluator.swift` (firstJSON scorer), `AdapterDeploymentManager.swift` (pending-state cleanup and self-referential expectedCandidatePath).

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift | Deploy now requires a verifying receipt; two issues: the self-referential `expectedCandidatePath` check is a no-op, and `pendingAdapterPath`/`pendingAdapterKind`/`pendingCycleId` are not cleared before calling `promoteAndConsumeReceipt`, leaving stale pending state after a deploy via this utility. |
| native/macos/Fae/Sources/Fae/Scheduler/DaemonABEvaluator.swift | New file: A/B daemon evaluator with restore-on-every-exit safety property; the `firstJSON` bracket-counter doesn't handle braces/brackets inside JSON string values, causing false-negative scoring for `expectJSONKeys`/`expectJSONArray` examples when model output has embedded special chars. |
| native/macos/Fae/Sources/Fae/Scheduler/ImprovementCycleCoordinator.swift | Core gate enforcement: pending/current state split, fail-closed gate, receipt mint→store→consume chain, and stale-state recovery are all correctly implemented; test seams are cleanly isolated from the production paths. |
| native/macos/Fae/Sources/Fae/Scheduler/GateReceipt.swift | New file: HMAC-signed tamper-evident gate receipt with artifact digest binding; minter, verifier, and Keychain-backed key management are all well-structured with proper constant-time HMAC comparison. |
| native/macos/Fae/Sources/Fae/Memory/ImprovementStore.swift | Adds `pendingAdapterPath/Kind/CycleId` columns with migrations, `gate_receipts` table, and atomic `promoteAndConsumeReceipt` (WHERE-based single-use enforcement); all paths look correct. |
| native/macos/Fae/Sources/Fae/Memory/ExternalReviewGate.swift | Internal reviewer now delegates to `AdapterGate.decide` (fail-closed), adding `blockedNoMeasurement` verdict mapping; `GateDimension`, `MeasuredDeltas`, `AdapterGate`, and `EvalDelta` extensions added cleanly. |
| native/macos/Fae/Sources/Fae/Scheduler/AdapterEvaluator.swift | New file: `AdapterEvaluator` protocol seam and `FaeBenchmarkEvaluator`; baseline is correctly set to the deployed adapter (not base model), and error paths map to `measurementFailed` for uniform fail-closed handling. |
| native/macos/Fae/Sources/Fae/Scheduler/FaeScheduler.swift | Wires W7a/W7b evaluators with correct availability guards, runs stale-state recovery once before the first cycle (awaited, not fire-and-forget), and stores the daemon engine reference. |
| native/macos/Fae/Tests/HandoffTests/GateGoldenWiringTests.swift | New file: E2E production-wiring tests covering no-evaluator block, real-evaluator pass+consume, tamper/forgery/replay scenarios, and the AdapterGate truth table — a thorough DoD gate. |
| native/macos/Fae/Sources/Fae/Core/FaeCore.swift | Passes daemon engine to scheduler for W7b; adds audited out-of-gate hatch for manual adapter overrides with security event logged before the swap within the same Task. |
| native/macos/Fae/Sources/FaeBenchmark/main.swift | Adds `--model auto` resolution that mirrors the app's RAM-based preset selection; fails loudly if the expected Qwen3.5 short name is missing from the registry. |
| native/macos/Fae/Sources/Fae/ML/DaemonLLMEngine.swift | Adds `runtimeStatus()` for adapter confirm-after-restore and `inferForEval` for the A/B harness; both are thin wrappers over existing protocol machinery. |

</details>


</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Sched as FaeScheduler
    participant Coord as ImprovementCycleCoordinator
    participant Eval as AdapterEvaluator (W7a/W7b)
    participant Minter as GateMinter
    participant Store as ImprovementStore
    participant Verifier as GateReceiptVerifier

    Sched->>Coord: runCycle()
    Coord->>Store: "writeState(pendingAdapterPath=candidate)"
    Coord->>Eval: "evaluate(candidatePath, baselinePath=deployed)"
    Eval-->>Coord: GateOutcome(delta, baseModelId, evalSuiteVersion)
    Coord->>Coord: AdapterGate.decide — all-nil/flat → blockedNoMeasurement → failClosed()
    Coord->>Minter: mint(cycleId, candidatePath, measured, evaluatorId, ...)
    Minter->>Minter: digest artifact + HMAC-sign payload (Keychain key)
    Minter-->>Coord: GateReceipt
    Coord->>Store: insertGateReceipt(receipt)
    Coord->>Coord: External review gate
    Coord->>Coord: performDeploy()
    Coord->>Store: "readState() → pendingAdapterPath=candidate"
    Coord->>Store: gateReceipt(cycleId) + isGateReceiptConsumed?
    Coord->>Verifier: "verify(receipt, expectedCandidatePath=pendingAdapterPath)"
    Verifier->>Verifier: check decision, allowlist, policyVersion, candidatePath, HMAC, on-disk digest
    Verifier-->>Coord: OK (or throw)
    Coord->>Store: "promoteAndConsumeReceipt — UPDATE consumed_at WHERE NULL + upsertState(current=candidate, pending=nil)"
    Store-->>Coord: committed
    Coord->>Coord: adapterPatchCallback(currentAdapterPath)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Sched as FaeScheduler
    participant Coord as ImprovementCycleCoordinator
    participant Eval as AdapterEvaluator (W7a/W7b)
    participant Minter as GateMinter
    participant Store as ImprovementStore
    participant Verifier as GateReceiptVerifier

    Sched->>Coord: runCycle()
    Coord->>Store: "writeState(pendingAdapterPath=candidate)"
    Coord->>Eval: "evaluate(candidatePath, baselinePath=deployed)"
    Eval-->>Coord: GateOutcome(delta, baseModelId, evalSuiteVersion)
    Coord->>Coord: AdapterGate.decide — all-nil/flat → blockedNoMeasurement → failClosed()
    Coord->>Minter: mint(cycleId, candidatePath, measured, evaluatorId, ...)
    Minter->>Minter: digest artifact + HMAC-sign payload (Keychain key)
    Minter-->>Coord: GateReceipt
    Coord->>Store: insertGateReceipt(receipt)
    Coord->>Coord: External review gate
    Coord->>Coord: performDeploy()
    Coord->>Store: "readState() → pendingAdapterPath=candidate"
    Coord->>Store: gateReceipt(cycleId) + isGateReceiptConsumed?
    Coord->>Verifier: "verify(receipt, expectedCandidatePath=pendingAdapterPath)"
    Verifier->>Verifier: check decision, allowlist, policyVersion, candidatePath, HMAC, on-disk digest
    Verifier-->>Coord: OK (or throw)
    Coord->>Store: "promoteAndConsumeReceipt — UPDATE consumed_at WHERE NULL + upsertState(current=candidate, pending=nil)"
    Store-->>Coord: committed
    Coord->>Coord: adapterPatchCallback(currentAdapterPath)
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `native/macos/Fae/Sources/Fae/Scheduler/DaemonABEvaluator.swift`, line 798-818 ([link](https://github.com/saorsa-labs/fae/blob/4f5f4a232b6479c035bba698865b77ad1734a43d/native/macos/Fae/Sources/Fae/Scheduler/DaemonABEvaluator.swift#L798-L818)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Naive bracket-counter mismatch on JSON strings with embedded braces**

   `firstJSON` counts `{`/`}` and `[`/`]` characters as depth-markers but never skips characters inside quoted strings. A model response like `{"name": "Alice }Smith", "age": 30}` causes `depth` to hit 0 at the `}` inside the string, so `firstJSON` extracts the invalid slice `{"name": "Alice `, which `JSONSerialization` rejects, and the function returns `nil`. The example is then scored as incorrect even though the model's answer was valid. This applies to both `expectJSONKeys` and `expectJSONArray` scorers — any LLM output whose string values happen to contain a closing bracket/brace triggers a silent false-negative, and these systematic false negatives in the eval gate would block a better adapter from deploying.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: native/macos/Fae/Sources/Fae/Scheduler/DaemonABEvaluator.swift
   Line: 798-818

   Comment:
   **Naive bracket-counter mismatch on JSON strings with embedded braces**

   `firstJSON` counts `{`/`}` and `[`/`]` characters as depth-markers but never skips characters inside quoted strings. A model response like `{"name": "Alice }Smith", "age": 30}` causes `depth` to hit 0 at the `}` inside the string, so `firstJSON` extracts the invalid slice `{"name": "Alice `, which `JSONSerialization` rejects, and the function returns `nil`. The example is then scored as incorrect even though the model's answer was valid. This applies to both `expectJSONKeys` and `expectJSONArray` scorers — any LLM output whose string values happen to contain a closing bracket/brace triggers a silent false-negative, and these systematic false negatives in the eval gate would block a better adapter from deploying.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift`, line 43-56 ([link](https://github.com/saorsa-labs/fae/blob/4f5f4a232b6479c035bba698865b77ad1734a43d/native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift#L43-L56)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`pendingAdapterPath` / `pendingAdapterKind` / `pendingCycleId` not cleared after deploy**

   After a successful deploy, the function updates `previousAdapterPath` and `currentAdapterPath` but writes the state through `promoteAndConsumeReceipt` without first setting `pendingAdapterPath = nil`, `pendingAdapterKind = nil`, and `pendingCycleId = nil`. If this utility is called while a pending candidate exists in the store, those three fields survive the deploy unchanged. The coordinator's cycle-start cleanup would clear them on the next run, but `recoverStaleStateIfNeeded` could see a non-nil `pendingAdapterPath` alongside an already-deployed `currentAdapterPath` and apply its stale-state repair logic incorrectly. The coordinator's own `performDeploy` explicitly nulls these three fields before calling `promoteAndConsumeReceipt`; this utility path should do the same to preserve the idle-state invariant.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift
   Line: 43-56

   Comment:
   **`pendingAdapterPath` / `pendingAdapterKind` / `pendingCycleId` not cleared after deploy**

   After a successful deploy, the function updates `previousAdapterPath` and `currentAdapterPath` but writes the state through `promoteAndConsumeReceipt` without first setting `pendingAdapterPath = nil`, `pendingAdapterKind = nil`, and `pendingCycleId = nil`. If this utility is called while a pending candidate exists in the store, those three fields survive the deploy unchanged. The coordinator's cycle-start cleanup would clear them on the next run, but `recoverStaleStateIfNeeded` could see a non-nil `pendingAdapterPath` alongside an already-deployed `currentAdapterPath` and apply its stale-state repair logic incorrectly. The coordinator's own `performDeploy` explicitly nulls these three fields before calling `promoteAndConsumeReceipt`; this utility path should do the same to preserve the idle-state invariant.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
native/macos/Fae/Sources/Fae/Scheduler/DaemonABEvaluator.swift:798-818
**Naive bracket-counter mismatch on JSON strings with embedded braces**

`firstJSON` counts `{`/`}` and `[`/`]` characters as depth-markers but never skips characters inside quoted strings. A model response like `{"name": "Alice }Smith", "age": 30}` causes `depth` to hit 0 at the `}` inside the string, so `firstJSON` extracts the invalid slice `{"name": "Alice `, which `JSONSerialization` rejects, and the function returns `nil`. The example is then scored as incorrect even though the model's answer was valid. This applies to both `expectJSONKeys` and `expectJSONArray` scorers — any LLM output whose string values happen to contain a closing bracket/brace triggers a silent false-negative, and these systematic false negatives in the eval gate would block a better adapter from deploying.

### Issue 2 of 3
native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift:43-56
**`pendingAdapterPath` / `pendingAdapterKind` / `pendingCycleId` not cleared after deploy**

After a successful deploy, the function updates `previousAdapterPath` and `currentAdapterPath` but writes the state through `promoteAndConsumeReceipt` without first setting `pendingAdapterPath = nil`, `pendingAdapterKind = nil`, and `pendingCycleId = nil`. If this utility is called while a pending candidate exists in the store, those three fields survive the deploy unchanged. The coordinator's cycle-start cleanup would clear them on the next run, but `recoverStaleStateIfNeeded` could see a non-nil `pendingAdapterPath` alongside an already-deployed `currentAdapterPath` and apply its stale-state repair logic incorrectly. The coordinator's own `performDeploy` explicitly nulls these three fields before calling `promoteAndConsumeReceipt`; this utility path should do the same to preserve the idle-state invariant.

### Issue 3 of 3
native/macos/Fae/Sources/Fae/Scheduler/AdapterDeploymentManager.swift:126-131
**Self-referential `expectedCandidatePath` makes the candidate-path guard a tautology**

`GateReceiptVerifier.verify` checks `receipt.candidatePath == expectedCandidatePath` to ensure the receipt was issued for the specific artifact the caller intends to deploy. Passing `receipt.candidatePath` as that argument makes the check always `true`. The defense-in-depth layer (independent path binding) is neutralized for this deploy path; protection falls entirely on HMAC + artifact digest. The `ImprovementCycleCoordinator` correctly passes the independently-read `pendingAdapterPath` from state as the expected path. This utility should accept the intended candidate path as a separate parameter.

```suggestion
    static func deploy(
        receipt: GateReceipt, expectedCandidatePath: String, store: ImprovementStore, verifyingWith key: SymmetricKey
    ) async throws {
        try GateReceiptVerifier.verify(
            receipt, expectedCandidatePath: expectedCandidatePath, using: key
        )
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(training): P9/C4 — open-gaps status..."](https://github.com/saorsa-labs/fae/commit/4f5f4a232b6479c035bba698865b77ad1734a43d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39013792)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->