### PR TITLE
fix(audit): dev-gate FAE_MODELS_LOCK_PATH + TTS char-vs-byte bound

### DIFF
--- a/crates/fae-daemon/src/main.rs
+++ b/crates/fae-daemon/src/main.rs
@@ -1516,15 +1516,40 @@ fn qwen3_asr_locked_artifacts(
     ))
 }
 
+/// Trusted, in-process lock-path override set ONLY by the `--verify-runtime
+/// --models-lock` CLI flag. `OnceLock` (not `LazyLock`) is deliberate: the
+/// value is runtime input from the flag, not a fixed initializer, and it is
+/// never reachable from the process environment — so a launchd/parent-process
+/// injection of `FAE_MODELS_LOCK_PATH` cannot redirect verification at a
+/// crafted lock matching a swapped model.
+static VERIFY_CLI_LOCK_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+
 fn load_installed_models_lock() -> Result<ModelsLock, String> {
-    // `FAE_MODELS_LOCK_PATH` lets the release-CI `--verify-runtime` gate point the
-    // SAME verification at a specific lock (e.g. the re-signed bundle's copy)
-    // without a separate code path; unset in normal operation → installed lock.
-    let path = match std::env::var_os("FAE_MODELS_LOCK_PATH") {
-        Some(override_path) => PathBuf::from(override_path),
-        None => data_directory()
-            .map_err(|error| error.to_string())?
-            .join("models.lock"),
+    // Resolution order:
+    // 1. Trusted CLI override (`--verify-runtime --models-lock`) — in-process
+    //    only; the release-CI verifier's legitimate way to point the SAME
+    //    checks at a specific lock (e.g. the re-signed bundle's copy).
+    // 2. `FAE_MODELS_LOCK_PATH` env override — DEV ONLY, mirroring the
+    //    `FAE_MODELS_LOCK=off` gate. A production build never honors an
+    //    externally-injected lock path.
+    // 3. The installed `<data>/models.lock` (normal operation).
+    let dev = dev_mode();
+    let path: PathBuf = if let Some(cli_path) = VERIFY_CLI_LOCK_PATH.get() {
+        cli_path.clone()
+    } else {
+        let env_override = std::env::var_os("FAE_MODELS_LOCK_PATH");
+        if env_override.is_some() && !dev {
+            eprintln!(
+                "fae-daemon: WARNING: ignoring FAE_MODELS_LOCK_PATH in production \
+                 (set FAE_DEV=1 to honor it); using installed models.lock"
+            );
+        }
+        match (env_override, dev) {
+            (Some(override_path), true) => PathBuf::from(override_path),
+            _ => data_directory()
+                .map_err(|error| error.to_string())?
+                .join("models.lock"),
+        }
     };
     ModelsLock::load(&path).map_err(|error| error.to_string())
 }
@@ -1654,7 +1679,17 @@ fn verify_runtime_cli(flags: &[String]) -> Result<(), (&'static str, String)> {
                 let value = iter
                     .next()
                     .ok_or(("verify_runtime", "--models-lock requires a path".to_owned()))?;
-                std::env::set_var("FAE_MODELS_LOCK_PATH", value);
+                // Route through the trusted in-process channel (not the env
+                // var) so `--models-lock` works in release-CI without FAE_DEV,
+                // while the external `FAE_MODELS_LOCK_PATH` env var stays
+                // dev-gated. First value wins; passing the flag twice is an
+                // operator error surfaced loudly.
+                if VERIFY_CLI_LOCK_PATH
+                    .set(PathBuf::from(value.as_str()))
+                    .is_err()
+                {
+                    return Err(("verify_runtime", "--models-lock already set".to_owned()));
+                }
             }
             other => {
                 return Err((
@@ -2536,6 +2571,7 @@ mod tests {
             "FAE_LLAMA_SHARED_SERVER_URL",
             "FAE_LLAMA_SHARED_SERVER_TIMEOUT_MS",
             "FAE_MODELS_LOCK",
+            "FAE_MODELS_LOCK_PATH",
             "FAE_AUDIO_FALLBACK",
             "FAE_ASR_LLAMA_CACHE_DIR",
         ] {
@@ -2739,6 +2775,66 @@ created_at = "test"
         std::env::set_var("FAE_DEV", "1");
         validate_models_lock_escape().unwrap();
         verify_llama_server_binary(&bin).unwrap();
+    }
+
+    #[test]
+    fn models_lock_path_env_override_is_dev_only() {
+        // Security gate (#1): a production build must load the INSTALLED lock
+        // even when FAE_MODELS_LOCK_PATH is injected (launchd/parent), so a
+        // crafted lock cannot redirect verification at a swapped model. Only
+        // FAE_DEV honors the env override — mirroring FAE_MODELS_LOCK=off.
+        let _g = _lock_env();
+        clear_fae_env();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", dir.path());
+
+        // Installed lock carries "installed-marker"; a crafted override file
+        // carries "override-marker".
+        write_test_models_lock(
+            dir.path(),
+            &artifact_toml(
+                "installed-marker",
+                "asr_model",
+                "installed.gguf",
+                1,
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            ),
+        );
+        let crafted = dir.path().join("crafted-override.lock");
+        std::fs::write(
+            &crafted,
+            format!(
+                "schema_version = 1\ncreated_at = \"test\"\n{}",
+                artifact_toml(
+                    "override-marker",
+                    "asr_model",
+                    "override.gguf",
+                    2,
+                    "1111111111111111111111111111111111111111111111111111111111111111",
+                )
+            ),
+        )
+        .unwrap();
+
+        // PRODUCTION (no FAE_DEV): the injected override is ignored.
+        std::env::set_var("FAE_MODELS_LOCK_PATH", &crafted);
+        let loaded = load_installed_models_lock().expect("installed lock loads");
+        assert!(
+            loaded.artifacts.iter().any(|a| a.id == "installed-marker"),
+            "production must ignore an injected FAE_MODELS_LOCK_PATH"
+        );
+        assert!(
+            !loaded.artifacts.iter().any(|a| a.id == "override-marker"),
+            "production must not honor an externally-injected lock path"
+        );
+
+        // DEV (FAE_DEV=1): the override IS honored — the escape hatch.
+        std::env::set_var("FAE_DEV", "1");
+        let loaded = load_installed_models_lock().expect("override lock loads in dev");
+        assert!(
+            loaded.artifacts.iter().any(|a| a.id == "override-marker"),
+            "dev mode must honor FAE_MODELS_LOCK_PATH"
+        );
     }
 
     #[test]

--- a/crates/fae-daemon/src/main.rs
+++ b/crates/fae-daemon/src/main.rs
@@ -1517,12 +1517,14 @@ fn qwen3_asr_locked_artifacts(
 }
 
 /// Trusted, in-process lock-path override set ONLY by the `--verify-runtime
-/// --models-lock` CLI flag. `OnceLock` (not `LazyLock`) is deliberate: the
-/// value is runtime input from the flag, not a fixed initializer, and it is
-/// never reachable from the process environment — so a launchd/parent-process
-/// injection of `FAE_MODELS_LOCK_PATH` cannot redirect verification at a
-/// crafted lock matching a swapped model.
-static VERIFY_CLI_LOCK_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+/// --models-lock` CLI flag. It is never reachable from the process
+/// environment — so a launchd/parent-process injection of
+/// `FAE_MODELS_LOCK_PATH` cannot redirect verification at a crafted lock
+/// matching a swapped model. A `RwLock<Option<PathBuf>>` (not `OnceLock`) is
+/// deliberate: the test suite can reset it in `clear_fae_env()`, whereas a
+/// process-global `OnceLock` can never be cleared — which would let the first
+/// `--models-lock` test silently corrupt every later models-lock test.
+static VERIFY_CLI_LOCK_PATH: std::sync::RwLock<Option<PathBuf>> = std::sync::RwLock::new(None);
 
 fn load_installed_models_lock() -> Result<ModelsLock, String> {
     // Resolution order:
@@ -1534,8 +1536,14 @@ fn load_installed_models_lock() -> Result<ModelsLock, String> {
     //    externally-injected lock path.
     // 3. The installed `<data>/models.lock` (normal operation).
     let dev = dev_mode();
-    let path: PathBuf = if let Some(cli_path) = VERIFY_CLI_LOCK_PATH.get() {
-        cli_path.clone()
+    let cli_override = VERIFY_CLI_LOCK_PATH
+        .read()
+        // A poisoned lock means a panic held it mid-write; fail safe to "no
+        // override" (→ installed lock) instead of propagating the panic.
+        .map(|guard| guard.clone())
+        .unwrap_or(None);
+    let path: PathBuf = if let Some(cli_path) = cli_override {
+        cli_path
     } else {
         let env_override = std::env::var_os("FAE_MODELS_LOCK_PATH");
         if env_override.is_some() && !dev {
@@ -1684,11 +1692,19 @@ fn verify_runtime_cli(flags: &[String]) -> Result<(), (&'static str, String)> {
                 // while the external `FAE_MODELS_LOCK_PATH` env var stays
                 // dev-gated. First value wins; passing the flag twice is an
                 // operator error surfaced loudly.
-                if VERIFY_CLI_LOCK_PATH
-                    .set(PathBuf::from(value.as_str()))
-                    .is_err()
-                {
-                    return Err(("verify_runtime", "--models-lock already set".to_owned()));
+                match VERIFY_CLI_LOCK_PATH.write() {
+                    Ok(mut guard) => {
+                        if guard.is_some() {
+                            return Err(("verify_runtime", "--models-lock already set".to_owned()));
+                        }
+                        *guard = Some(PathBuf::from(value.as_str()));
+                    }
+                    Err(_) => {
+                        return Err((
+                            "verify_runtime",
+                            "--models-lock: configuration lock poisoned".to_owned(),
+                        ));
+                    }
                 }
             }
             other => {
@@ -2576,6 +2592,12 @@ mod tests {
             "FAE_ASR_LLAMA_CACHE_DIR",
         ] {
             std::env::remove_var(key);
+        }
+        // Reset the trusted CLI lock-path override so a `--models-lock` test
+        // cannot leak into later models-lock tests (the RwLock is resettable,
+        // unlike a OnceLock).
+        if let Ok(mut guard) = VERIFY_CLI_LOCK_PATH.write() {
+            *guard = None;
         }
     }
 

--- a/crates/fae-daemon/src/session.rs
+++ b/crates/fae-daemon/src/session.rs
@@ -2067,6 +2067,10 @@ const TTS_DEFAULT_VOICE: &str = "af_heart";
 /// sentence-chunked by the client (matching the Swift TTS pipeline's
 /// `String.prefix(2_000)`). Bounding by `chars().count()` — NOT `str::len()`
 /// (bytes) — keeps multibyte UTF-8 payloads under the cap from being rejected.
+/// Accepted residual: `chars()` counts Unicode SCALARS while Swift
+/// `String.count` counts grapheme CLUSTERS, so a ZWJ-emoji-heavy payload right
+/// at the 2_000 boundary can still be rejected here — acceptable for TTS
+/// content (real utterances sit far below the cap).
 const TTS_MAX_TEXT_CHARS: usize = 2_000;
 
 /// Parsed `{ text, voice?, speed? }` payload shared by `tts.synthesize` and

--- a/crates/fae-daemon/src/session.rs
+++ b/crates/fae-daemon/src/session.rs
@@ -2063,8 +2063,10 @@ async fn audio_play(
 
 /// Default Kokoro voice when the client does not name one.
 const TTS_DEFAULT_VOICE: &str = "af_heart";
-/// Bound a single synthesis request — long text should be sentence-chunked
-/// by the client (matching the Swift TTS pipeline's behaviour).
+/// Bound a single synthesis request (in CHARACTERS) — long text should be
+/// sentence-chunked by the client (matching the Swift TTS pipeline's
+/// `String.prefix(2_000)`). Bounding by `chars().count()` — NOT `str::len()`
+/// (bytes) — keeps multibyte UTF-8 payloads under the cap from being rejected.
 const TTS_MAX_TEXT_CHARS: usize = 2_000;
 
 /// Parsed `{ text, voice?, speed? }` payload shared by `tts.synthesize` and
@@ -2081,7 +2083,7 @@ fn parse_tts_payload(cmd: &Command) -> Result<TtsPayload<'_>, &'static str> {
         .get("text")
         .and_then(serde_json::Value::as_str)
         .ok_or("bad_request")?;
-    if text.trim().is_empty() || text.len() > TTS_MAX_TEXT_CHARS {
+    if text.trim().is_empty() || text.chars().count() > TTS_MAX_TEXT_CHARS {
         return Err("bad_request");
     }
     let voice = cmd


### PR DESCRIPTION
## Release validation

- [x] Release validation: N/A — no runtime/UI/policy/routing change.
      Reason: headless daemon changes only — #1 fail-closed integrity gate (production runtime byte-identical: Swift never sets `FAE_MODELS_LOCK_PATH`) + #3 TTS bound unit-alignment (no audio-output change); both covered by unit tests (`models_lock_path_env_override_is_dev_only` + 608 fae-daemon tests); no user-visible app flow / live-app scenario applies.

## Mission B item 2 — audit-MEDIUM quick-wins (batch)

Scouted the 6 audit §MEDIUM quick-wins against `main` (`6394f4d0`): **3 actionable, 3 stale**. This PR ships the 2 unambiguous fixes (one commit each). The 3rd actionable is a design call — deferred (B-plus), design in the ledger.

### #1 — `FAE_MODELS_LOCK_PATH` env override is now dev-gated  (`fae-daemon/src/main.rs`)
`load_installed_models_lock()` read `FAE_MODELS_LOCK_PATH` **ungated**, unlike the peer `FAE_MODELS_LOCK=off` which is dev-gated. An env injection (launchd wrapper / parent process) could redirect the runtime-integrity verifier at a crafted lock matching a swapped model.

- External env read now gated behind `dev_mode()` (mirrors `FAE_MODELS_LOCK=off`); production logs a WARNING and uses the installed lock.
- The release-CI `--verify-runtime --models-lock` CLI still works **without `FAE_DEV`**: it now routes through a trusted in-process `OnceLock` (runtime input from the flag → `OnceLock`, not `LazyLock`), never reachable from the process environment. A naive dev-only gate would have silently made `--models-lock` a no-op in release-CI — turning the verifier into a silent bypass.
- New test `models_lock_path_env_override_is_dev_only`: production ignores the injected path; `FAE_DEV=1` honors it.

### #3 — TTS synthesis bound by char count, not bytes  (`fae-daemon/src/session.rs`)
The daemon enforced `TTS_MAX_TEXT_CHARS` (2_000) via `str::len()` = **bytes**, while the Swift client truncates with `String.prefix(2_000)` = **chars**. A 2_000-char multibyte UTF-8 payload (emoji/non-Latin) exceeded 2_000 bytes → `bad_request` → silent synthesis failure on that sentence. Now `text.chars().count()`, matching the client and the constant's name.

### Verification
- `cd crates && env -u RUSTFLAGS just check` green (fmt-check + workspace clippy `-D warnings` + strict `-D panic/unwrap/expect` on fae-daemon/fae-engine/fae-metaopt + `cargo test --all-features`), re-run at G3.
- Full `fae-daemon` suite: **608 passed, 0 failed**.

### Stale (skipped, ledger-noted — verified against current `main`)
- **#2 deny-path audit swallowed** — FIXED (`tracing::error!`/`eprintln!`).
- **#5 URL basic-auth/`?token=`** — FIXED (`SensitiveDataRedactor.swift`).
- **#6 CHANGELOG zero entries** — false (full `[v0.8.x]` series predates the audit).

### #4 — fallback-TTS cold-load guard (B-plus, DEFERRED — separate change)
`PipelineCoordinator.swift:5619-5646` lazily `engine.load()`s the in-process Kokoro fallback on the live reply path. Investigation: the daemon lane already bundles `prince-canuma/Kokoro-82M` (MLX Safetensors) locally since task #35; the Swift `FaeTTSAdapter` auto-downloads the *same* model. If mlx-audio-swift loads from the local bundle, the model is always present (ideal). Building B-plus (presence guard + timeout + prewarm) as a follow-up per meta-orchestrator ruling.