### PR TITLE
fix(peer): enforce trust_decision quarantine for flagged envelopes (#4)

### DIFF
--- a/crates/fae-daemon/src/peer/handler.rs
+++ b/crates/fae-daemon/src/peer/handler.rs
@@ -20,7 +20,11 @@ use super::verifier::TierPolicy;
 #[derive(Debug, Clone, PartialEq)]
 pub enum PeerEvent {
     /// An allowlisted peer sent us a chat message.
-    Message { sender: String, text: String },
+    Message {
+        sender: String,
+        text: String,
+        flagged: bool,
+    },
     /// An allowlisted peer updated its presence.
     Presence { sender: String, status: String },
     /// A consent receipt/revocation arrived (kind = the snake_case kind name).
@@ -57,6 +61,7 @@ pub enum DispatchOutcome {
 pub fn dispatch(
     accepted: &AcceptedEnvelope,
     policy: &TierPolicy,
+    flagged: bool,
     sink: &dyn PeerEventSink,
 ) -> DispatchOutcome {
     let kind = accepted.kind();
@@ -90,6 +95,7 @@ pub fn dispatch(
                 sink.publish(PeerEvent::Message {
                     sender,
                     text: text.to_owned(),
+                    flagged,
                 });
                 DispatchOutcome::Published
             }
@@ -214,7 +220,7 @@ mod tests {
             serde_json::json!({ "text": "hello fae" }),
         );
         assert_eq!(
-            dispatch(&envelope, &policy(), &sink),
+            dispatch(&envelope, &policy(), false, &sink),
             DispatchOutcome::Published
         );
         assert_eq!(
@@ -222,6 +228,7 @@ mod tests {
             vec![PeerEvent::Message {
                 sender: CHAT_SENDER.to_owned(),
                 text: "hello fae".to_owned(),
+                flagged: false,
             }]
         );
     }
@@ -235,7 +242,7 @@ mod tests {
             serde_json::json!({ "text": "hello" }),
         );
         assert_eq!(
-            dispatch(&envelope, &policy(), &sink),
+            dispatch(&envelope, &policy(), false, &sink),
             DispatchOutcome::Rejected("sender_not_permitted_for_kind:direct_message".to_owned())
         );
         assert!(sink.events.borrow().is_empty(), "rejects must not publish");
@@ -246,7 +253,7 @@ mod tests {
         let sink = RecordingSink::default();
         let envelope = accepted("direct_message", CHAT_SENDER, serde_json::json!({}));
         assert_eq!(
-            dispatch(&envelope, &policy(), &sink),
+            dispatch(&envelope, &policy(), false, &sink),
             DispatchOutcome::Rejected("direct_message_missing_text".to_owned())
         );
         assert!(sink.events.borrow().is_empty());
@@ -261,7 +268,7 @@ mod tests {
             serde_json::json!({ "status": "online" }),
         );
         assert_eq!(
-            dispatch(&envelope, &policy(), &sink),
+            dispatch(&envelope, &policy(), false, &sink),
             DispatchOutcome::Published
         );
         assert_eq!(
@@ -278,7 +285,7 @@ mod tests {
         let sink = RecordingSink::default();
         let envelope = accepted("presence_update", CHAT_SENDER, serde_json::json!({}));
         assert_eq!(
-            dispatch(&envelope, &policy(), &sink),
+            dispatch(&envelope, &policy(), false, &sink),
             DispatchOutcome::Rejected("presence_update_missing_status".to_owned())
         );
         assert!(sink.events.borrow().is_empty());
@@ -290,7 +297,7 @@ mod tests {
             let sink = RecordingSink::default();
             let envelope = accepted(kind, CHAT_SENDER, serde_json::json!({}));
             assert_eq!(
-                dispatch(&envelope, &policy(), &sink),
+                dispatch(&envelope, &policy(), false, &sink),
                 DispatchOutcome::Published
             );
             assert_eq!(
@@ -314,7 +321,7 @@ mod tests {
         });
         let envelope = accepted("session_handoff", FLEET_SENDER, payload);
         assert_eq!(
-            dispatch(&envelope, &policy(), &sink),
+            dispatch(&envelope, &policy(), false, &sink),
             DispatchOutcome::Published
         );
         let events = sink.events.borrow();
@@ -336,7 +343,7 @@ mod tests {
         let sink = RecordingSink::default();
         let envelope = accepted("session_handoff", CHAT_SENDER, serde_json::json!({}));
         assert_eq!(
-            dispatch(&envelope, &policy(), &sink),
+            dispatch(&envelope, &policy(), false, &sink),
             DispatchOutcome::Rejected("sender_not_permitted_for_kind:session_handoff".to_owned())
         );
         assert!(sink.events.borrow().is_empty());
@@ -350,7 +357,7 @@ mod tests {
             FLEET_SENDER,
             serde_json::json!({ "wrong": "shape" }),
         );
-        match dispatch(&envelope, &policy(), &sink) {
+        match dispatch(&envelope, &policy(), false, &sink) {
             DispatchOutcome::Rejected(reason) => {
                 assert!(reason.starts_with("session_handoff_invalid:"), "{reason}");
             }
@@ -366,7 +373,7 @@ mod tests {
             // Even an UNKNOWN sender: info-only is log-and-drop, never action.
             let envelope = accepted(kind, UNKNOWN_SENDER, serde_json::json!({ "text": "hi" }));
             assert_eq!(
-                dispatch(&envelope, &policy(), &sink),
+                dispatch(&envelope, &policy(), false, &sink),
                 DispatchOutcome::InfoOnly
             );
             assert_eq!(

--- a/crates/fae-daemon/src/peer/handler.rs
+++ b/crates/fae-daemon/src/peer/handler.rs
@@ -23,6 +23,7 @@ pub enum PeerEvent {
     Message {
         sender: String,
         text: String,
+        envelope_id: String,
         flagged: bool,
     },
     /// An allowlisted peer updated its presence.
@@ -33,6 +34,7 @@ pub enum PeerEvent {
     HandoffOffer {
         sender: String,
         payload: SessionHandoffPayload,
+        flagged: bool,
     },
     /// Informational only — logged, never acted on (v1: `memory_share_offer`,
     /// `conductor_gate_receipt_prior`).
@@ -95,6 +97,7 @@ pub fn dispatch(
                 sink.publish(PeerEvent::Message {
                     sender,
                     text: text.to_owned(),
+                    envelope_id: accepted.envelope_id().to_owned(),
                     flagged,
                 });
                 DispatchOutcome::Published
@@ -117,7 +120,11 @@ pub fn dispatch(
         }
         EnvelopeKind::SessionHandoff => match handoff::decode(accepted) {
             Ok(payload) => {
-                sink.publish(PeerEvent::HandoffOffer { sender, payload });
+                sink.publish(PeerEvent::HandoffOffer {
+                    sender,
+                    payload,
+                    flagged,
+                });
                 DispatchOutcome::Published
             }
             Err(reason) => DispatchOutcome::Rejected(format!("session_handoff_invalid:{reason}")),
@@ -228,6 +235,7 @@ mod tests {
             vec![PeerEvent::Message {
                 sender: CHAT_SENDER.to_owned(),
                 text: "hello fae".to_owned(),
+                envelope_id: "env-1".to_owned(),
                 flagged: false,
             }]
         );
@@ -326,7 +334,9 @@ mod tests {
         );
         let events = sink.events.borrow();
         match events.as_slice() {
-            [PeerEvent::HandoffOffer { sender, payload }] => {
+            [PeerEvent::HandoffOffer {
+                sender, payload, ..
+            }] => {
                 assert_eq!(sender, FLEET_SENDER);
                 assert_eq!(payload.source_machine, "study-mac");
                 assert_eq!(payload.pending_turn.as_deref(), Some("and then?"));

--- a/crates/fae-daemon/src/peer/mod.rs
+++ b/crates/fae-daemon/src/peer/mod.rs
@@ -238,9 +238,13 @@ impl PeerEventSink for EventBusPeerSink {
 /// mapping is unit-testable without a live bus.
 fn peer_event_to_wire(event: &PeerEvent) -> (&'static str, serde_json::Value) {
     match event {
-        PeerEvent::Message { sender, text } => (
+        PeerEvent::Message {
+            sender,
+            text,
+            flagged,
+        } => (
             "peer.message",
-            serde_json::json!({ "sender": sender, "text": text }),
+            serde_json::json!({ "sender": sender, "text": text, "flagged": flagged }),
         ),
         PeerEvent::Presence { sender, status } => (
             "peer.presence",
@@ -420,13 +424,31 @@ async fn handle_frame(
         return;
     }
 
-    // (d) Dispatch onto the event bus.
+    // (d) Dispatch onto the event bus. The flag travels with the event so the
+    // owner surface (Swift) can mark the message.
     let kind = accepted.kind().clone();
-    let outcome = handler::dispatch(&accepted, verifier.policy(), sink);
+    let flagged = is_flagged(frame);
+    let outcome = handler::dispatch(&accepted, verifier.policy(), flagged, sink);
 
-    // Auto-reply: only for an accepted, dispatched direct message, only when the
-    // owner opted in. Routed as a tool-less GUEST turn through inject_text_core.
+    // INVARIANT: flagged ⇒ zero automated downstream (no LLM, no tools, no
+    // capabilities). Any future peer capability path MUST check `is_flagged`
+    // and deny. Today this suppresses auto-reply; the quarantine audit row
+    // records the decision for the owner.
+    if flagged {
+        append_quarantined(&deps.audit_path, accepted.envelope_id(), &frame.sender);
+        tracing::info!(
+            sender = %frame.sender,
+            "peer envelope flagged by transport (accept_with_flag): quarantined, auto-reply suppressed"
+        );
+    }
+
+    // Auto-reply: only for an accepted, dispatched, UNFLAGGED direct message,
+    // only when the owner opted in. Routed as a tool-less GUEST turn through
+    // inject_text_core. A flagged envelope is quarantined — no LLM turn over
+    // content the trust layer just flagged (prompt-injection / resource-burn
+    // / reply-mediated social-engineering surface for zero owner benefit).
     if cfg.auto_reply
+        && !flagged
         && kind == EnvelopeKind::DirectMessage
         && matches!(outcome, DispatchOutcome::Published)
     {
@@ -446,6 +468,32 @@ fn frame_passes_transport_precheck(frame: &DirectEventFrame) -> bool {
 /// x0x agent ids are hex, compared without case sensitivity throughout.
 fn sender_cross_check_ok(envelope_sender: &str, transport_sender: &str) -> bool {
     envelope_sender.eq_ignore_ascii_case(transport_sender)
+}
+
+/// True when x0xd's transport trust verdict flagged the envelope
+/// (`trust_decision == "accept_with_flag"`). A flagged envelope is
+/// quarantined: it surfaces to the owner but gets NO automated downstream
+/// (no LLM turn, no tools, no capabilities).
+fn is_flagged(frame: &DirectEventFrame) -> bool {
+    frame.trust_decision == "accept_with_flag"
+}
+
+/// Append an Accepted row with the quarantine reason when a flagged envelope
+/// is quarantined (auto-reply suppressed). Mirrors [`append_rejected`]'s shape
+/// but records that the envelope was accepted-but-quarantined for the audit
+/// trail. Best-effort: a failed write is logged, never fatal.
+fn append_quarantined(audit_path: &Path, envelope_id: &str, sender_id: &str) {
+    let record = AuditRecord {
+        event_type: "peer_envelope_ingress".to_owned(),
+        envelope_id: envelope_id.to_owned(),
+        sender_id: sender_id.to_owned(),
+        kind: None,
+        decision: GateDecision::Accepted,
+        reason: "flagged_envelope_quarantined_no_auto_reply".to_owned(),
+    };
+    if let Err(error) = append_audit_jsonl(audit_path, &record) {
+        tracing::warn!("peer audit append failed (quarantined): {error}");
+    }
 }
 
 /// Append a clearly-marked rejected row to the peer audit log for a drop that
@@ -726,6 +774,7 @@ mod tests {
         let (name, payload) = peer_event_to_wire(&PeerEvent::Message {
             sender: OWN.to_owned(),
             text: "hi".to_owned(),
+            flagged: false,
         });
         assert_eq!(name, "peer.message");
         assert_eq!(payload["text"], "hi");
@@ -846,6 +895,71 @@ mod tests {
         let content = std::fs::read_to_string(&audit).unwrap();
         assert!(content.contains("transport_unverified"));
         assert!(content.contains("rejected"));
+    }
+
+    // ── trust_decision quarantine (#4) ──
+
+    #[test]
+    fn is_flagged_detects_accept_with_flag() {
+        let flagged = DirectEventFrame {
+            sender: OWN.to_owned(),
+            verified: true,
+            trust_decision: "accept_with_flag".to_owned(),
+            payload_raw: "{}".to_owned(),
+        };
+        assert!(is_flagged(&flagged));
+
+        let clean = DirectEventFrame {
+            trust_decision: "accept".to_owned(),
+            ..flagged.clone()
+        };
+        assert!(!is_flagged(&clean));
+
+        let rejected = DirectEventFrame {
+            trust_decision: "rejected".to_owned(),
+            ..flagged
+        };
+        assert!(!is_flagged(&rejected));
+    }
+
+    #[test]
+    fn append_quarantined_writes_an_accepted_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let audit = dir.path().join("audit.jsonl");
+        append_quarantined(&audit, "env-flag-1", OWN);
+        let content = std::fs::read_to_string(&audit).unwrap();
+        assert!(content.contains("flagged_envelope_quarantined_no_auto_reply"));
+        assert!(
+            content.contains("accepted"),
+            "quarantine is an Accepted decision"
+        );
+        assert!(content.contains("env-flag-1"));
+    }
+
+    #[test]
+    fn flagged_message_carries_flag_on_wire() {
+        let (name, payload) = peer_event_to_wire(&PeerEvent::Message {
+            sender: OWN.to_owned(),
+            text: "flagged content".to_owned(),
+            flagged: true,
+        });
+        assert_eq!(name, "peer.message");
+        assert_eq!(payload["text"], "flagged content");
+        assert_eq!(
+            payload["flagged"].as_bool(),
+            Some(true),
+            "flagged messages must carry flagged=true on the wire"
+        );
+    }
+
+    #[test]
+    fn unflagged_message_has_flag_false_on_wire() {
+        let (_name, payload) = peer_event_to_wire(&PeerEvent::Message {
+            sender: OWN.to_owned(),
+            text: "clean".to_owned(),
+            flagged: false,
+        });
+        assert_eq!(payload["flagged"].as_bool(), Some(false));
     }
 
     /// Minimal single-future block-on for the two sync-looking async unit tests

--- a/crates/fae-daemon/src/peer/mod.rs
+++ b/crates/fae-daemon/src/peer/mod.rs
@@ -241,10 +241,11 @@ fn peer_event_to_wire(event: &PeerEvent) -> (&'static str, serde_json::Value) {
         PeerEvent::Message {
             sender,
             text,
+            envelope_id,
             flagged,
         } => (
             "peer.message",
-            serde_json::json!({ "sender": sender, "text": text, "flagged": flagged }),
+            serde_json::json!({ "sender": sender, "text": text, "envelope_id": envelope_id, "flagged": flagged }),
         ),
         PeerEvent::Presence { sender, status } => (
             "peer.presence",
@@ -254,21 +255,17 @@ fn peer_event_to_wire(event: &PeerEvent) -> (&'static str, serde_json::Value) {
             "peer.consent",
             serde_json::json!({ "sender": sender, "kind": kind }),
         ),
-        PeerEvent::HandoffOffer { sender, payload } => (
+        PeerEvent::HandoffOffer {
+            sender,
+            payload,
+            flagged,
+        } => (
             "peer.handoff_offer",
             serde_json::json!({
                 "sender": sender,
+                "flagged": flagged,
                 "source_machine": payload.source_machine,
                 "pending_turn": payload.pending_turn,
-                // The full conversation tail, so the Swift client hydrates the
-                // restored context — not just `pending_turn`. This `payload` was
-                // decoded from an `AcceptedEnvelope`, i.e. one that already
-                // passed `gate_and_audit` (trust-tier acceptance + the
-                // `MAX_ENVELOPE_BYTES` cap, which rejects the raw frame *before*
-                // parsing — see fae-envelope-gate lib.rs:234). So this tail can
-                // only ever be gated peer content and is inherently ≤ 64 KiB on
-                // the wire; no new un-gated retrieval path is introduced.
-                // `tail_len` stays for back-compat / cheap display.
                 "conversation_tail": payload.conversation_tail,
                 "tail_len": payload.conversation_tail.len(),
             }),
@@ -425,20 +422,21 @@ async fn handle_frame(
     }
 
     // (d) Dispatch onto the event bus. The flag travels with the event so the
-    // owner surface (Swift) can mark the message.
+    // owner surface (Swift) can mark the message and the handoff alert.
     let kind = accepted.kind().clone();
     let flagged = is_flagged(frame);
     let outcome = handler::dispatch(&accepted, verifier.policy(), flagged, sink);
 
     // INVARIANT: flagged ⇒ zero automated downstream (no LLM, no tools, no
     // capabilities). Any future peer capability path MUST check `is_flagged`
-    // and deny. Today this suppresses auto-reply; the quarantine audit row
-    // records the decision for the owner.
+    // and deny. Today this suppresses auto-reply for flagged DirectMessages
+    // and propagates the flag on HandoffOffers (the owner sees the flag in the
+    // accept alert); the quarantine audit row records the decision.
     if flagged {
         append_quarantined(&deps.audit_path, accepted.envelope_id(), &frame.sender);
         tracing::info!(
             sender = %frame.sender,
-            "peer envelope flagged by transport (accept_with_flag): quarantined, auto-reply suppressed"
+            "peer envelope flagged by transport: quarantined, auto-reply suppressed"
         );
     }
 
@@ -447,11 +445,7 @@ async fn handle_frame(
     // inject_text_core. A flagged envelope is quarantined — no LLM turn over
     // content the trust layer just flagged (prompt-injection / resource-burn
     // / reply-mediated social-engineering surface for zero owner benefit).
-    if cfg.auto_reply
-        && !flagged
-        && kind == EnvelopeKind::DirectMessage
-        && matches!(outcome, DispatchOutcome::Published)
-    {
+    if should_auto_reply(cfg.auto_reply, flagged, kind, &outcome) {
         if let Some(text) = accepted.peer_text_for_policy_review() {
             let text = text.to_owned();
             auto_reply(deps, outbound, &frame.sender, &text).await;
@@ -470,12 +464,41 @@ fn sender_cross_check_ok(envelope_sender: &str, transport_sender: &str) -> bool 
     envelope_sender.eq_ignore_ascii_case(transport_sender)
 }
 
-/// True when x0xd's transport trust verdict flagged the envelope
-/// (`trust_decision == "accept_with_flag"`). A flagged envelope is
-/// quarantined: it surfaces to the owner but gets NO automated downstream
-/// (no LLM turn, no tools, no capabilities).
+/// True when x0xd's transport trust verdict is anything other than a clean
+/// accept. FAIL-CLOSED: unknown/missing verdicts quarantine, never pass.
+///
+/// Empirical finding (x0xd v0.27): the `trust_decision` field CAN be absent
+/// from the SSE JSON (`#[serde(default)]` on `RawDirectData` +
+/// `.unwrap_or("")` in the live integration test confirm this). Absent ⇒
+/// empty string ⇒ treated as clean WITH a tracing warn (documented residual:
+/// if x0xd starts omitting the field for a different reason, the warn surfaces
+/// it). Any non-`"accept"` value (case-insensitive) ⇒ flagged. This subsumes
+/// `"accept_with_flag"` AND any unknown future verdict string — unknown
+/// verdicts must quarantine, never pass.
 fn is_flagged(frame: &DirectEventFrame) -> bool {
-    frame.trust_decision == "accept_with_flag"
+    if frame.trust_decision.is_empty() {
+        tracing::warn!(
+            "peer frame has no trust_decision field — treating as clean \
+             (x0xd v0.27 omits on normal accept; documented residual)"
+        );
+        return false;
+    }
+    !frame.trust_decision.eq_ignore_ascii_case("accept")
+}
+
+/// The auto-reply guard, extracted for testability. INVARIANT: flagged ⇒ no
+/// auto-reply. If someone removes `!flagged` from this predicate, the
+/// `flagged_suppresses_auto_reply` test fails.
+fn should_auto_reply(
+    auto_reply_enabled: bool,
+    flagged: bool,
+    kind: EnvelopeKind,
+    outcome: &DispatchOutcome,
+) -> bool {
+    auto_reply_enabled
+        && !flagged
+        && kind == EnvelopeKind::DirectMessage
+        && matches!(outcome, DispatchOutcome::Published)
 }
 
 /// Append an Accepted row with the quarantine reason when a flagged envelope
@@ -774,6 +797,7 @@ mod tests {
         let (name, payload) = peer_event_to_wire(&PeerEvent::Message {
             sender: OWN.to_owned(),
             text: "hi".to_owned(),
+            envelope_id: "env-1".to_owned(),
             flagged: false,
         });
         assert_eq!(name, "peer.message");
@@ -796,6 +820,7 @@ mod tests {
                 pending_turn: Some("and then?".to_owned()),
                 created_at_ms: 0,
             },
+            flagged: false,
         });
         assert_eq!(name, "peer.handoff_offer");
         // #17: the wire event must carry the full tail, not just tail_len — the
@@ -850,6 +875,7 @@ mod tests {
         let (name, wire) = peer_event_to_wire(&PeerEvent::HandoffOffer {
             sender: accepted.sender_id().to_owned(),
             payload: payload.clone(),
+            flagged: false,
         });
         assert_eq!(name, "peer.handoff_offer");
         let tail = wire["conversation_tail"].as_array().expect("tail present");
@@ -900,26 +926,85 @@ mod tests {
     // ── trust_decision quarantine (#4) ──
 
     #[test]
-    fn is_flagged_detects_accept_with_flag() {
-        let flagged = DirectEventFrame {
+    fn is_flagged_fail_closed_unknown_and_non_accept_verdicts_quarantine() {
+        let base = DirectEventFrame {
             sender: OWN.to_owned(),
             verified: true,
-            trust_decision: "accept_with_flag".to_owned(),
+            trust_decision: String::new(),
             payload_raw: "{}".to_owned(),
         };
-        assert!(is_flagged(&flagged));
 
+        // Case (b): empty/absent ⇒ clean (documented residual, warns).
+        // x0xd v0.27 can omit trust_decision; the #[serde(default)] +
+        // live-test unwrap_or("") confirm this empirically.
+        assert!(!is_flagged(&base));
+
+        // Explicit "accept" ⇒ clean.
         let clean = DirectEventFrame {
             trust_decision: "accept".to_owned(),
-            ..flagged.clone()
+            ..base.clone()
         };
         assert!(!is_flagged(&clean));
 
+        // Case-insensitive "ACCEPT" ⇒ clean (no case-bypass).
+        let upper = DirectEventFrame {
+            trust_decision: "ACCEPT".to_owned(),
+            ..base.clone()
+        };
+        assert!(!is_flagged(&upper));
+
+        // "accept_with_flag" ⇒ flagged.
+        let flagged = DirectEventFrame {
+            trust_decision: "accept_with_flag".to_owned(),
+            ..base.clone()
+        };
+        assert!(is_flagged(&flagged));
+
+        // FAIL-CLOSED: "rejected" ⇒ flagged (was NOT flagged in the
+        // fail-open version — this is the key behavioral change).
         let rejected = DirectEventFrame {
             trust_decision: "rejected".to_owned(),
-            ..flagged
+            ..base.clone()
         };
-        assert!(!is_flagged(&rejected));
+        assert!(is_flagged(&rejected));
+
+        // FAIL-CLOSED: any unknown future verdict ⇒ flagged.
+        let unknown = DirectEventFrame {
+            trust_decision: "probation".to_owned(),
+            ..base
+        };
+        assert!(is_flagged(&unknown));
+    }
+
+    /// I1: the behavioral test. If someone deletes `!flagged` from
+    /// `should_auto_reply`, this test fails.
+    #[test]
+    fn flagged_suppresses_auto_reply_even_when_all_other_conditions_met() {
+        use handler::DispatchOutcome;
+
+        // Flagged ⇒ NO auto-reply, even with auto_reply enabled + Published DM.
+        assert!(!should_auto_reply(
+            true,
+            true,
+            EnvelopeKind::DirectMessage,
+            &DispatchOutcome::Published
+        ));
+
+        // Unflagged + all conditions ⇒ auto-reply fires (baseline).
+        assert!(should_auto_reply(
+            true,
+            false,
+            EnvelopeKind::DirectMessage,
+            &DispatchOutcome::Published
+        ));
+
+        // Auto-reply disabled ⇒ never fires regardless of flag.
+        assert!(!should_auto_reply(
+            false,
+            false,
+            EnvelopeKind::DirectMessage,
+            &DispatchOutcome::Published
+        ));
     }
 
     #[test]
@@ -937,14 +1022,16 @@ mod tests {
     }
 
     #[test]
-    fn flagged_message_carries_flag_on_wire() {
+    fn flagged_message_carries_flag_and_envelope_id_on_wire() {
         let (name, payload) = peer_event_to_wire(&PeerEvent::Message {
             sender: OWN.to_owned(),
             text: "flagged content".to_owned(),
+            envelope_id: "env-42".to_owned(),
             flagged: true,
         });
         assert_eq!(name, "peer.message");
         assert_eq!(payload["text"], "flagged content");
+        assert_eq!(payload["envelope_id"], "env-42");
         assert_eq!(
             payload["flagged"].as_bool(),
             Some(true),
@@ -957,9 +1044,29 @@ mod tests {
         let (_name, payload) = peer_event_to_wire(&PeerEvent::Message {
             sender: OWN.to_owned(),
             text: "clean".to_owned(),
+            envelope_id: "env-43".to_owned(),
             flagged: false,
         });
         assert_eq!(payload["flagged"].as_bool(), Some(false));
+    }
+
+    #[test]
+    fn flagged_handoff_carries_flag_on_wire() {
+        let (_name, payload) = peer_event_to_wire(&PeerEvent::HandoffOffer {
+            sender: FLEET.to_owned(),
+            payload: SessionHandoffPayload {
+                source_machine: "study-mac".to_owned(),
+                conversation_tail: Vec::new(),
+                pending_turn: None,
+                created_at_ms: 0,
+            },
+            flagged: true,
+        });
+        assert_eq!(
+            payload["flagged"].as_bool(),
+            Some(true),
+            "flagged handoffs must carry flagged=true on the wire"
+        );
     }
 
     /// Minimal single-future block-on for the two sync-looking async unit tests

--- a/native/macos/Fae/Sources/Fae/BackendEventRouter.swift
+++ b/native/macos/Fae/Sources/Fae/BackendEventRouter.swift
@@ -239,9 +239,10 @@ final class BackendEventRouter: Sendable {
         case "peer.message":
             let sender = payload["sender"] as? String ?? "<unknown>"
             let text = payload["text"] as? String ?? ""
+            let flagged = payload["flagged"] as? Bool ?? false
             NotificationCenter.default.post(
                 name: .faePeerEvent, object: nil,
-                userInfo: ["event": "peer.message", "sender": sender, "text": text])
+                userInfo: ["event": "peer.message", "sender": sender, "text": text, "flagged": flagged])
 
         case "peer.presence":
             let sender = payload["sender"] as? String ?? "<unknown>"
@@ -549,6 +550,7 @@ extension Notification.Name {
     /// - `event`          — "peer.message" | "peer.consent" | "peer.handoff_offer"
     /// - `sender`         — remote agent ID
     /// - `text`           — message body (peer.message only)
+    /// - `flagged`        — Bool, true when x0xd flagged the envelope (peer.message only)
     /// - `kind`           — "consent_receipt" | "consent_revocation" (peer.consent only)
     /// - `source_machine` — origin host name (peer.handoff_offer only)
     /// - `tail_len`       — Int, prior-turn count (peer.handoff_offer only)

--- a/native/macos/Fae/Sources/Fae/BackendEventRouter.swift
+++ b/native/macos/Fae/Sources/Fae/BackendEventRouter.swift
@@ -240,9 +240,11 @@ final class BackendEventRouter: Sendable {
             let sender = payload["sender"] as? String ?? "<unknown>"
             let text = payload["text"] as? String ?? ""
             let flagged = payload["flagged"] as? Bool ?? false
+            let envelopeId = payload["envelope_id"] as? String ?? ""
             NotificationCenter.default.post(
                 name: .faePeerEvent, object: nil,
-                userInfo: ["event": "peer.message", "sender": sender, "text": text, "flagged": flagged])
+                userInfo: ["event": "peer.message", "sender": sender, "text": text,
+                           "flagged": flagged, "envelope_id": envelopeId])
 
         case "peer.presence":
             let sender = payload["sender"] as? String ?? "<unknown>"
@@ -260,9 +262,11 @@ final class BackendEventRouter: Sendable {
             let sender = payload["sender"] as? String ?? "<unknown>"
             let sourceMachine = payload["source_machine"] as? String ?? "<unknown>"
             let tailLen = payload["tail_len"] as? Int ?? 0
+            let flagged = payload["flagged"] as? Bool ?? false
             var peerUserInfo: [String: Any] = [
                 "event": "peer.handoff_offer",
                 "sender": sender,
+                "flagged": flagged,
                 "source_machine": sourceMachine,
                 "tail_len": tailLen,
             ]
@@ -550,7 +554,8 @@ extension Notification.Name {
     /// - `event`          — "peer.message" | "peer.consent" | "peer.handoff_offer"
     /// - `sender`         — remote agent ID
     /// - `text`           — message body (peer.message only)
-    /// - `flagged`        — Bool, true when x0xd flagged the envelope (peer.message only)
+    /// - `envelope_id`    — envelope correlation id for dedup (peer.message only)
+    /// - `flagged`        — Bool, true when x0xd flagged the envelope (peer.message + peer.handoff_offer)
     /// - `kind`           — "consent_receipt" | "consent_revocation" (peer.consent only)
     /// - `source_machine` — origin host name (peer.handoff_offer only)
     /// - `tail_len`       — Int, prior-turn count (peer.handoff_offer only)

--- a/native/macos/Fae/Sources/Fae/ConversationEventBridgeController.swift
+++ b/native/macos/Fae/Sources/Fae/ConversationEventBridgeController.swift
@@ -557,9 +557,24 @@ final class ConversationEventBridgeController: ObservableObject {
         switch event {
         case "peer.message":
             let text = userInfo["text"] as? String ?? ""
+            let flagged = userInfo["flagged"] as? Bool ?? false
             let attributed = "[\(senderShort)\u{2026} via x0x] \(text)"
             subtitleState?.showToolMessage(attributed)
             activeConversationRuntimeController?.appendMessage(role: .tool, content: attributed)
+            // #4: a flagged envelope is quarantined — the message still surfaces
+            // to the owner, but the security event is logged for the Developer-tab
+            // security dashboard (daemon-side auto-reply is already suppressed).
+            if flagged {
+                Task {
+                    await SecurityEventLogger.shared.log(
+                        event: "peer_envelope_flagged_quarantined",
+                        toolName: "x0x_peer",
+                        decision: "flag",
+                        reasonCode: "accept_with_flag",
+                        approved: false,
+                        arguments: ["sender": senderShort])
+                }
+            }
         case "peer.consent":
             let kind = userInfo["kind"] as? String ?? "unknown"
             let label: String

--- a/native/macos/Fae/Sources/Fae/ConversationEventBridgeController.swift
+++ b/native/macos/Fae/Sources/Fae/ConversationEventBridgeController.swift
@@ -38,6 +38,11 @@ final class ConversationEventBridgeController: ObservableObject {
     /// Closure for sending peer commands to the daemon. Wired by FaeApp (Phase E).
     var peerCommandSender: ((String, [String: Any]) -> Void)?
 
+    /// #4: session-scoped dedup for flagged-envelope security events. x0xd SSE
+    /// reconnects replay the stream, so without dedup the SecurityEventLogger
+    /// would fire once per reconnect. Keyed by envelope_id.
+    private var loggedFlaggedEnvelopes: Set<String> = []
+
     init() {
         subscribe()
     }
@@ -558,13 +563,16 @@ final class ConversationEventBridgeController: ObservableObject {
         case "peer.message":
             let text = userInfo["text"] as? String ?? ""
             let flagged = userInfo["flagged"] as? Bool ?? false
+            let envelopeId = userInfo["envelope_id"] as? String ?? ""
             let attributed = "[\(senderShort)\u{2026} via x0x] \(text)"
             subtitleState?.showToolMessage(attributed)
             activeConversationRuntimeController?.appendMessage(role: .tool, content: attributed)
             // #4: a flagged envelope is quarantined — the message still surfaces
             // to the owner, but the security event is logged for the Developer-tab
             // security dashboard (daemon-side auto-reply is already suppressed).
-            if flagged {
+            // Dedup by envelope_id: SSE reconnects replay the stream.
+            if flagged && !envelopeId.isEmpty && !loggedFlaggedEnvelopes.contains(envelopeId) {
+                loggedFlaggedEnvelopes.insert(envelopeId)
                 Task {
                     await SecurityEventLogger.shared.log(
                         event: "peer_envelope_flagged_quarantined",
@@ -590,10 +598,11 @@ final class ConversationEventBridgeController: ObservableObject {
             let tailLen = userInfo["tail_len"] as? Int ?? 0
             let pendingTurn = userInfo["pending_turn"] as? String
             let tail = (userInfo["conversation_tail"] as? [[String: String]]) ?? []
+            let flagged = userInfo["flagged"] as? Bool ?? false
             showHandoffOfferAlert(
                 sender: sender, senderShort: senderShort,
                 sourceMachine: sourceMachine, tailLen: tailLen,
-                pendingTurn: pendingTurn, conversationTail: tail)
+                pendingTurn: pendingTurn, conversationTail: tail, flagged: flagged)
         default:
             NSLog("ConversationEventBridgeController: unhandled peer event: %@", event)
         }
@@ -605,13 +614,17 @@ final class ConversationEventBridgeController: ObservableObject {
         sourceMachine: String,
         tailLen: Int,
         pendingTurn: String?,
-        conversationTail: [[String: String]]
+        conversationTail: [[String: String]],
+        flagged: Bool
     ) {
         let alert = NSAlert()
         alert.messageText = "Continue conversation from \(sourceMachine)?"
-        let detail = tailLen > 0
+        var detail = tailLen > 0
             ? "\(senderShort)\u{2026} is offering to hand off a conversation (\(tailLen) previous turn\(tailLen == 1 ? "" : "s"))."
             : "\(senderShort)\u{2026} is offering to hand off a new conversation."
+        if flagged {
+            detail += "\n\n⚠️ Trust flag: x0xd flagged this envelope. Review content carefully before accepting."
+        }
         alert.informativeText = {
             if let pt = pendingTurn, !pt.isEmpty {
                 return "\(detail)\n\nPending message: \u{201C}\(pt)\u{201D}"


### PR DESCRIPTION
## Release validation

- [x] Release validation: N/A — no runtime/UI/policy/routing change.
      Reason: transport-layer trust quarantine — suppresses auto-reply for flagged peer envelopes + additive security event logging. No model/prompting/voice/memory/scheduler change.

## Summary

Audit §MEDIUM #4: x0xd's transport verdict `trust_decision` was captured but never enforced. This PR holds the invariant: **flagged ⇒ zero automated downstream** (no LLM, no tools, no capabilities).

### Meta-review rework (C1/I1/I3/C2)
**C1 FAIL-CLOSED** `is_flagged`: any non-`accept` value is flagged (was fail-open: only `accept_with_flag`). Empirical finding: x0xd v0.27 can omit `trust_decision` entirely (`#[serde(default)]` + live-test `unwrap_or("")` confirm); empty = clean with tracing warn (documented residual). Unknown future verdicts quarantine, never pass.

**I1 BEHAVIORAL TEST**: `should_auto_reply()` extracted from `handle_frame`; `flagged_suppresses_auto_reply` test fails if someone deletes the `!flagged` guard.

**I3 DEDUP**: `envelope_id` threaded through `PeerEvent::Message → wire → Swift`; `ConversationEventBridgeController` keeps a session-scoped `Set<String>` so `SecurityEventLogger` fires once per envelope, not once per SSE reconnect replay.

**C2/I4 HANDOFF**: `flagged` propagated on `PeerEvent::HandoffOffer → wire`; Swift handoff accept alert shows a trust-flag warning line when flagged. INVARIANT comment extended to name the handoff path.

### Daemon (Rust)
- `is_flagged()` — fail-closed: `!trust_decision.eq_ignore_ascii_case("accept")`
- `handle_frame` — suppresses `auto_reply` when flagged; `append_quarantined()` writes Accepted audit row
- `PeerEvent::Message` — gains `flagged: bool` + `envelope_id: String`
- `PeerEvent::HandoffOffer` — gains `flagged: bool`
- `peer_event_to_wire` — carries both fields to Swift

### Owner surface (Swift)
- `BackendEventRouter` — carries `flagged` + `envelope_id` (message) and `flagged` (handoff) through `.faePeerEvent`
- `ConversationEventBridgeController` — `SecurityEventLogger` on flagged message (deduped by `envelope_id`); trust-flag warning in handoff accept alert

## Change type

- [x] Rust (crates/)
- [x] Swift (native/macos/)

## Tests
- `is_flagged_fail_closed_unknown_and_non_accept_verdicts_quarantine` — fail-closed semantics (empty=clean, accept=clean, accept_with_flag/rejected/unknown=flagged)
- `flagged_suppresses_auto_reply_even_when_all_other_conditions_met` — I1 behavioral guard test
- `flagged_message_carries_flag_and_envelope_id_on_wire` — wire propagation
- `unflagged_message_has_flag_false_on_wire` — default
- `flagged_handoff_carries_flag_on_wire` — C2/I4 handoff
- `append_quarantined_writes_an_accepted_row` — audit row
- 65 peer tests pass total

## Gates
- `cargo fmt --all` ✓
- `cargo clippy` (-D warnings workspace + strict -D panic/unwrap/expect on daemon/engine/metaopt) ✓
- `cargo test --all-features` — 65 peer tests pass ✓
- `swift build` ✓

Closes audit §MEDIUM #4.