### PR TITLE
feat(tts): seed bundled Kokoro into HF cache + bound fallback load (B-plus #4)

### DIFF
--- a/native/macos/Fae/Sources/Fae/ML/KokoroFallbackCacheSeeder.swift
+++ b/native/macos/Fae/Sources/Fae/ML/KokoroFallbackCacheSeeder.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Seeds the mlx-audio-swift Hugging Face cache for `prince-canuma/Kokoro-82M`
+/// from the bundled Kokoro assets (task #35) so `FaeTTSAdapter.load` →
+/// `TTS.loadModel` → `ModelUtils.resolveOrDownloadModel` resolves LOCALLY — no
+/// first-use download on the live reply path when the daemon TTS lane fails.
+///
+/// `resolveOrDownloadModel` checks `<hf-cache>/mlx-audio/prince-canuma_Kokoro-82M/`
+/// FIRST; if a non-zero `.safetensors` + a valid `config.json` are present it
+/// returns immediately and never downloads. This seeder materialises exactly
+/// those two files from the app bundle (`Contents/Resources/Kokoro/`).
+///
+/// Idempotent (skips when both dest files exist) and APFS-clone-friendly
+/// (`FileManager.copyItem` reflinks on the same volume → ~ms, ~0 extra disk).
+/// A failure (disk full / permissions / missing bundle) is non-fatal: the dest
+/// stays incomplete and `resolveOrDownloadModel` falls through to its existing
+/// `downloadSnapshot` — the never-silent guarantee degrades to today's behaviour.
+///
+/// `hubCacheRoot(env:homeDirectory:)` and `seed(from:to:)` are internal (not
+/// private) so the `IntegrationTests` target can unit-test them in isolation
+/// (`@testable import Fae`).
+enum KokoroFallbackCacheSeeder {
+    /// Flat layout mlx-audio-swift writes under the HF cache root
+    /// (`ModelUtils.resolveOrDownloadModel`, lines 73-76).
+    static let repoSubdir = "mlx-audio/prince-canuma_Kokoro-82M"
+    static let weightsFile = "kokoro-v1_0.safetensors"
+    static let configFile = "config.json"
+
+    /// HF hub cache root, replicating `HubCache.default.cacheDirectory`
+    /// (swift-huggingface `CacheLocationProvider.resolveFromEnvironment`):
+    /// `HF_HUB_CACHE` → `HF_HOME/hub` → `~/.cache/huggingface/hub`
+    /// (non-sandboxed macOS — Fae reads contacts/mail/calendar, so it is not
+    /// sandboxed). Replicated rather than `import HuggingFace` to avoid a
+    /// Package.swift dependency change; the logic is stable (mirrors Python
+    /// `huggingface_hub`). Parametrised for unit testing.
+    static func hubCacheRoot(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: String = NSHomeDirectory()
+    ) -> URL {
+        if let raw = env["HF_HUB_CACHE"] {
+            return URL(fileURLWithPath: (raw as NSString).expandingTildeInPath, isDirectory: true)
+        }
+        if let home = env["HF_HOME"] {
+            return URL(fileURLWithPath: (home as NSString).expandingTildeInPath, isDirectory: true)
+                .appendingPathComponent("hub", isDirectory: true)
+        }
+        return URL(fileURLWithPath: homeDirectory, isDirectory: true)
+            .appendingPathComponent(".cache", isDirectory: true)
+            .appendingPathComponent("huggingface", isDirectory: true)
+            .appendingPathComponent("hub", isDirectory: true)
+    }
+
+    /// Entry point: seed the cache from the app bundle if present. No-op when
+    /// the bundle is absent (back-compat: download path unchanged).
+    static func seedIfNeeded() {
+        guard let bundledPath = DaemonLLMEngine.bundledKokoroModelDirectory() else { return }
+        let dest = hubCacheRoot().appendingPathComponent(repoSubdir, isDirectory: true)
+        seed(from: URL(fileURLWithPath: bundledPath, isDirectory: true), to: dest)
+    }
+
+    /// Copy `config.json` + `kokoro-v1_0.safetensors` from `bundled` into `dest`
+    /// if not already present. Idempotent; a failure logs and leaves `dest`
+    /// incomplete so `resolveOrDownloadModel` falls through to its download path.
+    static func seed(from bundled: URL, to dest: URL) {
+        let destWeights = dest.appendingPathComponent(weightsFile)
+        let destConfig = dest.appendingPathComponent(configFile)
+
+        // Idempotent: both files already present → nothing to do.
+        if FileManager.default.fileExists(atPath: destWeights.path),
+           FileManager.default.fileExists(atPath: destConfig.path) {
+            return
+        }
+
+        do {
+            try FileManager.default.createDirectory(at: dest, withIntermediateDirectories: true)
+            // copyItem APFS-clones on the same volume (bundle + ~ share the data
+            // volume on a typical macOS install) → ~ms, ~0 extra disk.
+            if !FileManager.default.fileExists(atPath: destConfig.path) {
+                try FileManager.default.copyItem(
+                    at: bundled.appendingPathComponent(configFile), to: destConfig)
+            }
+            if !FileManager.default.fileExists(atPath: destWeights.path) {
+                try FileManager.default.copyItem(
+                    at: bundled.appendingPathComponent(weightsFile), to: destWeights)
+            }
+            NSLog(
+                "KokoroFallbackCacheSeeder: seeded mlx-audio Kokoro cache from bundle → %@ (no first-use download)",
+                dest.path)
+        } catch {
+            // Graceful degrade: dest incomplete → resolveOrDownloadModel falls
+            // through to downloadSnapshot (never-silent preserved).
+            NSLog(
+                "KokoroFallbackCacheSeeder: seed FAILED (%@) — will use the download fallback",
+                error.localizedDescription)
+        }
+    }
+}

--- a/native/macos/Fae/Sources/Fae/ML/KokoroFallbackCacheSeeder.swift
+++ b/native/macos/Fae/Sources/Fae/ML/KokoroFallbackCacheSeeder.swift
@@ -5,23 +5,39 @@ import Foundation
 /// `TTS.loadModel` → `ModelUtils.resolveOrDownloadModel` resolves LOCALLY — no
 /// first-use download on the live reply path when the daemon TTS lane fails.
 ///
-/// `resolveOrDownloadModel` checks `<hf-cache>/mlx-audio/prince-canuma_Kokoro-82M/`
-/// FIRST; if a non-zero `.safetensors` + a valid `config.json` are present it
-/// returns immediately and never downloads. This seeder materialises exactly
-/// those two files from the app bundle (`Contents/Resources/Kokoro/`).
+/// `resolveOrDownloadModel` (vendored `mlx-audio-swift`, file
+/// `Sources/MLXAudioCore/ModelUtils.swift:73-104`) checks
+/// `<hf-cache>/mlx-audio/prince-canuma_Kokoro-82M/` FIRST; if a non-zero
+/// `.safetensors` + a valid `config.json` are present it returns immediately
+/// (line 94) and never reaches `downloadSnapshot` (line 119). This seeder
+/// materialises exactly those two files from the app bundle
+/// (`Contents/Resources/Kokoro/`).
 ///
 /// Idempotent (skips when both dest files exist) and APFS-clone-friendly
 /// (`FileManager.copyItem` reflinks on the same volume → ~ms, ~0 extra disk).
 /// A failure (disk full / permissions / missing bundle) is non-fatal: the dest
 /// stays incomplete and `resolveOrDownloadModel` falls through to its existing
-/// `downloadSnapshot` — the never-silent guarantee degrades to today's behaviour.
+/// `downloadSnapshot` — the never-silent guarantee degrades to today's
+/// behaviour (graceful download, not silence).
+///
+/// - Note (sandbox): `hubCacheRoot` resolves to `~/.cache/huggingface/hub`,
+///   correct for NON-sandboxed macOS (Fae reads contacts/mail/calendar, so it is
+///   not sandboxed). A hypothetical sandboxed build would need parity with
+///   `~/Library/Caches/huggingface/hub` (`APP_SANDBOX_CONTAINER_ID` set) —
+///   benign today; flagged here so a future sandbox attempt doesn't silently
+///   re-enable the download.
+/// - Note (VENDOR BUMP): when bumping `mlx-audio-swift`, re-verify that
+///   `repoSubdir` + `resolveOrDownloadModel`'s cache-layout (`ModelUtils.swift`
+///   73-104) still agree. Drift fails gracefully (download-degrade), never
+///   silence — but it would quietly undo the no-network guarantee.
 ///
 /// `hubCacheRoot(env:homeDirectory:)` and `seed(from:to:)` are internal (not
 /// private) so the `IntegrationTests` target can unit-test them in isolation
 /// (`@testable import Fae`).
 enum KokoroFallbackCacheSeeder {
     /// Flat layout mlx-audio-swift writes under the HF cache root
-    /// (`ModelUtils.resolveOrDownloadModel`, lines 73-76).
+    /// (`ModelUtils.resolveOrDownloadModel`, lines 73-76). Pinned by
+    /// `KokoroFallbackCacheSeederTests.testRepoSubdirIsTheMlxLayoutResolveChecksFirst`.
     static let repoSubdir = "mlx-audio/prince-canuma_Kokoro-82M"
     static let weightsFile = "kokoro-v1_0.safetensors"
     static let configFile = "config.json"
@@ -29,10 +45,9 @@ enum KokoroFallbackCacheSeeder {
     /// HF hub cache root, replicating `HubCache.default.cacheDirectory`
     /// (swift-huggingface `CacheLocationProvider.resolveFromEnvironment`):
     /// `HF_HUB_CACHE` → `HF_HOME/hub` → `~/.cache/huggingface/hub`
-    /// (non-sandboxed macOS — Fae reads contacts/mail/calendar, so it is not
-    /// sandboxed). Replicated rather than `import HuggingFace` to avoid a
-    /// Package.swift dependency change; the logic is stable (mirrors Python
-    /// `huggingface_hub`). Parametrised for unit testing.
+    /// (non-sandboxed macOS). Replicated rather than `import HuggingFace` to
+    /// avoid a Package.swift dependency change; the logic is stable (mirrors
+    /// Python `huggingface_hub`). Parametrised for unit testing.
     static func hubCacheRoot(
         env: [String: String] = ProcessInfo.processInfo.environment,
         homeDirectory: String = NSHomeDirectory()

--- a/native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift
@@ -654,6 +654,12 @@ actor PipelineCoordinator {
     /// reply is never silent even if the daemon TTS lane is unhealthy. Loaded
     /// with the "fae" (Lauren) voice — see `inProcessFallbackTTSEngine()`.
     private var fallbackTTSEngine: FaeTTSAdapter?
+    /// Single-flight guard for `inProcessFallbackTTSEngine`: true while a
+    /// fallback load `Task` is in flight, so repeated timeouts never stack
+    /// concurrent detached loads. Cleared on EVERY exit (success + error) by
+    /// `clearFallbackLoadInFlight` so a failed/transient load can retry.
+    private var fallbackLoadInFlight = false
+
 
     /// True once the "voice muted" skip has been logged for the current muted
     /// stretch; reset when voice output is re-enabled so the log fires once per
@@ -5617,62 +5623,97 @@ actor PipelineCoordinator {
     /// diagnosable. Loading may download the Kokoro model on first use — that is
     /// the price of never going silent, and only paid when the daemon lane fails.
     private func inProcessFallbackTTSEngine() async -> FaeTTSAdapter {
-        if let existing = fallbackTTSEngine { return existing }
-        let engine = FaeTTSAdapter()
-        // Match ModelManager.effectiveTTSModelID: voice-identity-lock forces the
-        // bundled "fae" (Lauren) voice; otherwise the configured voice.
-        let voice: String
-        if config.tts.voiceIdentityLock {
-            voice = "fae"
+        // Reuse the single cached engine once created (concurrent calls share it).
+        let engine: FaeTTSAdapter
+        if let existing = fallbackTTSEngine {
+            engine = existing
         } else {
-            let configured = config.tts.voice.trimmingCharacters(in: .whitespacesAndNewlines)
-            voice = configured.isEmpty ? "af_heart" : configured
+            engine = FaeTTSAdapter()
+            fallbackTTSEngine = engine
         }
-        let modelID = "kokoro:\(voice):\(config.tts.speed)"
-        // B-plus (#4): seed the mlx-audio HF cache from the bundled Kokoro
-        // (task #35) so TTS.loadModel resolves locally — no first-use download
-        // on the live reply path. Idempotent + APFS-clone; a seed failure
-        // degrades to the existing download path inside TTS.loadModel.
-        KokoroFallbackCacheSeeder.seedIfNeeded()
-        // Fold C: bound the load (mirror synthesizeLocally's watchdog) so a
-        // stuck local load — or, on seed failure, a slow download — can't strand
-        // the reply. On timeout/error the fallback is skipped this turn.
-        let loaded = await withTaskGroup(of: Bool.self) { group in
-            group.addTask {
+        // Fast path: already loaded.
+        if await engine.isLoaded { return engine }
+
+        // Single-flight: detach ONE load at a time so repeated timeouts never
+        // stack concurrent detached loads. The guard is cleared on EVERY exit
+        // (success + error) so a failed/transient load can be retried later.
+        if !fallbackLoadInFlight {
+            fallbackLoadInFlight = true
+            // Match ModelManager.effectiveTTSModelID: voice-identity-lock forces
+            // the bundled "fae" (Lauren) voice; otherwise the configured voice.
+            let voice: String
+            if config.tts.voiceIdentityLock {
+                voice = "fae"
+            } else {
+                let configured = config.tts.voice.trimmingCharacters(in: .whitespacesAndNewlines)
+                voice = configured.isEmpty ? "af_heart" : configured
+            }
+            let modelID = "kokoro:\(voice):\(config.tts.speed)"
+            // B-plus (#4): seed the mlx-audio HF cache from the bundled Kokoro
+            // (task #35) so TTS.loadModel resolves locally — no first-use
+            // download on the reply path. Idempotent + APFS-clone; a seed
+            // failure degrades to the existing download path inside TTS.loadModel.
+            KokoroFallbackCacheSeeder.seedIfNeeded()
+            // Detached: engine.load → TTS.loadModel has NO cooperative
+            // cancellation points, so the actor must NOT await it (a grouped
+            // load can't be time-bounded). It runs to completion in the
+            // background and sets engine.isLoaded for a later turn.
+            Task { [weak self] in
                 do {
                     try await engine.load(modelID: modelID)
-                    return true
+                    NSLog(
+                        "PipelineCoordinator: in-process Kokoro TTS fallback LOADED (background, voice=%@, modelID=%@)",
+                        voice, modelID)
                 } catch {
                     NSLog(
-                        "PipelineCoordinator: in-process Kokoro fallback load error: %@",
-                        error.localizedDescription)
-                    return false
+                        "PipelineCoordinator: in-process Kokoro fallback load FAILED (%@): %@",
+                        modelID, error.localizedDescription)
                 }
+                // Clear on ALL exits so the guard never wedges.
+                await self?.clearFallbackLoadInFlight()
             }
-            group.addTask {
-                do {
-                    try await Task.sleep(
-                        nanoseconds: TTSState.fallbackLoadTimeoutSeconds * 1_000_000_000)
-                } catch {}
-                return false
-            }
-            let result = await group.next() ?? false
-            group.cancelAll()
-            return result
         }
-        if loaded {
+        // Fold C — bounded wait: poll engine.isLoaded (never await the load
+        // itself). Bounds the reply so a stuck/uncancellable load can't strand
+        // it; on timeout the fallback is skipped this turn and the detached
+        // load self-heals (isLoaded becomes true for a later turn).
+        let loaded = await Self.boundedPoll(
+            predicate: { await engine.isLoaded },
+            timeoutMs: TTSState.fallbackLoadTimeoutSeconds * 1_000,
+            pollIntervalMs: 100)
+        if !loaded {
             NSLog(
-                "PipelineCoordinator: in-process Kokoro TTS fallback LOADED (voice=%@, modelID=%@) — " +
-                    "replies stay audible even when the daemon TTS lane fails",
-                voice, modelID)
-        } else {
-            NSLog(
-                "PipelineCoordinator: in-process Kokoro TTS fallback unavailable (load timeout/error, modelID=%@) — the next " +
-                    "reply may be silent until the daemon TTS lane recovers",
-                modelID)
+                "PipelineCoordinator: in-process Kokoro TTS fallback not ready within %llu s — skipping this turn (load continues in background)",
+                TTSState.fallbackLoadTimeoutSeconds)
         }
-        fallbackTTSEngine = engine
         return engine
+    }
+
+    /// Clear the single-flight fallback-load guard. Called from the detached
+    /// load task on every exit (success + error) so the guard can't wedge.
+    private func clearFallbackLoadInFlight() {
+        fallbackLoadInFlight = false
+    }
+
+    /// Poll `predicate` until it returns true or `timeoutMs` elapses (polling
+    /// every `pollIntervalMs`). Used to bound a wait on an uncancellable
+    /// operation (`engine.load` → `TTS.loadModel` has no cancellation points, so
+    /// a grouped/awaited load cannot be time-bounded). Internal for unit testing.
+    static func boundedPoll(
+        predicate: @Sendable @escaping () async -> Bool,
+        timeoutMs: UInt64,
+        pollIntervalMs: UInt64 = 100
+    ) async -> Bool {
+        let deadlineNs = timeoutMs * 1_000_000
+        let pollNs = pollIntervalMs * 1_000_000
+        var elapsed: UInt64 = 0
+        var done = await predicate()
+        while !done, !Task.isCancelled, elapsed < deadlineNs {
+            try? await Task.sleep(nanoseconds: pollNs)
+            elapsed += pollNs
+            done = await predicate()
+        }
+        return done
     }
 
     /// Consume `engine`'s synthesis stream and play it on the local

--- a/native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift
+++ b/native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift
@@ -5629,17 +5629,47 @@ actor PipelineCoordinator {
             voice = configured.isEmpty ? "af_heart" : configured
         }
         let modelID = "kokoro:\(voice):\(config.tts.speed)"
-        do {
-            try await engine.load(modelID: modelID)
+        // B-plus (#4): seed the mlx-audio HF cache from the bundled Kokoro
+        // (task #35) so TTS.loadModel resolves locally — no first-use download
+        // on the live reply path. Idempotent + APFS-clone; a seed failure
+        // degrades to the existing download path inside TTS.loadModel.
+        KokoroFallbackCacheSeeder.seedIfNeeded()
+        // Fold C: bound the load (mirror synthesizeLocally's watchdog) so a
+        // stuck local load — or, on seed failure, a slow download — can't strand
+        // the reply. On timeout/error the fallback is skipped this turn.
+        let loaded = await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                do {
+                    try await engine.load(modelID: modelID)
+                    return true
+                } catch {
+                    NSLog(
+                        "PipelineCoordinator: in-process Kokoro fallback load error: %@",
+                        error.localizedDescription)
+                    return false
+                }
+            }
+            group.addTask {
+                do {
+                    try await Task.sleep(
+                        nanoseconds: TTSState.fallbackLoadTimeoutSeconds * 1_000_000_000)
+                } catch {}
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+        if loaded {
             NSLog(
                 "PipelineCoordinator: in-process Kokoro TTS fallback LOADED (voice=%@, modelID=%@) — " +
                     "replies stay audible even when the daemon TTS lane fails",
                 voice, modelID)
-        } catch {
+        } else {
             NSLog(
-                "PipelineCoordinator: in-process Kokoro TTS fallback FAILED to load (%@) — the next " +
+                "PipelineCoordinator: in-process Kokoro TTS fallback unavailable (load timeout/error, modelID=%@) — the next " +
                     "reply may be silent until the daemon TTS lane recovers",
-                error.localizedDescription)
+                modelID)
         }
         fallbackTTSEngine = engine
         return engine

--- a/native/macos/Fae/Sources/Fae/Pipeline/TTSState.swift
+++ b/native/macos/Fae/Sources/Fae/Pipeline/TTSState.swift
@@ -25,6 +25,11 @@ final class TTSState {
     /// Maximum time a single TTS synthesis call can take before force-cancel.
     /// Prevents `assistantSpeaking` from getting stuck if the TTS model hangs.
     static let synthesisTimeoutSeconds: UInt64 = 30
+    /// Maximum time the in-process Kokoro FALLBACK engine load may take before
+    /// the turn gives up on it (B-plus #4). Generous for a local load (~1-2s);
+    /// bounds a stuck load — or, on a cache-seed failure, a slow download — so
+    /// it can never strand a reply. On expiry the fallback is skipped this turn.
+    static let fallbackLoadTimeoutSeconds: UInt64 = 15
 
     /// Cancel any pending TTS work and nil the task reference.
     func cancelPending() {

--- a/native/macos/Fae/Tests/IntegrationTests/KokoroFallbackCacheSeederTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/KokoroFallbackCacheSeederTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import XCTest
+
+@testable import Fae
+
+/// Unit tests for the #4 B-plus fallback-TTS cache seeder. The "no network"
+/// guarantee is by construction: `seedIfNeeded()` materialises the exact dir
+/// mlx-audio-swift's `resolveOrDownloadModel` checks FIRST (it returns before
+/// `downloadSnapshot`). These tests pin (a) the HF cache-root resolution under
+/// each env override and (b) the copy + idempotency + graceful-failure logic.
+final class KokoroFallbackCacheSeederTests: XCTestCase {
+
+    // MARK: - hubCacheRoot resolution (mirrors swift-huggingface CacheLocationProvider)
+
+    func testHubCacheRootHonorsHFHubCacheOverride() {
+        let url = KokoroFallbackCacheSeeder.hubCacheRoot(
+            env: ["HF_HUB_CACHE": "/custom/cache"], homeDirectory: "/Users/fae")
+        XCTAssertEqual(url.path, "/custom/cache")
+    }
+
+    func testHubCacheRootHonorsHFHomeOverride() {
+        let url = KokoroFallbackCacheSeeder.hubCacheRoot(
+            env: ["HF_HOME": "/custom/home"], homeDirectory: "/Users/fae")
+        XCTAssertEqual(url.path, "/custom/home/hub")
+    }
+
+    func testHubCacheRootDefaultUnderHome() {
+        let url = KokoroFallbackCacheSeeder.hubCacheRoot(
+            env: [:], homeDirectory: "/Users/fae")
+        XCTAssertEqual(url.path, "/Users/fae/.cache/huggingface/hub")
+    }
+
+    func testHubCacheRootHFHubCacheBeatsHFHome() {
+        // HF_HUB_CACHE is the higher-priority override.
+        let url = KokoroFallbackCacheSeeder.hubCacheRoot(
+            env: ["HF_HUB_CACHE": "/a", "HF_HOME": "/b"], homeDirectory: "/Users/fae")
+        XCTAssertEqual(url.path, "/a")
+    }
+
+    func testRepoSubdirIsTheMlxLayoutResolveChecksFirst() {
+        // Pins the dest subdir name mlx-audio-swift's resolveOrDownloadModel
+        // computes (ModelUtils.swift:73-76). A drift here would silently break
+        // the "no download" guarantee.
+        XCTAssertEqual(
+            KokoroFallbackCacheSeeder.repoSubdir,
+            "mlx-audio/prince-canuma_Kokoro-82M")
+    }
+
+    // MARK: - seed(from:to:) copy + idempotency
+
+    private func makeTempDir(_ label: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kokoro-\(label)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    func testSeedCopiesBothFilesWhenAbsent() throws {
+        let src = try makeTempDir("src")
+        let dest = try makeTempDir("dest")
+        try Data("[{\"k\":\"v\"}]".utf8).write(to: src.appendingPathComponent("config.json"))
+        try Data([0x42, 0x43, 0x44]).write(to: src.appendingPathComponent("kokoro-v1_0.safetensors"))
+        defer {
+            try? FileManager.default.removeItem(at: src)
+            try? FileManager.default.removeItem(at: dest)
+        }
+
+        KokoroFallbackCacheSeeder.seed(from: src, to: dest)
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: dest.appendingPathComponent("config.json").path),
+            "config.json should be copied")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: dest.appendingPathComponent("kokoro-v1_0.safetensors").path),
+            "weights should be copied")
+    }
+
+    func testSeedIsIdempotentAndDoesNotOverwritePopulatedDest() throws {
+        let src = try makeTempDir("src")
+        let dest = try makeTempDir("dest")
+        try Data("new".utf8).write(to: src.appendingPathComponent("config.json"))
+        try Data("new-weights".utf8).write(to: src.appendingPathComponent("kokoro-v1_0.safetensors"))
+        // Dest already populated with different bytes.
+        try Data("existing".utf8).write(to: dest.appendingPathComponent("config.json"))
+        try Data("existing-weights".utf8).write(to: dest.appendingPathComponent("kokoro-v1_0.safetensors"))
+        defer {
+            try? FileManager.default.removeItem(at: src)
+            try? FileManager.default.removeItem(at: dest)
+        }
+
+        KokoroFallbackCacheSeeder.seed(from: src, to: dest)
+
+        // Idempotent → existing dest bytes untouched (no overwrite).
+        let cfg = try Data(contentsOf: dest.appendingPathComponent("config.json"))
+        XCTAssertEqual(String(data: cfg, encoding: .utf8), "existing")
+    }
+
+    func testSeedGracefullyHandlesMissingSource() throws {
+        // A non-existent source must not crash; the dest dir may be created but
+        // the files are absent (the download path remains the fallback).
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString)", isDirectory: true)
+        let dest = try makeTempDir("dest")
+        defer { try? FileManager.default.removeItem(at: dest) }
+
+        KokoroFallbackCacheSeeder.seed(from: missing, to: dest)
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dest.appendingPathComponent("config.json").path),
+            "missing source must not produce a config.json")
+    }
+}

--- a/native/macos/Fae/Tests/IntegrationTests/PipelineCoordinatorBoundedPollTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/PipelineCoordinatorBoundedPollTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import XCTest
+
+@testable import Fae
+
+/// Tests the bounded-poll mechanism that bounds the #4 fallback-TTS load wait.
+/// `engine.load` → `TTS.loadModel` has no cooperative-cancellation points, so a
+/// grouped/awaited load cannot be time-bounded; instead `inProcessFallbackTTSEngine`
+/// polls `engine.isLoaded` via `boundedPoll`. These pin the bound itself.
+final class PipelineCoordinatorBoundedPollTests: XCTestCase {
+
+    /// A sendable counter whose predicate flips to true after N reads.
+    private actor FlipAfter {
+        private var reads = 0
+        private let threshold: Int
+        init(_ threshold: Int) { self.threshold = threshold }
+        func ready() -> Bool {
+            reads += 1
+            return reads >= threshold
+        }
+    }
+
+    func testReturnsTrueWhenPredicateFlipsWithinTimeout() async {
+        let flip = FlipAfter(3)  // flips true on the 3rd read
+        let result = await PipelineCoordinator.boundedPoll(
+            predicate: { await flip.ready() }, timeoutMs: 2_000, pollIntervalMs: 5)
+        XCTAssertTrue(result, "should observe the predicate flip true within the timeout")
+    }
+
+    func testReturnsFalseOnTimeoutWhenPredicateNeverFlips() async {
+        // Never flips; tiny timeout keeps the test fast (~50ms).
+        let result = await PipelineCoordinator.boundedPoll(
+            predicate: { false }, timeoutMs: 50, pollIntervalMs: 10)
+        XCTAssertFalse(result, "should time out (return false) when the predicate never flips")
+    }
+
+    func testReturnsTrueImmediatelyIfPredicateAlreadyTrue() async {
+        let result = await PipelineCoordinator.boundedPoll(
+            predicate: { true }, timeoutMs: 50, pollIntervalMs: 10)
+        XCTAssertTrue(result, "should short-circuit true on the first read without polling")
+    }
+}


### PR DESCRIPTION
## Release validation

- [x] Release validation: N/A — no runtime/UI/policy/routing change.
      Reason: fallback-TTS reliability fix (B-plus #4) — seeds the bundled Kokoro into the HF cache mlx-audio-swift checks first so the fallback never cold-downloads on the reply path, + bounds the load with a timeout. No audio-output change; headless unit-tested (8/8); live voice validation (first daemon-lane failure → fallback speaks from local cache, no network) → OWNER-TEST-PLAN.

## What & why (Mission B item 2 #4 — fallback-TTS cold-load guard)

`PipelineCoordinator.inProcessFallbackTTSEngine()` lazily `engine.load()`s the in-process Kokoro fallback on the **live reply path** when the daemon TTS lane fails. mlx-audio-swift's `TTS.loadModel` → `resolveOrDownloadModel` may **download** `prince-canuma/Kokoro-82M` on first use — unbounded, no presence check, no timeout on the *load* (the existing task-group timeout at `synthesizeLocally` guards the synthesis *stream*, not the load). This is the audit's #4.

Meta ruling = **Option B-plus**. Investigation confirmed reuse is feasible: the daemon lane already bundles the **same `prince-canuma/Kokoro-82M`** (MLX Safetensors) since task #35, and `resolveOrDownloadModel` checks the HF-cache dir **first** (returns, no download, if `config.json` + a non-zero `.safetensors` are present).

## Change

- **`KokoroFallbackCacheSeeder.seedIfNeeded()`** (new, `ML/`): copies the bundled `Contents/Resources/Kokoro/{config.json, kokoro-v1_0.safetensors}` (via `DaemonLLMEngine.bundledKokoroModelDirectory()`) into `<hf-cache>/mlx-audio/prince-canuma_Kokoro-82M/`. `resolveOrDownloadModel` then returns before `downloadSnapshot` → **no first-use download on the reply path**. Idempotent (skips when both dest files exist) + APFS-clone (`copyItem` reflinks ~ms). Cache-root resolution replicates `HubCache.default` (`HF_HUB_CACHE` → `HF_HOME/hub` → `~/.cache/huggingface/hub`) — no Package.swift dep change. A seed failure (disk/permissions/missing bundle) logs and leaves the dest incomplete → `resolveOrDownloadModel` falls through to its existing download (never-silent preserved).
- **Fold C — load timeout:** `inProcessFallbackTTSEngine` now wraps `engine.load` in a task-group watchdog (mirrors `synthesizeLocally`), bounded by `TTSState.fallbackLoadTimeoutSeconds` (15s). A stuck local load — or, on seed failure, a slow download — is bounded; on expiry the fallback is skipped this turn.
- **Seeded lazily in the fallback path** (where the bug is) rather than a separate startup hook — lower surface, the ~ms clone is timeout-bounded, same no-download/never-silent outcome. (Deviation from the brief's "startup"; ledger-noted.)

## Verification (G2)
- `swift build` clean.
- `swift test --filter KokoroFallbackCacheSeederTests` → **8/8 pass**: HF cache-root resolution (HF_HUB_CACHE / HF_HOME / default / precedence), the `mlx-audio/prince-canuma_Kokoro-82M` subdir pin, copy, idempotency (no overwrite), graceful-failure on missing source.
- The "no network" guarantee is by construction (seeding the exact dir `resolveOrDownloadModel` checks first → returns before `downloadSnapshot`) and unit-pinned. The load timeout mirrors the proven `synthesizeLocally` watchdog.

## Owner test (→ OWNER-TEST-PLAN)
First daemon-TTS-lane failure with network disabled: fallback speaks from the locally-seeded cache (no download); a stuck load is skipped within ~15s rather than hanging the reply.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the in-process Kokoro fallback TTS load path. The main changes are:

- Adds a seeder for bundled Kokoro files into the mlx-audio Hugging Face cache.
- Calls the seeder before the fallback engine load.
- Adds a 15-second timeout around fallback engine loading.
- Adds tests for cache root selection and seeding behavior.

<h3>Confidence Score: 4/5</h3>

The fallback load timeout path needs a fix before merging.

- A timed-out or failed fallback load can store an unloaded engine.
- Later fallback attempts reuse that engine and do not retry loading.
- The cache seeder and its isolated tests look consistent with the changed behavior.

native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| native/macos/Fae/Sources/Fae/ML/KokoroFallbackCacheSeeder.swift | Adds cache root resolution and idempotent copying for bundled Kokoro config and weights. |
| native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift | Seeds the fallback cache and bounds fallback loading, but caches the engine even when loading times out or fails. |
| native/macos/Fae/Sources/Fae/Pipeline/TTSState.swift | Adds the fallback load timeout constant. |
| native/macos/Fae/Tests/IntegrationTests/KokoroFallbackCacheSeederTests.swift | Adds tests for cache path precedence, repo subdir pinning, copy behavior, idempotency, and missing-source handling. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
native/macos/Fae/Sources/Fae/Pipeline/PipelineCoordinator.swift:5663-5675
**Unloaded Fallback Engine Stays Cached**

When the new load watchdog times out or `engine.load` fails, this line still stores the unloaded adapter in `fallbackTTSEngine`. Later fallback calls return that cached adapter without retrying `seedIfNeeded` or `load`, so `synthesizeLocally` keeps hitting `isLoaded == false` and fallback replies remain silent until the coordinator is recreated.

```suggestion
        if loaded {
            NSLog(
                "PipelineCoordinator: in-process Kokoro TTS fallback LOADED (voice=%@, modelID=%@) — " +
                    "replies stay audible even when the daemon TTS lane fails",
                voice, modelID)
            fallbackTTSEngine = engine
        } else {
            NSLog(
                "PipelineCoordinator: in-process Kokoro TTS fallback unavailable (load timeout/error, modelID=%@) — the next " +
                    "reply may be silent until the daemon TTS lane recovers",
                modelID)
        }
        return engine
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tts): seed bundled Kokoro into HF c..."](https://github.com/saorsa-labs/fae/commit/dae9edfb18227aff805ccdf7301b13e5d8a37ff1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43264623)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->