### PR TITLE
test(c): add FAE_SKIP_HEAVY_TESTS local-dev skip for EndToEnd tests (Mission C)

### DIFF
--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndBashReversibilityTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndBashReversibilityTests.swift
@@ -8,6 +8,11 @@ import XCTest
 /// so that changes to the allowlist are immediately visible in CI.
 final class EndToEndBashReversibilityTests: XCTestCase {
 
+    override func setUpWithError() throws {
+        try HeavyTestSkip.skipIfRequested()
+    }
+
+
     // MARK: - Reversible Commands
 
     /// `echo hello > /tmp/test.txt` → `.reversible` (file write, output path captured)

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndBatchUndoTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndBatchUndoTests.swift
@@ -11,6 +11,7 @@ final class EndToEndBatchUndoTests: XCTestCase {
     private var harness: TestRuntimeHarness!
 
     override func setUp() async throws {
+        try HeavyTestSkip.skipIfRequested()
         harness = try TestRuntimeHarness()
         await harness.setUp()
     }

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndBuiltInAwarenessTaskTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndBuiltInAwarenessTaskTests.swift
@@ -2,6 +2,11 @@ import XCTest
 @testable import Fae
 
 final class EndToEndBuiltInAwarenessTaskTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try HeavyTestSkip.skipIfRequested()
+    }
+
     private actor DispatchCapture {
         private(set) var taskIDs: [String] = []
         private(set) var allowedToolSets: [Set<String>] = []

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndIrreversibleCountdownTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndIrreversibleCountdownTests.swift
@@ -12,6 +12,11 @@ import XCTest
 /// active audio pipeline. Tests here cover the static decision layer only.
 final class EndToEndIrreversibleCountdownTests: XCTestCase {
 
+    override func setUpWithError() throws {
+        try HeavyTestSkip.skipIfRequested()
+    }
+
+
     // MARK: - Countdown Decision Tests
 
     /// Mail send action → requiresCountdown returns true.

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndMemoryFlowTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndMemoryFlowTests.swift
@@ -7,6 +7,7 @@ final class EndToEndMemoryFlowTests: XCTestCase {
     private var harness: TestRuntimeHarness!
 
     override func setUp() async throws {
+        try HeavyTestSkip.skipIfRequested()
         harness = try TestRuntimeHarness()
         await harness.setUp()
     }

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndNarrationAndBargeInTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndNarrationAndBargeInTests.swift
@@ -13,6 +13,7 @@ final class EndToEndNarrationAndBargeInTests: XCTestCase {
     private var harness: TestRuntimeHarness!
 
     override func setUp() async throws {
+        try HeavyTestSkip.skipIfRequested()
         harness = try TestRuntimeHarness()
         await harness.setUp()
     }

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndProactiveAwarenessRoutingTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndProactiveAwarenessRoutingTests.swift
@@ -2,6 +2,11 @@ import XCTest
 @testable import Fae
 
 final class EndToEndProactiveAwarenessRoutingTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try HeavyTestSkip.skipIfRequested()
+    }
+
     private actor DispatchCapture {
         private(set) var taskIDs: [String] = []
         private(set) var allowedTools: [Set<String>] = []

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndSchedulerAutonomyTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndSchedulerAutonomyTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import Fae
 
 final class EndToEndSchedulerAutonomyTests: XCTestCase {
+
     private actor DispatchCapture {
         private(set) var prompts: [String] = []
         private(set) var taskIDs: [String] = []
@@ -24,6 +25,7 @@ final class EndToEndSchedulerAutonomyTests: XCTestCase {
     private var originalSchedulerOverride: URL?
 
     override func setUpWithError() throws {
+        try HeavyTestSkip.skipIfRequested()
         tempDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("fae-e2e-scheduler-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndSchedulerFlowTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndSchedulerFlowTests.swift
@@ -19,6 +19,7 @@ final class EndToEndSchedulerFlowTests: XCTestCase {
     private var harness: TestRuntimeHarness!
 
     override func setUp() async throws {
+        try HeavyTestSkip.skipIfRequested()
         harness = try TestRuntimeHarness()
         await harness.setUp()
     }

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndSchedulerPersistenceStressTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndSchedulerPersistenceStressTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import Fae
 
 final class EndToEndSchedulerPersistenceStressTests: XCTestCase {
+
     private actor DispatchCapture {
         private(set) var taskIDs: [String] = []
 
@@ -19,6 +20,7 @@ final class EndToEndSchedulerPersistenceStressTests: XCTestCase {
     private var originalSchedulerOverride: URL?
 
     override func setUpWithError() throws {
+        try HeavyTestSkip.skipIfRequested()
         tempDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("fae-scheduler-stress-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndTextToolFlowTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndTextToolFlowTests.swift
@@ -11,6 +11,7 @@ final class EndToEndTextToolFlowTests: XCTestCase {
     private var harness: TestRuntimeHarness!
 
     override func setUp() async throws {
+        try HeavyTestSkip.skipIfRequested()
         harness = try TestRuntimeHarness()
         await harness.setUp()
     }

--- a/native/macos/Fae/Tests/IntegrationTests/EndToEndVoiceIdentityTests.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/EndToEndVoiceIdentityTests.swift
@@ -10,6 +10,7 @@ final class EndToEndVoiceIdentityTests: XCTestCase {
     private var harness: TestRuntimeHarness!
 
     override func setUp() async throws {
+        try HeavyTestSkip.skipIfRequested()
         harness = try TestRuntimeHarness()
         await harness.setUp()
     }

--- a/native/macos/Fae/Tests/IntegrationTests/HeavyTestSkip.swift
+++ b/native/macos/Fae/Tests/IntegrationTests/HeavyTestSkip.swift
@@ -1,0 +1,13 @@
+import XCTest
+
+/// Local-dev convenience: skip heavy EndToEnd tests when FAE_SKIP_HEAVY_TESTS=1.
+/// CI does NOT set this env var — the full suite runs in CI for coverage.
+/// Every skip prints a visible XCTSkip reason; never a silent green.
+enum HeavyTestSkip {
+    static func skipIfRequested() throws {
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["FAE_SKIP_HEAVY_TESTS"] == "1",
+            "Skipped via FAE_SKIP_HEAVY_TESTS=1 (local-dev convenience; CI runs the full suite)"
+        )
+    }
+}

--- a/native/macos/Fae/justfile
+++ b/native/macos/Fae/justfile
@@ -51,6 +51,10 @@ clean:
 test:
     swift test --skip EvalTests
 
+
+# Run fast tests only (skips EndToEnd via FAE_SKIP_HEAVY_TESTS=1; no dev-app quit needed)
+test-quick:
+    FAE_SKIP_HEAVY_TESTS=1 swift test --skip EvalTests
 # Run specific test target
 test-target target:
     swift test --filter {{target}}


### PR DESCRIPTION
## Release validation

- [x] Release validation: N/A — no runtime/UI/policy/routing change.
      Reason: test infrastructure only — adds local-dev convenience skip + just recipe. CI unchanged.

## Summary

Mission C: RuntimeContractTests isolation. The task premise was stale — RuntimeContractTests does NOT spawn daemons (creates FaeCore without start()), and config isolation already exists (fae-dev/ vs fae/). CI runs the full suite green on macos-26 runners (**case (a) confirmed**).

### Changes
- HeavyTestSkip.swift: XCTSkipIf(FAE_SKIP_HEAVY_TESTS==1) with loud reason string
- Applied to all 12 EndToEnd test classes (5 via setUp, 7 via setUpWithError)
- just test-quick recipe: runs fast suite without quitting the dev app
- CI UNCHANGED: no FAE_SKIP_HEAVY_TESTS in CI env, full coverage maintained

### G2 answer: case (a)
CI runs the full swift test suite (no filters, no skips) and passes green on macos-26 runners. No dev app, no port conflict, no XPC hangs. The skip is local-dev only.

## Change type
- [x] Docs / CI / tooling

## Gates
- swift build pass
- FAE_SKIP_HEAVY_TESTS=1 swift test pass (skips fire with loud reason)
- CI will run full suite unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a local skip path for heavy EndToEnd tests. The main changes are:

- A shared `HeavyTestSkip` helper gated by `FAE_SKIP_HEAVY_TESTS=1`.
- Skip setup added to the EndToEnd integration test classes.
- A Fae-local `test-quick` just recipe for the fast non-Eval test run.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small tooling cleanup.

- The XCTest helper is in the IntegrationTests target path.
- CI remains on the full test path because the skip variable is not set there.
- The only follow-up is exposing the new quick recipe from the same root workflow developers already use.

native/macos/Fae/justfile

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| native/macos/Fae/Tests/IntegrationTests/HeavyTestSkip.swift | Adds the shared XCTest helper for the local EndToEnd skip. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndBashReversibilityTests.swift | Adds the shared skip helper to setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndBatchUndoTests.swift | Adds the shared skip helper before harness setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndBuiltInAwarenessTaskTests.swift | Adds the shared skip helper to setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndIrreversibleCountdownTests.swift | Adds the shared skip helper to setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndMemoryFlowTests.swift | Adds the shared skip helper before harness setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndNarrationAndBargeInTests.swift | Adds the shared skip helper before harness setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndProactiveAwarenessRoutingTests.swift | Adds the shared skip helper to setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndSchedulerAutonomyTests.swift | Adds the shared skip helper before scheduler test state setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndSchedulerFlowTests.swift | Adds the shared skip helper before harness setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndSchedulerPersistenceStressTests.swift | Adds the shared skip helper before scheduler stress-test state setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndTextToolFlowTests.swift | Adds the shared skip helper before harness setup. |
| native/macos/Fae/Tests/IntegrationTests/EndToEndVoiceIdentityTests.swift | Adds the shared skip helper before harness setup. |
| native/macos/Fae/justfile | Adds the Fae-local quick test recipe that enables the EndToEnd skip. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
native/macos/Fae/justfile:56-57
**Root Recipe Is Missing**

The new quick-test workflow only exists in the Fae-local justfile. Developers who already run `just test` from the repo root can reasonably try `just test-quick` there and get no matching recipe, so the advertised fast local validation path is not available from the same entry point as the existing root test command.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(c): add FAE\_SKIP\_HEAVY\_TESTS local-..."](https://github.com/saorsa-labs/fae/commit/e358e7741e1b0964c54f239bbb7ebf9480204d8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43346046)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->