### PR TITLE
fix(tools): conditional memory-recall rule (Mission A #24)

### DIFF
--- a/native/macos/Fae/Sources/Fae/Core/PersonalityManager.swift
+++ b/native/macos/Fae/Sources/Fae/Core/PersonalityManager.swift
@@ -229,6 +229,10 @@ enum PersonalityManager {
         - If you want to use a tool, USE IT immediately. Don't narrate your plan and stop.
         - Each response must either: (1) call one or more tools, OR (2) give a direct answer.
         - There is no third option. Never respond with just a description of what you would do.
+        - Memory before tools: for personal questions about the user (their name, contacts, \
+        preferences, where they live, what you discussed), answer from your own knowledge or \
+        the conversation so far. Only use contacts or web_search for details you genuinely \
+        do not already have.
         """
 
     static let showDataBehaviorPrompt = """
@@ -306,13 +310,13 @@ enum PersonalityManager {
           - "enable/disable thinking" → self_config adjust_setting llm.thinking_enabled true/false
           - "set your directive to X" → self_config set_directive X
           - "what did we say about X" / "search our earlier chat for X" → session_search
-          - "search for X" / "look up X" → web_search
+          - "search the web for X" / "look up current facts about X" → web_search (not for personal recall)
           - "what's on my calendar" → calendar list
           - "list my tasks" / "show scheduled tasks" → scheduler_list
           - "schedule X daily at 9am" → scheduler_create with interval_type=daily, time=09:00
           - "read the file X" → read
           - "save a note" → notes create
-          - "who is X" / "contact for X" → contacts search
+          - "find X's phone or email" / "contact details for X you don't have" → contacts search
         - Apple tools (calendar, reminders, contacts, mail, notes) automatically open the \
         corresponding macOS app when called, so the user can see the actual data. Your spoken \
         summary is a companion to the visual — keep it brief.
@@ -323,6 +327,8 @@ enum PersonalityManager {
         Don't just confirm the action — analyze what you found, flag anything noteworthy, and \
         add your own observations as a thoughtful friend would.
         - For general knowledge and simple conversation, answer directly without tools.
+        - For questions about the user (their name, contacts, preferences, what you \
+        discussed), answer from memory or the conversation — do not call tools for that.
         """
 
     static let proactiveBehaviorPrompt = """

--- a/native/macos/Fae/Sources/Fae/Tools/AppleTools.swift
+++ b/native/macos/Fae/Sources/Fae/Tools/AppleTools.swift
@@ -688,7 +688,7 @@ struct RemindersTool: Tool {
 /// Requires Contacts permission (System Settings > Privacy > Contacts).
 struct ContactsTool: Tool {
     let name = "contacts"
-    let description = "Search macOS Contacts. Actions: search, get_phone, get_email."
+    let description = "Look up contact details you do not already know (phone, email). Actions: search, get_phone, get_email."
     let parametersSchema = """
         {"action": "string (required: search|get_phone|get_email)", \
         "query": "string (required)"}

--- a/native/macos/Fae/Sources/Fae/Tools/BuiltinTools.swift
+++ b/native/macos/Fae/Sources/Fae/Tools/BuiltinTools.swift
@@ -574,7 +574,7 @@ struct SelfConfigTool: Tool {
 /// DDG redirect URLs.
 struct WebSearchTool: Tool {
     let name = "web_search"
-    let description = "Search the web using multiple engines (DuckDuckGo, Brave, Google, Bing). Results are deduplicated and ranked across engines for quality."
+    let description = "Search the web for external or current facts you do not already know. Multiple engines (DuckDuckGo, Brave, Google, Bing); results deduplicated and ranked."
     let parametersSchema = #"{"query": "string (required)", "max_results": "integer (optional, default 10)"}"#
     let requiresApproval = false
     let example = #"<tool_call>{"name":"web_search","arguments":{"query":"latest Swift concurrency features"}}</tool_call>"#


### PR DESCRIPTION
## Mission A (#24): tool-discipline — conditional memory-recall rule

Daemon-lane Gemma over-reached on personal-recall turns (fired `contacts`/`web_search`
where recall-from-memory was correct). Fix on **Swift production surfaces** (not eval
fixtures):

- **`PersonalityManager.toolCallingContractPrompt`**: a **CONDITIONAL** "memory before
  tools" rule — answer from injected memory/conversation for personal questions about the
  user; reach for `contacts`/`web_search` only for details genuinely not already known.
  Not blanket: the escape clause explicitly permits `contacts`/`web_search` for unknown
  details. Re-routes the tool examples (dropped the broad "who is X → contacts").
- **`ContactsTool.description` / `WebSearchTool.description`**: sharpened to
  "details/facts you do not already know".
- Mirrored the wording into `lightweightToolGuidancePrompt` (E2B/Qwen-2B path) for
  consistency (unmeasured; the daemon-lane Gemma-4-E4B uses the non-lightweight path).

### Measured (G1→G2→G3, meta-orchestrator-gated)
- **G2 over-reach** (production prompt, temp=0, mean-of-2, deterministic): **10.3% → 6.9%**
  (memory-recall 50% → 33%; opinion/clean 0%). Approved thresholds (≤10% overall,
  ≤33% memory-recall) met.
- **4-dim v2 should-call** (no-regression): unchanged within sampling variance — the fix
  is Swift-only; the v2 harness never touches the production prompt or Swift tool
  descriptions (no-causal-path).
- **COV-1 should-call smoke test** (3 legit lookups under the fixed prompt): see
  `.pi-subagents/deliverables/mission-a-cov1-smoke.md`.
- **Reviewer**: APPROVE (under-reach risk not a blocker — the rule is not blanket, escape
  clause permissive, empirically under-suppresses; prompt-size ~70 tokens = 0.21% of 32K).

Full G1/G2/G3 + verbatim extraction provenance: `.pi-subagents/deliverables/mission-a-{baseline,fix,g2,g3-review}.md`.

### Release validation
- [x] Release validation: done — the relevant checklist phases passed. Evidence: `.pi-subagents/deliverables/mission-a-g2.md` (over-reach + 4-dim measurements), `.pi-subagents/deliverables/mission-a-cov1-smoke.md` (legit-lookup smoke), `.pi-subagents/deliverables/mission-a-g3-review.md` (adversarial review).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR sharpens tool-calling discipline for the production Gemma daemon by adding a conditional "memory before tools" rule: personal questions about the user should be answered from injected memory or the conversation, with `contacts`/`web_search` reserved for details genuinely not already known.

- `PersonalityManager.toolCallingContractPrompt`: new memory-before-tools bullet with an explicit escape clause; mapping examples for `web_search` and `contacts` narrowed to signal-based triggers rather than broad topic matches.
- `ContactsTool.description` / `WebSearchTool.description`: both trimmed to emphasise "details/facts you do not already know".
- `lightweightToolGuidancePrompt` (Qwen-2B path): mirrors the new rule, but the escape clause present in the full-prompt version was omitted, creating a contradictory hard-stop that clashes with the existing `"contact details for X you don't have" → contacts search` mapping example in the same prompt.

<h3>Confidence Score: 4/5</h3>

The fix to the main (Gemma) production path is clean and well-measured. The lightweight (Qwen-2B) path has a contradictory rule that could suppress legitimate contacts lookups.

The full-prompt change is correct and backed by G2/G3 measurements. However, the lightweight prompt mirror drops the escape clause, leaving the Qwen-2B path with a hard 'do not call tools' prohibition that directly contradicts the contacts mapping example in the same block.

PersonalityManager.swift — specifically the tail of lightweightToolGuidancePrompt where the new rule lacks its escape clause.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| native/macos/Fae/Sources/Fae/Core/PersonalityManager.swift | Adds memory-before-tools rule to toolCallingContractPrompt (with escape clause) and mirrors it into lightweightToolGuidancePrompt (without the escape clause), creating a contradiction with the existing contacts mapping example on the lightweight path. |
| native/macos/Fae/Sources/Fae/Tools/AppleTools.swift | ContactsTool description sharpened to "details you do not already know" — minimal, correct change. |
| native/macos/Fae/Sources/Fae/Tools/BuiltinTools.swift | WebSearchTool description updated to "external or current facts you do not already know" — minimal, correct change. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Q["User question received"] --> P{Personal question\nabout the user?}
    P -->|No| TOOL["Call contacts / web_search freely"]
    P -->|Yes| K{Detail already\nin memory / conversation?}
    K -->|Yes| MEM["Answer from memory (no tool call)"]
    K -->|No - Full path| ESC["Escape clause: use contacts or web_search"]
    K -->|No - Lightweight path| BLOCK["Hard stop: do not call tools\n⚠ contradicts mapping example"]
    ESC --> TOOL2["Call contacts / web_search"]
    BLOCK -.->|"mapping example says: contacts search"| CONTRA["Contradiction in same prompt"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    Q["User question received"] --> P{Personal question\nabout the user?}
    P -->|No| TOOL["Call contacts / web_search freely"]
    P -->|Yes| K{Detail already\nin memory / conversation?}
    K -->|Yes| MEM["Answer from memory (no tool call)"]
    K -->|No - Full path| ESC["Escape clause: use contacts or web_search"]
    K -->|No - Lightweight path| BLOCK["Hard stop: do not call tools\n⚠ contradicts mapping example"]
    ESC --> TOOL2["Call contacts / web_search"]
    BLOCK -.->|"mapping example says: contacts search"| CONTRA["Contradiction in same prompt"]
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
native/macos/Fae/Sources/Fae/Core/PersonalityManager.swift:330-331
**Missing escape clause in lightweight path**

The rule added to `lightweightToolGuidancePrompt` ends with a hard prohibition — "do not call tools for that" — but omits the escape clause present in `toolCallingContractPrompt` ("Only use contacts or web_search for details you genuinely do not already have"). This directly contradicts the mapping example two lines above (line 319: `"contact details for X you don't have" → contacts search`). On the Qwen-2B path, a user asking "what's Bob's phone number?" hits both a mapping example that routes to `contacts search` and a blanket "do not call tools" rule with no disambiguation, giving the model conflicting signals.

```suggestion
        - For questions about the user (their name, contacts, preferences, what you \
        discussed), answer from memory or the conversation. Only use contacts or \
        web_search for details you genuinely do not already have.
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tools): conditional memory-recall ru..."](https://github.com/saorsa-labs/fae/commit/6dbbe7d49cba7416d643a7af8dcbc9dc18e05bb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42966966)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->