### PR TITLE
P9/C4 — daemon-A/B live de-risk harness + first-run results

### DIFF
--- a/crates/fae-engine/examples/daemon_ab_derisk.rs
+++ b/crates/fae-engine/examples/daemon_ab_derisk.rs
@@ -1,0 +1,373 @@
+//! P9/C4 HEADLESS LIVE DE-RISK (manual only — NOT a test, never runs in CI).
+//!
+//! Proves the two things only real hardware can show about the gguf-lane A/B
+//! eval gate (`DaemonABEvaluator`):
+//!   1. the real llama.cpp scale-0/1 + reload mechanism A/Bs a real GGUF LoRA
+//!      end-to-end and yields a MEASURED per-dimension delta (not "blocked"),
+//!   2. the bundled held-out eval set `daemon-ab-eval-v1.json` actually
+//!      DISCRIMINATES — a different adapter scores measurably differently, not
+//!      identically.
+//!
+//! Mirrors `examples/llama_reload.rs`. Needs the `~/llama-spike` bench
+//! artifacts. Run manually:
+//! ```sh
+//! env -u RUSTFLAGS cargo run -p fae-engine --example daemon_ab_derisk
+//! ```
+//! Scoring rules are a faithful port of `DaemonEvalScorer.isCorrect` in
+//! `native/macos/Fae/Sources/Fae/Scheduler/DaemonABEvaluator.swift`.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use fae_engine::{
+    ChatEvent, ChatMessage, ChatRequest, LlamaModelSource, LlamaServerAdapter, LlamaServerConfig,
+    ProviderAdapter, Role, ToolSpec,
+};
+use futures_util::StreamExt;
+use serde_json::Value;
+
+const EVAL_JSON: &str =
+    include_str!("../../../native/macos/Fae/Sources/Fae/Resources/Models/daemon-ab-eval-v1.json");
+
+/// One scored inference: the model's text + any tool calls it emitted.
+struct Inference {
+    text: String,
+    tool_calls: Vec<(String, BTreeSet<String>)>, // (name, arg keys)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let home = std::env::var("HOME")?;
+
+    // Let `reload_adapter`'s confinement accept the bench adapters (they live in
+    // ~/llama-spike, not the app's personal-adapters dir). This is the documented
+    // FAE_PERSONAL_ADAPTERS_DIR override the daemon honours.
+    std::env::set_var("FAE_PERSONAL_ADAPTERS_DIR", format!("{home}/llama-spike"));
+
+    let base = format!("{home}/llama-spike/gguf/gemma-4-E4B-it-Q4_K_M.gguf");
+    let metric = format!("{home}/llama-spike/personal-metric.gguf");
+    let c2 = format!("{home}/llama-spike/personal-c2.gguf");
+    let server = format!("{home}/llama-spike/llama.cpp/build/bin/llama-server");
+
+    let examples = parse_examples(EVAL_JSON)?;
+    eprintln!("[derisk] loaded {} eval examples", examples.len());
+
+    // Spawn ONE sidecar: base model + personal-metric loaded but inactive
+    // (--lora-init-without-apply). scale 0 = base, scale 1 = personalized — the
+    // exact production "portable gate" the design names.
+    let config = LlamaServerConfig {
+        binary: server,
+        model: LlamaModelSource::Local {
+            model_gguf: base,
+            mmproj: None,
+            mtp_draft: None,
+        },
+        lora_gguf: Some(metric.clone()),
+        alias: "gemma-4-e4b".to_owned(),
+        enable_thinking: false, // deterministic, fast — no thinking span
+        mtp_draft_tokens: None,
+        port: 18133,
+        ctx_size: 4096,
+        ngl: 99,
+    };
+    eprintln!("[derisk] spawning sidecar (base + personal-metric loaded inactive)…");
+    let adapter = LlamaServerAdapter::spawn(config, "gemma-4-e4b").await?;
+
+    // --- Good-candidate A/B via the scale-0/1 portable gate -----------------
+    eprintln!("\n[derisk] === PHASE 1: scale-0 BASELINE (base model) ===");
+    adapter.set_adapter_scale(0.0)?;
+    let baseline = run_suite(&adapter, &examples).await?;
+    let base_acc = accuracy_by_dim(&baseline);
+
+    eprintln!("\n[derisk] === PHASE 2: scale-1 CANDIDATE (personal-metric) ===");
+    adapter.set_adapter_scale(1.0)?;
+    let candidate = run_suite(&adapter, &examples).await?;
+    let cand_acc = accuracy_by_dim(&candidate);
+
+    eprintln!("\n[derisk] === GOOD-CANDIDATE A/B (personal-metric scale1 − base scale0) ===");
+    print_delta_table(&base_acc, &cand_acc);
+
+    // --- Restore + confirm safety property ----------------------------------
+    eprintln!("\n[derisk] === RESTORE: scale back to 0 (base) ===");
+    adapter.set_adapter_scale(0.0)?;
+    match adapter.loaded_adapter() {
+        Some(la) => eprintln!(
+            "[derisk] loaded_adapter after restore: path={} scale={} sha={}…",
+            la.path,
+            la.scale,
+            &la.sha256.chars().take(12).collect::<String>()
+        ),
+        None => eprintln!("[derisk] loaded_adapter after restore: None (base only)"),
+    }
+
+    // --- Discrimination: a DIFFERENT adapter via the real reload primitive ---
+    // reload_adapter confines + SHA-hashes the path (the untrusted NDJSON path),
+    // then restarts the sidecar with --lora personal-c2.gguf.
+    eprintln!("\n[derisk] === PHASE 3: reload → personal-c2 (different adapter) ===");
+    adapter.reload_adapter(Some(c2.clone())).await?;
+    match adapter.loaded_adapter() {
+        Some(la) => eprintln!(
+            "[derisk] reloaded adapter: path={} sha={}… scale={}",
+            la.path,
+            &la.sha256.chars().take(12).collect::<String>(),
+            la.scale
+        ),
+        None => eprintln!("[derisk] WARNING: reload reported no loaded adapter"),
+    }
+    adapter.set_adapter_scale(1.0)?;
+    let c2_results = run_suite(&adapter, &examples).await?;
+    let c2_acc = accuracy_by_dim(&c2_results);
+    eprintln!("\n[derisk] === DISCRIMINATION A/B (personal-c2 scale1 − base scale0) ===");
+    print_delta_table(&base_acc, &c2_acc);
+
+    eprintln!("\n[derisk] === SUMMARY (per-dimension accuracy %) ===");
+    let mut dims: Vec<&String> = base_acc.keys().collect();
+    dims.sort();
+    eprintln!(
+        "{:<16} {:>10} {:>14} {:>12}",
+        "dimension", "base(s0)", "metric(s1)", "c2(s1)"
+    );
+    for d in &dims {
+        eprintln!(
+            "{:<16} {:>9.0}% {:>13.0}% {:>11.0}%",
+            d,
+            base_acc.get(*d).copied().unwrap_or(0.0) * 100.0,
+            cand_acc.get(*d).copied().unwrap_or(0.0) * 100.0,
+            c2_acc.get(*d).copied().unwrap_or(0.0) * 100.0,
+        );
+    }
+
+    // Restore to base for a clean exit.
+    adapter.reload_adapter(None).await?;
+    eprintln!("\n[derisk] restored to base; exit");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Eval harness
+// ---------------------------------------------------------------------------
+
+struct Example {
+    dimension: String,
+    system: String,
+    prompt: String,
+    tools: Vec<ToolSpec>,
+    scoring: Value,
+}
+
+fn parse_examples(json: &str) -> Result<Vec<Example>, Box<dyn std::error::Error>> {
+    let root: Value = serde_json::from_str(json)?;
+    let arr = root["examples"]
+        .as_array()
+        .ok_or("daemon-ab-eval-v1.json missing examples[]")?;
+    let mut out = Vec::new();
+    for e in arr {
+        let tools = e["tools"]
+            .as_array()
+            .map(|ts| {
+                ts.iter()
+                    .map(|t| ToolSpec {
+                        name: t["name"].as_str().unwrap_or_default().to_owned(),
+                        description: t["description"].as_str().unwrap_or_default().to_owned(),
+                        parameters: t["parameters"].clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        out.push(Example {
+            dimension: e["dimension"].as_str().unwrap_or_default().to_owned(),
+            system: e["system"].as_str().unwrap_or_default().to_owned(),
+            prompt: e["prompt"].as_str().unwrap_or_default().to_owned(),
+            tools,
+            scoring: e["scoring"].clone(),
+        });
+    }
+    Ok(out)
+}
+
+async fn run_suite(
+    adapter: &LlamaServerAdapter,
+    examples: &[Example],
+) -> Result<Vec<(String, bool)>, Box<dyn std::error::Error>> {
+    let mut results = Vec::new();
+    for (i, ex) in examples.iter().enumerate() {
+        let inf = run_one(adapter, ex).await?;
+        let correct = is_correct(&inf, &ex.scoring);
+        if i == 0 {
+            // Show one concrete prompt→output so the run is verifiable.
+            eprintln!(
+                "  [sample] prompt={:?}\n           text={:?} toolCalls={:?} correct={}",
+                ex.prompt,
+                inf.text.chars().take(160).collect::<String>(),
+                inf.tool_calls.iter().map(|(n, _)| n).collect::<Vec<_>>(),
+                correct
+            );
+        }
+        results.push((ex.dimension.clone(), correct));
+    }
+    Ok(results)
+}
+
+async fn run_one(
+    adapter: &LlamaServerAdapter,
+    ex: &Example,
+) -> Result<Inference, Box<dyn std::error::Error>> {
+    let request = ChatRequest {
+        system: Some(ex.system.clone()),
+        messages: vec![ChatMessage::text(Role::User, ex.prompt.clone())],
+        tools: ex.tools.clone(),
+        max_tokens: 256,
+    };
+    let mut stream = adapter.stream_chat(request).await?;
+    let mut text = String::new();
+    let mut tool_calls = Vec::new();
+    while let Some(event) = stream.next().await {
+        match event? {
+            ChatEvent::Token(t) => text.push_str(&t),
+            ChatEvent::ToolCall { name, arguments } => {
+                let keys: BTreeSet<String> = serde_json::from_str::<Value>(&arguments)
+                    .ok()
+                    .and_then(|v| v.as_object().map(|o| o.keys().cloned().collect()))
+                    .unwrap_or_default();
+                tool_calls.push((name, keys));
+            }
+            ChatEvent::Done { .. } => break,
+        }
+    }
+    Ok(Inference { text, tool_calls })
+}
+
+// ---------------------------------------------------------------------------
+// Scorer — faithful port of DaemonEvalScorer.isCorrect (Swift)
+// ---------------------------------------------------------------------------
+
+fn is_correct(inf: &Inference, scoring: &Value) -> bool {
+    let text = inf.text.trim();
+    let lower = text.to_lowercase();
+    match scoring["type"].as_str().unwrap_or_default() {
+        "expectToolCall" => {
+            let name = scoring["name"].as_str().unwrap_or_default();
+            let Some((_, keys)) = inf.tool_calls.iter().find(|(n, _)| n == name) else {
+                return false;
+            };
+            let required: BTreeSet<String> = scoring["requiredArgs"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(str::to_owned))
+                        .collect()
+                })
+                .unwrap_or_default();
+            required.is_subset(keys)
+        }
+        "expectNoToolCall" => inf.tool_calls.is_empty() && !text.is_empty(),
+        "expectLinesPrefixed" => {
+            let prefix = scoring["prefix"].as_str().unwrap_or_default();
+            let min = scoring["minLines"].as_u64().unwrap_or(1) as usize;
+            let matching = text
+                .lines()
+                .map(str::trim)
+                .filter(|l| l.starts_with(prefix))
+                .count();
+            matching >= min
+        }
+        "expectJSONKeys" => {
+            let Some(keys) = scoring["keys"].as_array() else {
+                return false;
+            };
+            let Some(obj) = first_json_object(text) else {
+                return false;
+            };
+            keys.iter()
+                .filter_map(|v| v.as_str())
+                .all(|k| obj.contains_key(k))
+        }
+        "expectJSONArray" => {
+            let min = scoring["minCount"].as_u64().unwrap_or(1) as usize;
+            first_json_array(text).is_some_and(|a| a.len() >= min)
+        }
+        "expectKeywords" => {
+            if contains_forbidden(&lower, scoring) {
+                return false;
+            }
+            let any_of: Vec<String> = scoring["anyOf"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            if any_of.is_empty() {
+                return !text.is_empty();
+            }
+            any_of.iter().any(|k| lower.contains(k))
+        }
+        "expectNonEmpty" => !contains_forbidden(&lower, scoring) && !text.is_empty(),
+        _ => false,
+    }
+}
+
+fn contains_forbidden(lower: &str, scoring: &Value) -> bool {
+    scoring["forbidden"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str())
+                .any(|f| lower.contains(&f.to_lowercase()))
+        })
+        .unwrap_or(false)
+}
+
+fn first_json_object(text: &str) -> Option<serde_json::Map<String, Value>> {
+    first_json(text, '{', '}').and_then(|v| v.as_object().cloned())
+}
+
+fn first_json_array(text: &str) -> Option<Vec<Value>> {
+    first_json(text, '[', ']').and_then(|v| v.as_array().cloned())
+}
+
+fn first_json(text: &str, open: char, close: char) -> Option<Value> {
+    let start = text.find(open)?;
+    let mut depth = 0i32;
+    for (offset, ch) in text[start..].char_indices() {
+        if ch == open {
+            depth += 1;
+        } else if ch == close {
+            depth -= 1;
+            if depth == 0 {
+                let slice = &text[start..start + offset + ch.len_utf8()];
+                return serde_json::from_str(slice).ok();
+            }
+        }
+    }
+    None
+}
+
+fn accuracy_by_dim(results: &[(String, bool)]) -> BTreeMap<String, f64> {
+    let mut counts: BTreeMap<String, (u32, u32)> = BTreeMap::new();
+    for (dim, ok) in results {
+        let c = counts.entry(dim.clone()).or_insert((0, 0));
+        c.1 += 1;
+        if *ok {
+            c.0 += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .map(|(d, (correct, total))| (d, f64::from(correct) / f64::from(total)))
+        .collect()
+}
+
+fn print_delta_table(base: &BTreeMap<String, f64>, cand: &BTreeMap<String, f64>) {
+    eprintln!(
+        "{:<16} {:>10} {:>12} {:>10}",
+        "dimension", "base%", "cand%", "Δ(pp)"
+    );
+    let mut dims: BTreeSet<&String> = base.keys().collect();
+    dims.extend(cand.keys());
+    for d in dims {
+        let b = base.get(d).copied().unwrap_or(0.0) * 100.0;
+        let c = cand.get(d).copied().unwrap_or(0.0) * 100.0;
+        eprintln!("{:<16} {:>9.0}% {:>11.0}% {:>+9.0}", d, b, c, c - b);
+    }
+}

--- a/docs/architecture/p9-c4-daemon-ab-live-derisk-2026-06-22.md
+++ b/docs/architecture/p9-c4-daemon-ab-live-derisk-2026-06-22.md
@@ -172,6 +172,47 @@ the app mid-eval, confirm `runtime.status` afterwards: it must report the deploy
 adapter, never the candidate. If it reports the candidate, that is a safety
 regression and the `restore-on-every-exit` design did not hold — stop and surface it.
 
+## Live de-risk run — 2026-06-22 (results)
+
+First live run on real hardware (Apple M5 Max), driven headlessly by
+`crates/fae-engine/examples/daemon_ab_derisk.rs` (a manual, non-CI harness that
+spawns the real `llama-server` sidecar and exercises the *actual* `fae-engine`
+`set_adapter_scale` / `reload_adapter` / `loaded_adapter` primitives — the same
+mechanism `DaemonABEvaluator` drives — bypassing only the Swift/NDJSON layer, which
+is already unit-proven). Base model `gemma-4-E4B-it-Q4_K_M.gguf`; adapters
+`~/llama-spike/personal-metric.gguf` and `personal-c2.gguf` (P3/C3 bench probes).
+Run it with `env -u RUSTFLAGS cargo run --release --manifest-path crates/Cargo.toml -p fae-engine --example daemon_ab_derisk`.
+
+Per-dimension accuracy:
+
+| dimension      | base (s0) | personal-metric (s1) | personal-c2 (s1) |
+|----------------|-----------|----------------------|------------------|
+| assistantFit   | 100%      | 88%                  | 88%              |
+| faeCapability  | 88%       | 88%                  | 88%              |
+| serialization  | 100%      | 100%                 | 100%             |
+| toolCalling    | 100%      | 100%                 | 100%             |
+
+**Legs proven (mechanism + safety):**
+- ✅ Real sidecar spawn, scale-0/scale-1 A/B, `reload_adapter` to a *different* adapter
+  (SHA-confined), and `loaded_adapter` status all work end-to-end on real GGUF adapters.
+- ✅ **Restore-on-exit holds live** — after the A/B the harness logged
+  `loaded_adapter after restore: None (base only)`; the daemon was left on the base
+  model, never the candidate.
+
+**Leg NOT proven — discrimination (`daemon-ab-eval-v1` is too weak):**
+- 3 of 4 dimensions (`faeCapability`, `serialization`, `toolCalling`) are **identical**
+  across base and both adapters → zero delta; the suite cannot tell these adapters apart.
+- `assistantFit` moved −12pp, but **identically for both adapters** — a single-example
+  artifact (1 of 8 fit items), not signal that separates good from bad.
+- This is on probe adapters (not necessarily "good" personal adapters), but it confirms
+  the static review on real hardware: **v1 does not meaningfully discriminate.** The
+  gguf lane's *safety* is intact (a zero/negative delta fails closed — the gate blocks,
+  never deploys), but its *usefulness as an improvement filter is low until a
+  `daemon-ab-eval-v2`* hardens the weak dimensions (see the weaknesses section above).
+- Follow-up: investigate which `assistantFit` example drives the uniform −12pp (likely a
+  keyword/forbidden phrasing difference), and build v2 before relying on the gguf lane
+  to *promote* (as opposed to merely *block*) adapters.
+
 ## Scope notes
 
 - This is **dev-only** (`FAE_DEV=1` / `FAE_MODELS_LOCK=off`) because runtime LoRA


### PR DESCRIPTION
Follow-up to #21 (P9/C4 training-seam + eval gates). Records the **first live-hardware run** of the gguf-lane A/B mechanism and a reproducible harness.

## What ran
A headless de-risk on Apple M5 Max via a new manual harness (`crates/fae-engine/examples/daemon_ab_derisk.rs`) that spawns the real `llama-server` sidecar and drives the **actual** `fae-engine` `set_adapter_scale`/`reload_adapter`/`loaded_adapter` primitives over the 32-example held-out suite — base vs `personal-metric` vs `personal-c2` (P3/C3 bench adapters). It bypasses only the Swift/NDJSON layer (already unit-proven).

## Results

| dimension | base (s0) | personal-metric (s1) | personal-c2 (s1) |
|-----------|-----------|----------------------|------------------|
| assistantFit | 100% | 88% | 88% |
| faeCapability | 88% | 88% | 88% |
| serialization | 100% | 100% | 100% |
| toolCalling | 100% | 100% | 100% |

- ✅ **Mechanism + safety proven live:** real scale-0/1 A/B, reload to a different (SHA-confined) adapter, and **restore-to-base confirmed** (`loaded_adapter == base` after eval, never the candidate — the restore-on-exit safety property holds on real hardware).
- ⚠️ **Discrimination NOT proven:** 3/4 dimensions identical across base and both adapters; `assistantFit` moved −12pp *identically* for both → a single-example artifact, not signal. Confirms the static review on real hardware: **`daemon-ab-eval-v1` is too lenient to *promote* adapters.** Safety is intact (a zero/negative delta fails closed — the gate blocks, never deploys); the lane just can't usefully *promote* until a `daemon-ab-eval-v2` hardens the weak dimensions.

The harness passes fmt + clippy `-D warnings`; it is **not** wired into CI (needs a live daemon + GGUF adapters). The structural P9/C4 gate (merged in #21) is unaffected — this only documents the live legs and gives a reproducible harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a manual (non-CI) de-risk harness (`daemon_ab_derisk.rs`) that drives the real `fae-engine` A/B primitives against live GGUF adapters on Apple M5 Max hardware, and appends the first-run results to the architecture doc. The mechanism and restore-on-exit safety property are confirmed live; discrimination is not proven (zero delta across 3 of 4 dimensions), which the doc correctly attributes to the leniency of `daemon-ab-eval-v1` rather than a safety regression.

- The Rust harness exercises `set_adapter_scale`, `reload_adapter`, and `loaded_adapter` end-to-end across three phases (base scale-0, personal-metric scale-1, then a full `reload_adapter` to personal-c2), printing per-dimension accuracy and a delta table.
- The architecture doc update records the live results, clearly flags that discrimination is not yet proven, and prescribes a `daemon-ab-eval-v2` follow-up to harden the weak dimensions before the gguf lane can promote adapters.

<h3>Confidence Score: 4/5</h3>

Safe to merge — this is a manual-only example and a doc update; neither touches production paths or CI.

The harness's `first_json` brace-counter does not skip characters inside JSON string values, so any model output where a string field contains a literal `}` will silently score as incorrect for `expectJSONKeys`/`expectJSONArray` cases. This could produce artificially low `serialization` dimension scores on future re-runs if model outputs change. The `set_var` call in the default multi-threaded Tokio executor is a thread-safety concern that compilers ≥ 1.81 will flag as `unsafe`. Both issues are confined to this manual example and do not affect the production gate or CI.

`crates/fae-engine/examples/daemon_ab_derisk.rs` — the `first_json` scorer and the `set_var` in async context warrant a second look before this harness is relied upon for future discrimination runs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/fae-engine/examples/daemon_ab_derisk.rs | New manual de-risk harness driving real llama-server A/B; `first_json` brace-counting scorer is naive about string contents and can silently under-score, plus `set_var` is called in a multi-threaded async context. |
| docs/architecture/p9-c4-daemon-ab-live-derisk-2026-06-22.md | Live run results appended to existing architecture doc; accurately records mechanism/safety proof and discrimination failure, with clear follow-up action. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant H as daemon_ab_derisk
    participant A as LlamaServerAdapter
    participant S as llama-server

    H->>S: spawn (base + personal-metric --lora-init-without-apply)
    Note over H,S: Phase 1 — Baseline

    H->>A: set_adapter_scale(0.0)
    loop 32 examples
        H->>A: stream_chat(request)
        A->>S: /v1/chat/completions
        S-->>A: tokens / tool_calls
        A-->>H: ChatEvent stream
    end
    H->>H: accuracy_by_dim → base_acc

    Note over H,S: Phase 2 — Candidate (personal-metric)

    H->>A: set_adapter_scale(1.0)
    loop 32 examples
        H->>A: stream_chat(request)
        A->>S: /v1/chat/completions
        S-->>A: tokens
        A-->>H: ChatEvent stream
    end
    H->>H: accuracy_by_dim → cand_acc
    H->>A: set_adapter_scale(0.0)
    H->>A: loaded_adapter() — confirm restore

    Note over H,S: Phase 3 — Discrimination (personal-c2)

    H->>A: reload_adapter(Some(c2.gguf))
    A->>S: restart with --lora personal-c2.gguf
    S-->>A: ready
    H->>A: set_adapter_scale(1.0)
    loop 32 examples
        H->>A: stream_chat(request)
        A->>S: /v1/chat/completions
        S-->>A: tokens
        A-->>H: ChatEvent stream
    end
    H->>H: accuracy_by_dim → c2_acc

    H->>A: reload_adapter(None)
    A->>S: restart, base model only
    Note over H,S: Clean exit — base model restored
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant H as daemon_ab_derisk
    participant A as LlamaServerAdapter
    participant S as llama-server

    H->>S: spawn (base + personal-metric --lora-init-without-apply)
    Note over H,S: Phase 1 — Baseline

    H->>A: set_adapter_scale(0.0)
    loop 32 examples
        H->>A: stream_chat(request)
        A->>S: /v1/chat/completions
        S-->>A: tokens / tool_calls
        A-->>H: ChatEvent stream
    end
    H->>H: accuracy_by_dim → base_acc

    Note over H,S: Phase 2 — Candidate (personal-metric)

    H->>A: set_adapter_scale(1.0)
    loop 32 examples
        H->>A: stream_chat(request)
        A->>S: /v1/chat/completions
        S-->>A: tokens
        A-->>H: ChatEvent stream
    end
    H->>H: accuracy_by_dim → cand_acc
    H->>A: set_adapter_scale(0.0)
    H->>A: loaded_adapter() — confirm restore

    Note over H,S: Phase 3 — Discrimination (personal-c2)

    H->>A: reload_adapter(Some(c2.gguf))
    A->>S: restart with --lora personal-c2.gguf
    S-->>A: ready
    H->>A: set_adapter_scale(1.0)
    loop 32 examples
        H->>A: stream_chat(request)
        A->>S: /v1/chat/completions
        S-->>A: tokens
        A-->>H: ChatEvent stream
    end
    H->>H: accuracy_by_dim → c2_acc

    H->>A: reload_adapter(None)
    A->>S: restart, base model only
    Note over H,S: Clean exit — base model restored
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/fae-engine/examples/daemon_ab_derisk.rs:329-344
**`first_json` brace counting ignores string contents — silent scoring false negatives**

The function increments/decrements `depth` for every `{`/`}` character, including those inside JSON string values. Any model output whose JSON string fields contain a literal `}` (e.g. `{"summary": "done}"}`) will cause the function to hit `depth == 0` mid-string, attempt to parse a truncated slice, fail, and return `None` — causing `expectJSONKeys` and `expectJSONArray` cases to silently score as incorrect regardless of actual model quality. Since these scoring types are used for `serialization` dimension examples, this can artificially deflate accuracy for any run where the model includes a `}` character in a string value. The correct fix is to skip characters inside `"…"` spans (tracking quote state and handling `\"` escapes), or to use a streaming JSON lexer.

### Issue 2 of 2
crates/fae-engine/examples/daemon_ab_derisk.rs:37-44
`std::env::set_var` is not thread-safe in a multi-threaded async runtime. Tokio's default `#[tokio::main]` spawns a multi-threaded executor, and modifying the environment after worker threads exist is undefined behavior (and `unsafe` in Rust ≥ 1.81). Move the `set_var` call before `#[tokio::main]` starts (e.g., into a `std::env::set_var` inside a `main()` wrapper that sets up env and then enters the async runtime), or use `#[tokio::main(flavor = "current_thread")]` for this single-sidecar harness to eliminate the multi-thread concern entirely.

```suggestion
#[tokio::main(flavor = "current_thread")]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let home = std::env::var("HOME")?;

    // Let `reload_adapter`'s confinement accept the bench adapters (they live in
    // ~/llama-spike, not the app's personal-adapters dir). This is the documented
    // FAE_PERSONAL_ADAPTERS_DIR override the daemon honours.
    // SAFETY: current_thread runtime; no other threads exist at this point.
    unsafe { std::env::set_var("FAE_PERSONAL_ADAPTERS_DIR", format!("{home}/llama-spike")); }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(training): P9/C4 — daemon-A/B live..."](https://github.com/saorsa-labs/fae/commit/486b1c2a81a24f581c000b928785c99a0686990d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39021003)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->