### PR TITLE
fix(daemon): reclaim orphaned llama-server sidecar on startup (#36)

### DIFF
--- a/crates/fae-daemon/src/main.rs
+++ b/crates/fae-daemon/src/main.rs
@@ -1318,6 +1318,7 @@ fn build_qwen3_asr_engine() -> Option<Arc<dyn ProviderAdapter>> {
         port: env_parsed("FAE_ASR_LLAMA_PORT", 18_081_u16),
         ctx_size: env_parsed("FAE_ASR_LLAMA_CTX", 4096_u32),
         ngl: env_parsed("FAE_ASR_LLAMA_NGL", 999_u32),
+        pidfile_root: run_directory().ok(),
     };
     Some(Arc::new(LazyLlamaServerAdapter::new(
         config,
@@ -2204,6 +2205,7 @@ async fn build_llamacpp_engine() -> Arc<dyn ProviderAdapter> {
         // this raised default only applies to standalone/headless launches.
         ctx_size: env_parsed("FAE_LLAMA_CTX", 32_768),
         ngl: env_parsed("FAE_LLAMA_NGL", 999),
+        pidfile_root: run_directory().ok(),
     };
     config
         .preflight_pinned_artifacts()

--- a/crates/fae-engine/examples/llama_reload.rs
+++ b/crates/fae-engine/examples/llama_reload.rs
@@ -29,6 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         port: 18100,
         ctx_size: 4096,
         ngl: 99,
+        pidfile_root: None,
     };
     eprintln!("[reload] spawning managed sidecar (no LoRA)…");
     let adapter = LlamaServerAdapter::spawn(config, "gemma-4-e4b").await?;

--- a/crates/fae-engine/examples/v2_base_dryrun.rs
+++ b/crates/fae-engine/examples/v2_base_dryrun.rs
@@ -66,6 +66,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         port: 18134,
         ctx_size: 4096,
         ngl: 99,
+        pidfile_root: None,
     };
     eprintln!("[v2-dryrun] spawning sidecar (BASE model, no LoRA)…");
     let adapter = LlamaServerAdapter::spawn(config, "gemma-4-e4b").await?;

--- a/crates/fae-engine/examples/v2_calib_matrix.rs
+++ b/crates/fae-engine/examples/v2_calib_matrix.rs
@@ -114,6 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         port: 18135,
         ctx_size: 4096,
         ngl: 99,
+        pidfile_root: None,
     };
     eprintln!("[v2-calib] spawning sidecar (BASE model, no LoRA)…");
     let adapter = LlamaServerAdapter::spawn(config, "gemma-4-e4b").await?;

--- a/crates/fae-engine/src/bin/standin_llama_server.rs
+++ b/crates/fae-engine/src/bin/standin_llama_server.rs
@@ -1,0 +1,61 @@
+//! Test-fixture stand-in for `llama-server`, used ONLY by the #36 reclaim gate
+//! test (`tests/orphan_reclaim.rs`). It binds `127.0.0.1:<--port>` and answers
+//! the two endpoints `LlamaServerHandle::await_ready` requires — `GET /health`
+//! (200) and `GET /v1/models` (200, `data[0].id` == `--alias`) — then stays
+//! alive until killed. Stdlib only, so the test is CI-portable with no model/GPU.
+//! It ignores every other `llama-server` flag Fae passes (`-m`, `--host`, `-c`…).
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+
+fn main() {
+    let mut port = 0u16;
+    let mut alias = "standin".to_owned();
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--port" => port = args.next().and_then(|v| v.parse().ok()).unwrap_or(port),
+            "--alias" => alias = args.next().unwrap_or(alias),
+            _ => {}
+        }
+    }
+    let listener = match TcpListener::bind(("127.0.0.1", port)) {
+        Ok(l) => l,
+        Err(error) => {
+            eprintln!("standin bind {port} failed: {error}");
+            std::process::exit(1);
+        }
+    };
+    eprintln!(
+        "standin listening pid={} port={}",
+        std::process::id(),
+        listener.local_addr().map(|a| a.port()).unwrap_or(port)
+    );
+    for stream in listener.incoming() {
+        let mut stream = match stream {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(200)));
+        let mut buf = [0u8; 1024];
+        let n = stream.read(&mut buf).unwrap_or(0);
+        let request = String::from_utf8_lossy(&buf[..n]);
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("/");
+        let body = match path {
+            "/health" => r#"{"status":"ok"}"#.to_owned(),
+            "/v1/models" => {
+                format!("{{\"object\":\"list\",\"data\":[{{\"id\":\"{alias}\"}}]}}")
+            }
+            _ => "{}".to_owned(),
+        };
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = stream.write_all(response.as_bytes());
+    }
+}

--- a/crates/fae-engine/src/llamacpp_adapter.rs
+++ b/crates/fae-engine/src/llamacpp_adapter.rs
@@ -112,11 +112,7 @@ pub fn kill_all_registered_sidecars() {
 /// Is `pid` still alive? `kill(pid, 0)`-equivalent via `/bin/kill -0`. Best-effort:
 /// on any error we assume alive (so we over-kill, never under-kill).
 fn process_alive(pid: u32) -> bool {
-    let kill_bin = std::env::var("FAE_KILL_BIN")
-        .ok()
-        .filter(|b| !b.is_empty())
-        .unwrap_or_else(|| "/bin/kill".to_owned());
-    let status = std::process::Command::new(kill_bin)
+    let status = std::process::Command::new(kill_bin())
         .arg("-0")
         .arg(pid.to_string())
         .stdout(std::process::Stdio::null())
@@ -124,6 +120,200 @@ fn process_alive(pid: u32) -> bool {
         .status();
     // `kill -0` exits 0 if the process exists, non-zero otherwise.
     matches!(status, Ok(s) if s.success())
+}
+
+// ── Facet B: startup port takeover (reclaim a stale sidecar orphan) ───────────
+
+/// Resolve the configured `/bin/kill` binary (`FAE_KILL_BIN` override; default
+/// `/bin/kill`). Shared by the reclaim + reaper paths.
+fn kill_bin() -> String {
+    std::env::var("FAE_KILL_BIN")
+        .ok()
+        .filter(|b| !b.is_empty())
+        .unwrap_or_else(|| "/bin/kill".to_owned())
+}
+
+/// Best-effort `-<signal>` to a positive pid. Never panics.
+fn send_signal(pid: u32, signal: &str) {
+    let _ = std::process::Command::new(kill_bin())
+        .arg(format!("-{signal}"))
+        .arg(pid.to_string())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+/// Full command line of `pid` (`ps -o command=`), if available. Confirms a stale
+/// pidfile entry is still OUR `llama-server` — a recycled PID at an unrelated
+/// process must never be killed.
+fn process_command_line(pid: u32) -> Option<String> {
+    let out = std::process::Command::new("ps")
+        .args(["-o", "command=", "-p"])
+        .arg(pid.to_string())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_owned())
+}
+
+/// Best-effort port → listener PID via `lsof`. `None` when `lsof` is absent or the
+/// port has no listener. Cross-platform best-effort (macOS always; Linux when
+/// `lsof` is installed). Secondary reclaim signal — the primary is the pidfile.
+fn port_listener_pid(port: u16) -> Option<u32> {
+    let out = std::process::Command::new("lsof")
+        .args(["-nP", "-sTCP:LISTEN", "-t"])
+        .arg(format!("-iTCP:{port}"))
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()
+        .and_then(|line| line.trim().parse::<u32>().ok())
+}
+
+/// `true` while `127.0.0.1:port` accepts TCP connections (something is listening).
+/// Async, no subprocess. Drives the wait-for-port-free step of reclaim.
+async fn port_accepts_connection(port: u16) -> bool {
+    let addr = format!("127.0.0.1:{port}");
+    tokio::net::TcpStream::connect(addr).await.is_ok()
+}
+
+/// Does `cmd` (a process command line) belong to OUR sidecar? Requires the FULL
+/// path of the binary we are about to spawn — as-configured or its canonicalized
+/// (symlink-resolved) form — to appear in the command line. A bare `llama-server`
+/// basename is NEVER sufficient: a user's own llama-server instance would
+/// otherwise be matched and killed. When the path can't be confirmed as ours
+/// (unresolvable / symlink-ambiguous), this returns `false` and the caller fails
+/// loud rather than risk killing a stranger.
+fn cmdline_is_our_sidecar(cmd: &str, our_binary: &str) -> bool {
+    if !our_binary.is_empty() && cmd.contains(our_binary) {
+        return true;
+    }
+    if let Ok(canonical) = std::fs::canonicalize(our_binary) {
+        if let Some(resolved) = canonical.to_str() {
+            if cmd.contains(resolved) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Read a pidfile's PID, if present + parseable.
+fn read_pidfile(path: &std::path::Path) -> Option<u32> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u32>().ok())
+}
+
+/// Write a pidfile at mode `0600` (best-effort; its parent is created if needed).
+/// `0600` owner bits are immune to umask, so the sidecar PID is never
+/// world-readable — matching the private run dir's secret-file discipline. A
+/// missing pidfile only weakens reclaim to the `lsof` fallback.
+fn write_pidfile(path: &std::path::Path, pid: u32) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+        {
+            let _ = writeln!(file, "{pid}");
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = std::fs::write(path, pid.to_string());
+    }
+}
+
+/// Resolve the pidfile path for a sidecar on `port` under the Fae run dir.
+fn sidecar_pidfile(
+    pidfile_root: Option<&std::path::Path>,
+    port: u16,
+) -> Option<std::path::PathBuf> {
+    pidfile_root.map(|root| root.join(format!("llama-server.{port}.pid")))
+}
+
+/// Reclaim `port` if it is squatted by a stale `llama-server` from a prior
+/// unclean daemon death (SIGKILL / crash / jetsam). Called by
+/// [`LlamaServerHandle::spawn`] BEFORE launching a fresh sidecar, so the new
+/// child never collides with an orphan.
+///
+/// Identification — positively OUR orphan, never a stranger: the primary signal
+/// is the Fae-owned pidfile written at the previous spawn; `lsof` is a secondary
+/// fallback when no pidfile exists. Either way the candidate PID must be alive
+/// AND its command line must contain the FULL path of OUR configured binary
+/// ([`cmdline_is_our_sidecar`]: as-configured or canonicalized — a bare
+/// `llama-server` basename is never sufficient, so a user's own llama-server is
+/// never killed). If the path can't be confirmed as ours, nothing is killed and
+/// the port-free gate below fails loud.
+///
+/// Kill sequence (meta-orchestrator gate condition): `SIGTERM` → ~2 s grace →
+/// `SIGKILL`, then wait for the port to go free WITH a timeout. On timeout — or
+/// when the port is held by a process we refuse to kill — this returns `Err` and
+/// the caller MUST fail loud; it NEVER spawns anyway (a silent two-server
+/// collision would be worse than a loud launch failure).
+async fn reclaim_port_if_held(
+    port: u16,
+    pidfile: Option<&std::path::Path>,
+    our_binary: &str,
+) -> Result<(), EngineError> {
+    let candidate = pidfile
+        .and_then(read_pidfile)
+        .or_else(|| port_listener_pid(port));
+    if let Some(pid) = candidate {
+        if process_alive(pid) {
+            let cmd = process_command_line(pid).unwrap_or_default();
+            if cmdline_is_our_sidecar(&cmd, our_binary) {
+                // Confirmed stale sidecar: SIGTERM → ~2 s grace → SIGKILL.
+                send_signal(pid, "TERM");
+                let term_deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+                while std::time::Instant::now() < term_deadline {
+                    if !process_alive(pid) {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+                if process_alive(pid) {
+                    send_signal(pid, "KILL");
+                }
+            }
+            // cmdline mismatch ⇒ recycled PID (not ours): do NOT kill a stranger.
+            // Fall through to the port-free gate, which fails loud if still held.
+        }
+    }
+    // Wait for the port to go free WITH a timeout. Never bind on a held port.
+    let free_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        if !port_accepts_connection(port).await {
+            if let Some(path) = pidfile {
+                let _ = std::fs::remove_file(path);
+            }
+            return Ok(());
+        }
+        if std::time::Instant::now() >= free_deadline {
+            return Err(EngineError::Load(format!(
+                "port {port} is still held after reclaim; refusing to spawn a sidecar \
+                 that would collide — free the port (or kill the holder) and relaunch"
+            )));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
 }
 
 /// A pinned remote artifact. Downloaded on request into Fae-owned storage and
@@ -181,6 +371,12 @@ pub struct LlamaServerConfig {
     pub ctx_size: u32,
     /// GPU layers to offload (`999` = all on Metal/CUDA/Vulkan).
     pub ngl: u32,
+    /// Root directory for the sidecar pidfile (`<root>/llama-server.<port>.pid`),
+    /// used by [`LlamaServerHandle::spawn`] to reclaim a stale sidecar left by a
+    /// prior unclean daemon death (Facet B — the crash-loop gate-closer). `None`
+    /// disables pidfile-based reclaim (the `lsof` fallback still runs); the daemon
+    /// sets this to its private run dir.
+    pub pidfile_root: Option<std::path::PathBuf>,
 }
 
 impl LlamaServerConfig {
@@ -506,6 +702,9 @@ fn sha256_file(path: &std::path::Path) -> std::io::Result<String> {
 pub struct LlamaServerHandle {
     child: std::process::Child,
     base_url: String,
+    /// Pidfile recording this sidecar's PID; removed on clean shutdown (Drop) so a
+    /// surviving pidfile unambiguously means an orphan from an unclean death.
+    pidfile: Option<std::path::PathBuf>,
 }
 
 impl LlamaServerHandle {
@@ -515,9 +714,24 @@ impl LlamaServerHandle {
         timeout: std::time::Duration,
     ) -> Result<LlamaServerHandle, EngineError> {
         let materialized = config.materialized()?;
-        let base_url = format!("http://127.0.0.1:{}", materialized.port);
+        let port = materialized.port;
+        let base_url = format!("http://127.0.0.1:{}", port);
+        let pidfile = sidecar_pidfile(config.pidfile_root.as_deref(), port);
+        // Facet B (mandatory — the crash-loop gate-closer): reclaim any stale
+        // sidecar squatting our port BEFORE we bind, so an unclean daemon death
+        // (SIGKILL/crash/jetsam) cannot crash-loop the next launch. Returns Err
+        // (→ no spawn) when the port stays held — we NEVER bind on a squatted port.
+        reclaim_port_if_held(port, pidfile.as_deref(), &materialized.binary).await?;
         let mut command = std::process::Command::new(&materialized.binary);
         command.args(materialized.args());
+        // Facet A (recommended hardening): isolate the sidecar in its own process
+        // group so it is not a member of the daemon's group. Group-kill of any
+        // grandchildren is intentionally NOT performed here — see the Drop note.
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
         // Inherit stdout/stderr so daemon/app logs show llama.cpp download,
         // load, and token/runtime diagnostics. This evidence is required for
         // live validation and makes first-run HF downloads debuggable.
@@ -531,21 +745,30 @@ impl LlamaServerHandle {
         })?;
         let pid = child.id();
         register_sidecar(pid);
-        let mut handle = LlamaServerHandle { child, base_url };
-        handle.await_ready(timeout).await?;
+        if let Some(ref pf) = pidfile {
+            write_pidfile(pf, pid);
+        }
+        let mut handle = LlamaServerHandle {
+            child,
+            base_url,
+            pidfile,
+        };
+        handle.await_ready(timeout, &materialized.alias).await?;
         Ok(handle)
     }
 
-    async fn await_ready(&mut self, timeout: std::time::Duration) -> Result<(), EngineError> {
+    async fn await_ready(
+        &mut self,
+        timeout: std::time::Duration,
+        expected_alias: &str,
+    ) -> Result<(), EngineError> {
         let client = reqwest::Client::new();
         let health = format!("{}/health", self.base_url);
+        let models = format!("{}/v1/models", self.base_url);
         let deadline = std::time::Instant::now() + timeout;
         loop {
             // Fail loud if the child exited during startup (bad GGUF, OOM, bind
             // failure) instead of polling a dead server for the full timeout.
-            // Orphan-identity gap: a stale llama-server already bound to the
-            // port could answer /health as "ready" — verifying server identity
-            // (e.g. GET /props alias match) is a follow-up left unaddressed here.
             match self.child.try_wait() {
                 Ok(Some(status)) => {
                     return Err(EngineError::Load(format!(
@@ -561,7 +784,34 @@ impl LlamaServerHandle {
             }
             if let Ok(response) = client.get(&health).send().await {
                 if response.status().is_success() {
-                    return Ok(());
+                    // Identity check (gap fix): confirm this is OUR fresh server —
+                    // not a stale orphan still answering /health on the reclaimed
+                    // port. A healthy fresh llama-server exposes /v1/models with
+                    // data[0].id == the configured --alias. A non-empty mismatch is
+                    // a stale sidecar (fail loud); an empty id means the model list
+                    // is not populated yet (keep polling).
+                    if let Ok(models_resp) = client.get(&models).send().await {
+                        if models_resp.status().is_success() {
+                            if let Ok(json) = models_resp.json::<serde_json::Value>().await {
+                                let id = json
+                                    .get("data")
+                                    .and_then(|d| d.get(0))
+                                    .and_then(|m| m.get("id"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("");
+                                if !id.is_empty() && id != expected_alias {
+                                    return Err(EngineError::Load(format!(
+                                        "port answered /health but serves model id {id:?} \
+                                         (expected {expected_alias:?}); a stale llama-server may \
+                                         be squatting the port"
+                                    )));
+                                }
+                                if id == expected_alias {
+                                    return Ok(());
+                                }
+                            }
+                        }
+                    }
                 }
             }
             if std::time::Instant::now() >= deadline {
@@ -576,11 +826,35 @@ impl LlamaServerHandle {
 
 impl Drop for LlamaServerHandle {
     fn drop(&mut self) {
-        // Best-effort: never panic in Drop. Kill then reap so we don't leave a
-        // zombie or an orphaned model holding GPU memory.
-        unregister_sidecar(self.child.id());
-        let _ = self.child.kill();
+        // Best-effort; never panic. Graceful: SIGTERM → brief grace → SIGKILL the
+        // direct child, then reap so we leave neither a zombie nor an orphaned
+        // model holding GPU memory. Then remove the pidfile: a surviving pidfile
+        // must unambiguously mean an orphan from an UNCLEAN death (SIGKILL skips
+        // Drop), which is what reclaim keys off on the next launch.
+        //
+        // The sidecar runs in its own process group via spawn's `process_group(0)`;
+        // killing the direct child removes the single-process llama-server. Killing
+        // the whole GROUP for grandchildren would need `libc::kill(-pgid)` — blocked
+        // by `#![forbid(unsafe_code)]` and the macOS `/bin/kill -PGID` quirk; the
+        // sidecar is single-process so there are none, and Facet B reclaims any
+        // survivor on the next launch regardless.
+        let pid = self.child.id();
+        unregister_sidecar(pid);
+        send_signal(pid, "TERM");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1000);
+        while std::time::Instant::now() < deadline {
+            if !process_alive(pid) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        if process_alive(pid) {
+            let _ = self.child.kill();
+        }
         let _ = self.child.wait();
+        if let Some(ref pidfile) = self.pidfile {
+            let _ = std::fs::remove_file(pidfile);
+        }
     }
 }
 
@@ -1297,6 +1571,7 @@ mod tests {
             port: 18080,
             ctx_size: 8192,
             ngl: 999,
+            pidfile_root: None,
         };
         let args = config.args();
         assert!(!args.iter().any(|arg| arg == "-hf"));
@@ -1333,6 +1608,7 @@ mod tests {
             port: 18080,
             ctx_size: 8192,
             ngl: 999,
+            pidfile_root: None,
         };
         let args = config.args();
         assert!(args.windows(2).any(|w| w == ["-m", "/tmp/model.gguf"]));
@@ -1377,6 +1653,7 @@ mod tests {
             port: 18080,
             ctx_size: 8192,
             ngl: 999,
+            pidfile_root: None,
         }
     }
 
@@ -1481,6 +1758,7 @@ mod tests {
             port: 1,
             ctx_size: 8192,
             ngl: 999,
+            pidfile_root: None,
         };
         let adapter =
             LazyLlamaServerAdapter::new(config, "gemma-4", std::time::Duration::from_millis(1));
@@ -1602,6 +1880,7 @@ mod tests {
             port: 1,
             ctx_size: 8192,
             ngl: 999,
+            pidfile_root: None,
         }
     }
 

--- a/crates/fae-engine/tests/orphan_reclaim.rs
+++ b/crates/fae-engine/tests/orphan_reclaim.rs
@@ -1,0 +1,173 @@
+//! #36 orphaned `llama-server` — G2 gate test (the post-fix pass criterion).
+//!
+//! CI-race-safe: an OS-assigned ephemeral port + a per-process temp dir, so
+//! parallel `cargo test` runs never collide. Stdlib only (no reqwest/serde_json —
+//! those are engine deps, not dev-deps, so unavailable here). Asserts the full
+//! no-crash-loop contract:
+//!
+//! 1. a stale sidecar squatting the port (with a leftover pidfile — the state an
+//!    unclean SIGKILL/crash leaves behind) is **reclaimed** (SIGTERM→grace→SIGKILL)
+//!    before a fresh sidecar binds;
+//! 2. the port is **freed** then bound by the **new** child;
+//! 3. the new child is **healthy** and its `/v1/models` identity **matches** the
+//!    configured alias (the await_ready identity-gap fix — a stale server is no
+//!    longer silently trusted);
+//! 4. the new child's pidfile is `0600` in the private run dir, removed on clean
+//!    shutdown; **no orphan process remains**.
+
+// Test code: panicking on assertion failure is the point; unwrap/expect are
+// permitted for clarity, mirroring the lib's `#[cfg_attr(test, allow(...))]`.
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::panic)]
+
+use fae_engine::{LlamaModelSource, LlamaServerAdapter, LlamaServerConfig, ProviderAdapter};
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// Path to the stand-in `llama-server` example (`CARGO_BIN_EXE_<example>`).
+const STANDIN: &str = env!("CARGO_BIN_EXE_standin_llama_server");
+const ALIAS: &str = "gemma-4";
+
+/// Grab a free loopback port the OS hands us (bind :0, read it, drop). Tiny race
+/// window before the orphan rebinds — acceptable + standard for ephemeral ports.
+fn ephemeral_port() -> u16 {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+/// Wait until something is accepting TCP on `port`.
+fn wait_until_listening(port: u16) {
+    for _ in 0..100 {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("nothing ever listened on {port}");
+}
+
+/// Minimal HTTP/1.0 GET → response body (stdlib only).
+fn http_get(port: u16, path: &str) -> String {
+    let mut stream = TcpStream::connect_timeout(
+        &format!("127.0.0.1:{port}").parse().unwrap(),
+        Duration::from_millis(500),
+    )
+    .unwrap();
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    let _ = stream.write_all(format!("GET {path} HTTP/1.0\r\nHost: 127.0.0.1\r\n\r\n").as_bytes());
+    let mut buf = Vec::new();
+    let _ = stream.read_to_end(&mut buf);
+    String::from_utf8_lossy(&buf).to_string()
+}
+
+fn standin_config(port: u16, pidfile_root: &Path) -> LlamaServerConfig {
+    LlamaServerConfig {
+        binary: STANDIN.to_owned(),
+        model: LlamaModelSource::Local {
+            model_gguf: "/dev/null".to_owned(),
+            mmproj: None,
+            mtp_draft: None,
+        },
+        lora_gguf: None,
+        alias: ALIAS.to_owned(),
+        enable_thinking: false,
+        mtp_draft_tokens: None,
+        port,
+        ctx_size: 4096,
+        ngl: 0,
+        pidfile_root: Some(pidfile_root.to_path_buf()),
+    }
+}
+
+#[tokio::test]
+async fn reclaims_orphan_then_binds_and_identity_verifies() {
+    let port = ephemeral_port();
+    // Unique per test process → safe under parallel `cargo test`.
+    let tmp = std::env::temp_dir().join(format!("fae-orphan-reclaim-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let pidfile = tmp.join(format!("llama-server.{port}.pid"));
+
+    // ── Set up the orphan: a stale sidecar squatting `port` + a leftover pidfile,
+    //    exactly what an unclean daemon death (SIGKILL skips Drop) leaves behind.
+    //    Its alias differs from the fresh server's, so a non-reclaiming spawn would
+    //    hit the identity check and fail loud.
+    let mut orphan = Command::new(STANDIN)
+        .args(["--port", &port.to_string(), "--alias", "stale-orphan"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let orphan_pid = orphan.id();
+    std::fs::write(&pidfile, orphan_pid.to_string()).unwrap();
+    wait_until_listening(port);
+
+    // ── Fresh spawn = next daemon launch. reclaim must read the pidfile, confirm
+    //    the holder is our sidecar, kill it, free the port, then launch a NEW child
+    //    that binds + becomes healthy + identity-verifies.
+    let adapter = LlamaServerAdapter::spawn(standin_config(port, &tmp), ALIAS)
+        .await
+        .expect("spawn must reclaim the orphan, bind the port, and verify identity");
+
+    // (1) The orphan was reclaimed — killed by reclaim's SIGTERM/SIGKILL.
+    let orphan_status = orphan
+        .try_wait()
+        .expect("polling the orphan must not error");
+    assert!(
+        orphan_status.is_some(),
+        "stale sidecar must be reclaimed (killed), not left squatting the port"
+    );
+
+    // (2) The port is bound by the NEW child (something healthy is listening).
+    assert!(
+        TcpStream::connect(("127.0.0.1", port)).is_ok(),
+        "port must be bound by the new child after reclaim"
+    );
+
+    // (3) Identity-verified: the new child serves the configured alias (NOT the
+    //     orphan's "stale-orphan"). A direct /v1/models GET proves the fresh
+    //     server, closing the await_ready identity gap end-to-end.
+    let models = http_get(port, "/v1/models");
+    assert!(
+        models.contains(&format!("\"id\":\"{ALIAS}\"")),
+        "new child must serve the configured alias; got: {models}"
+    );
+    assert!(
+        !models.contains("stale-orphan"),
+        "must NOT be the orphan server; got: {models}"
+    );
+    assert_eq!(adapter.describe().model_id, ALIAS);
+
+    // (4) The new child's pidfile exists, is 0600, and lives under the run dir.
+    assert!(pidfile.exists(), "fresh sidecar pidfile must be written");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&pidfile).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "pidfile must be 0600 (owner-only)");
+    }
+
+    // ── Clean shutdown removes the pidfile + kills the new child; no orphan.
+    drop(adapter);
+    assert!(
+        !pidfile.exists(),
+        "pidfile must be removed on clean shutdown"
+    );
+    for _ in 0..50 {
+        if TcpStream::connect(("127.0.0.1", port)).is_err() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        TcpStream::connect(("127.0.0.1", port)).is_err(),
+        "no sidecar (orphan or fresh) must remain after clean shutdown"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+    let _ = orphan.wait(); // reap any lingering zombie, just in case
+}


### PR DESCRIPTION
## #36 orphaned llama-server — startup pidfile/port takeover (Mission B item 1)

When `fae-daemon` dies **uncleanly** (SIGKILL/crash/jetsam), its `llama-server`
sidecar was left **orphaned** (reparented to PID 1) squatting port 18080 → next
launch crash-loop or silent stale-engine driving. Fix (defense-in-depth):

- **Facet B (MANDATORY, gate-closer)** — `reclaim_port_if_held` at the TOP of
  `LlamaServerHandle::spawn`, before bind: identifies a stale sidecar (pidfile PID
  primary; lsof port-listener secondary), **positively verifies it's ours** (the
  listener cmdline contains the FULL resolved path of our configured binary —
  canonicalize fallback; fail-loud on ambiguity; **never** a bare `llama-server`
  substring that could kill a user's own instance), kills it (SIGTERM → ~2s grace →
  SIGKILL → wait-port-free 5s timeout), and returns `Err` (no spawn) if the port
  stays held. **Never blind-binds.**
- **Facet A (hardening)** — `process_group(0)` isolation + graceful Drop. Group-kill
  skipped (justified: `#![forbid(unsafe_code)]`; macOS `/bin/kill -PGID` broken;
  single-process `llama-server` = no grandchildren; Facet B covers all unclean deaths).
- **Identity-gap closed** — `await_ready` GETs `/v1/models` + requires
  `data[0].id == --alias` (no stale-orphan masquerade).
- **Pidfile** 0600 in the private run dir; removed on clean Drop/shutdown.

### Gated (G1→G2→G3, meta-orchestrator-verified)
- **G1** repro + diagnosis: `.pi-subagents/deliverables/mission-b-36-g1.md` (controlled
  repro on isolated port 18090 + live corroboration: the owner's sidecars 91507/5466
  are orphaned PPID=1 *now*).
- **G2** fix + CI-race-safe gate test (ephemeral port + unique temp dir) GREEN +
  orchestrator independent `just check` GREEN: `mission-b-36-g2.md`.
- **G3** reviewer APPROVE (all 4 focus points: ownership precision / TOCTOU /
  async-blocking / pidfile_root=None); meta-orchestrator diff-verify PASSED:
  `mission-b-36-g3-review.md`.

Owner real-world confirmation (first launch reclaims 91507/5466) on
`.pi-subagents/deliverables/OWNER-TEST-PLAN.md`. 3 LOW non-blocking reviewer notes
(substring-vs-equality theoretical edge; Drop ~1s blocking grace; test orphan-leak-on-panic).

### Release validation
- [x] Release validation: done — the relevant checklist phases passed. Evidence:
  `.pi-subagents/deliverables/mission-b-36-{g1,g2,g3-review}.md` (headless repro +
  CI-race-safe gate test + adversarial review + orchestrator independent gate re-run).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash-loop caused by orphaned `llama-server` sidecars left behind after an unclean `fae-daemon` death (SIGKILL/crash/jetsam). The fix adds defense-in-depth at two layers: a mandatory port-reclaim step before each spawn, and a hardened identity check in the readiness poll.

- **Facet B (gate-closer):** `reclaim_port_if_held` runs before every `LlamaServerHandle::spawn`; it reads a pidfile (written at spawn, removed at clean Drop), confirms the listening PID's command line contains the full configured binary path, then issues SIGTERM \u2192 2 s grace \u2192 SIGKILL and waits for the port to go free (5 s hard timeout).
- **Facet A (hardening):** `process_group(0)` isolates the sidecar; Drop now issues graceful SIGTERM before SIGKILL and removes the pidfile on clean shutdown.
- **Identity gap closed:** `await_ready` now GETs `/v1/models` and requires `data[0].id == --alias`.

<h3>Confidence Score: 3/5</h3>

The core reclaim logic is sound and the gate test covers the main scenario, but the ownership check in cmdline_is_our_sidecar can match a process that merely passes the binary path as an argument, which would kill an unrelated system process.

The ownership guard uses cmd.contains(our_binary) over the full command line string including all arguments. Any system process that references the configured binary path in its own arguments would be falsely claimed as our sidecar and sent SIGTERM/SIGKILL. The fix addresses a real production crash-loop and the overall structure is well-designed, but this matching gap creates a meaningful risk of killing unrelated processes during the reclaim step.

crates/fae-engine/src/llamacpp_adapter.rs — specifically cmdline_is_our_sidecar (line 195) and the await_ready identity-mismatch error message (line 802).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/fae-engine/src/llamacpp_adapter.rs | Core of the fix: adds reclaim_port_if_held, pidfile read/write, cmdline identity check, and an upgraded await_ready with /v1/models alias verification. The substring-based cmdline ownership check (cmd.contains) can produce a false positive on processes that pass the binary path as an argument, potentially killing unrelated system processes. |
| crates/fae-daemon/src/main.rs | Wires pidfile_root into both LlamaServerConfig structs via run_directory().ok(); straightforward integration. |
| crates/fae-engine/tests/orphan_reclaim.rs | CI-safe gate test covering the full reclaim contract. Minor acknowledged race in ephemeral_port(). |
| crates/fae-engine/src/bin/standin_llama_server.rs | New stdlib-only test fixture acting as a minimal llama-server stub; correctly scoped to CI use. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
crates/fae-engine/src/llamacpp_adapter.rs:195-207
**Substring match can falsely identify unrelated processes**

`cmd.contains(our_binary)` searches the entire command line string — binary path **plus all arguments**. A process that simply passes `our_binary`'s full path as an argument (e.g., `python3 /usr/bin/supervise.py --binary /usr/local/bin/llama-server`, or a log-rotation daemon whose config path contains the llama-server path) will match and be killed. The doc comment promises "the FULL path of the binary" must appear, but does not restrict the match to the first token (the actual binary position).

A safer check would split `cmd` on whitespace and compare only the first token (the executable path) against `our_binary` or its canonical form, which avoids false positives from argument substrings.

### Issue 2 of 3
crates/fae-engine/src/llamacpp_adapter.rs:271-317
**Blocking subprocess spawns inside an async function**

`reclaim_port_if_held` is `async`, but `process_alive`, `process_command_line`, `send_signal`, and `port_listener_pid` all call `std::process::Command::new(...).status()` synchronously. Each of those is a fork/exec/wait that blocks the Tokio worker thread while the child process runs. The SIGTERM grace loop calls `process_alive` up to ~20 times (every 100 ms over 2 s), so a total of 20+ blocking subprocess spawns occur on the executor. On a current-thread runtime (the default for `#[tokio::test]`), this prevents other tasks from making progress during the entire grace period. Wrapping each with `tokio::task::spawn_blocking` would keep the executor responsive.

### Issue 3 of 3
crates/fae-engine/src/llamacpp_adapter.rs:802-807
**Misleading error message when a freshly-spawned server has the wrong alias**

By the time this branch is reached, Facet B has already confirmed the port was free before the new child was spawned. If the server that answers `/health` has a different `data[0].id`, the most likely cause is a **configuration mismatch** (the `--alias` passed to the newly-launched server doesn't match `expected_alias`) rather than a stale orphan squatting the port. The current message — "a stale llama-server may be squatting the port" — will mislead an operator into hunting for orphans rather than checking the configured alias.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(daemon): reclaim orphaned llama-serv..."](https://github.com/saorsa-labs/fae/commit/6e9e90a2e6c7f97c859d06867655ace45b78387d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42990639)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->