### PR TITLE
fix(ui): latch conversation pill to streamed content (#47)

### DIFF
--- a/docs/checklists/app-release-validation.md
+++ b/docs/checklists/app-release-validation.md
@@ -112,6 +112,7 @@ These scenarios are mandatory for the new canonical UI shell once it is included
 - [ ] Default menu (9 items): Talk to Fae · Settings… · [Hand off submenu if fleet non-empty] · Reset Conversation · Hide Fae · Stop · Ask Fae for Help · Rescue Mode… · Quit Fae. Engineering items (Scheduler, Skills, Edit Soul, Edit Custom Instructions, permissions ×6, Memory Inbox) are NOT present unless `ui.advancedMenus = true` in config (applies at next launch).
 - [ ] Rust shell menu does not include Cowork or Open Work with Fae.
 - [ ] Stop, Hide, and Quit perform their expected action.
+- [ ] Send a long response: the conversation pill grows and remains open through speech, follows streamed text while already at the bottom, stops following when the owner scrolls up, resumes after the owner returns to the bottom, and collapses only on explicit user-done or the next interaction.
 - [ ] Open Browser/Data Panel opens an orb-launched browser/webview surface for charts, data, documents, and video.
 - [ ] Scheduler and Skills open orb-owned temporary panels rather than Cowork.
 - [ ] Rich output does not require a permanent canvas or Cowork surface.

--- a/native/macos/Fae/Sources/Fae/RustUiShellController.swift
+++ b/native/macos/Fae/Sources/Fae/RustUiShellController.swift
@@ -389,11 +389,22 @@ final class RustUiShellController: PillInputRouting {
             .store(in: &cancellables)
 
         conversation?.$messages
-            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { [weak self] messages in
                 self?.sendConversationSnapshot(messages)
             }
             .store(in: &cancellables)
+
+        // The finalized transcript arrives through `$messages`, but the pill
+        // must follow the response while it is still streaming. Send the
+        // accumulated text independently so the Rust host can render one
+        // transient assistant entry without rebuilding conversation history.
+        conversation?.$streamingText
+            .removeDuplicates()
+            .sink { [weak self] text in
+                self?.sendConversationStream(text)
+            }
+            .store(in: &cancellables)
+
 
         // Voice spine V4 RETIRED (orb-host-owns-state, 2026-06-17): the orb
         // host now subscribes to the daemon's `audio.level` / `audio.playback_
@@ -569,6 +580,10 @@ final class RustUiShellController: PillInputRouting {
             }
             send(["type": "conversation", "role": role, "text": message.content])
         }
+    }
+
+    private func sendConversationStream(_ text: String) {
+        send(["type": "conversation_stream", "text": text])
     }
 
     private func send(_ object: [String: Any]) {

--- a/native/rust/fae-ui-shell/src/main.rs
+++ b/native/rust/fae-ui-shell/src/main.rs
@@ -134,6 +134,10 @@ struct OrbUiModel {
     /// status line (Listening / Thinking… / Speaking).
     ui_mode: FaeUiState,
     messages: Vec<TranscriptMessage>,
+    /// Accumulated assistant response that has not yet been committed to the
+    /// finalized transcript. Rendered as one transient trailing message.
+    streaming_text: String,
+
     scheduler_tasks: Vec<SchedulerTask>,
     skills: Vec<SkillSummary>,
     settings_sections: Vec<SettingsSection>,
@@ -154,6 +158,7 @@ impl OrbUiModel {
             status_progress: None,
             ui_mode: FaeUiState::Quiescent,
             messages: Vec::new(),
+            streaming_text: String::new(),
             scheduler_tasks: Vec::new(),
             skills: Vec::new(),
             settings_sections: Vec::new(),
@@ -189,6 +194,22 @@ impl OrbUiModel {
 
     fn clear_messages(&mut self) {
         self.messages.clear();
+    }
+
+    fn set_streaming_text(&mut self, text: String) {
+        self.streaming_text = text;
+    }
+
+    fn has_distinct_streaming_text(&self) -> bool {
+        let stream = self.streaming_text.trim();
+        if stream.is_empty() {
+            return false;
+        }
+        !self.messages.last().is_some_and(|message| {
+            (message.role.eq_ignore_ascii_case("fae")
+                || message.role.eq_ignore_ascii_case("assistant"))
+                && message.text.trim() == stream
+        })
     }
 
     fn set_voice_muted(&mut self, muted: bool) {
@@ -638,9 +659,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut pill = open_pill_panel(&event_loop, &panel_proxy)?;
     position_pill(window, &pill);
     let mut last_pill: Option<(String, String)> = None;
-    // Last applied collapsed-pill height — skip redundant resizes so the pill
-    // doesn't flicker as a streamed reply re-measures on every sentence.
-    let mut last_pill_height: u32 = COLLAPSED_PILL.height;
     // When Fae entered thinking mode — drives the pill's elapsed counter so
     // long turns (NaN retries can take 30s+) read as progress, not a hang.
     let mut thinking_since: Option<Instant> = None;
@@ -797,8 +815,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 // in the collapsed caption; beyond the cap the
                                 // caption text scrolls internally (see PILL_HTML).
                                 let height = (height as u32).clamp(52, 320);
-                                if height != last_pill_height {
-                                    last_pill_height = height;
+                                if height != pill.last_collapsed_height {
+                                    pill.last_collapsed_height = height;
                                     pill.window.set_inner_size(LogicalSize::new(
                                         COLLAPSED_PILL.width,
                                         height,
@@ -1516,6 +1534,9 @@ fn apply_bridge_command(
             // loop after this command via push_pill_messages.
             orb_ui.push_message(role, text);
         }
+        ShellCommand::ConversationStream { text } => {
+            orb_ui.set_streaming_text(text);
+        }
         ShellCommand::ClearConversation => {
             orb_ui.clear_messages();
         }
@@ -1611,6 +1632,10 @@ struct PillPanel {
     /// Collapsed = one-line caption; expanded = scrollable history + composer.
     /// Drives the two window sizes and the JS `__faeExpand` toggle.
     expanded: bool,
+    /// Last applied collapsed-caption height. Reset whenever an explicit
+    /// collapse forces the window to its base size so the next content
+    /// measurement cannot be discarded as a stale duplicate.
+    last_collapsed_height: u32,
     /// Set to a `request_id` while the pill hosts a Swift `request_input` (UX
     /// W1): the composer is in prompted/masked mode. Cleared when the pill posts
     /// `input_response`/`input_cancel`. Focus-loss consults it so a click-away
@@ -1717,6 +1742,7 @@ fn open_pill_panel(
         window,
         webview,
         expanded: false,
+        last_collapsed_height: COLLAPSED_PILL.height,
         pending_input: None,
     })
 }
@@ -1726,6 +1752,9 @@ fn open_pill_panel(
 /// expand pull keyboard focus so the composer is ready to type.
 fn set_pill_expanded(pill: &mut PillPanel, orb_window: &Window, expanded: bool) {
     pill.expanded = expanded;
+    if !expanded {
+        pill.last_collapsed_height = COLLAPSED_PILL.height;
+    }
     pill.window.set_inner_size(if expanded {
         EXPANDED_PILL
     } else {
@@ -1783,7 +1812,7 @@ fn pill_request_input(
 /// when collapsed and the full scrollable log when expanded. Roles map to the
 /// JS palette: `user`→"you" (heather), `fae`/`assistant`→"fae" (gold).
 fn push_pill_messages(pill: &PillPanel, orb_ui: &OrbUiModel) {
-    let payload = orb_ui
+    let mut payload = orb_ui
         .messages
         .iter()
         .map(|message| {
@@ -1795,6 +1824,13 @@ fn push_pill_messages(pill: &PillPanel, orb_ui: &OrbUiModel) {
             serde_json::json!({ "role": role, "text": message.text })
         })
         .collect::<Vec<_>>();
+    if orb_ui.has_distinct_streaming_text() {
+        payload.push(serde_json::json!({
+            "role": "fae",
+            "text": orb_ui.streaming_text,
+            "streaming": true,
+        }));
+    }
     let json = serde_json::to_string(&payload).unwrap_or_else(|_| "[]".to_string());
     if let Err(error) = pill
         .webview
@@ -1898,8 +1934,6 @@ html.fae-opaque #shell{background:#16141C;-webkit-backdrop-filter:none;
 #shell.req #reqx{display:flex}
 /* Masked-mode caption in fae-gold-text (DESIGN.md, 9.4:1 on dark). */
 #hl.secure{color:#E6C05A}
-#line{transition:opacity .35s ease}
-#line.fading{opacity:0}
 /* Multi-line caption: the line fills the shell so a long reply SCROLLS inside
  * the pill (readable, not truncated) once it exceeds the grow-to-fit cap. */
 #line.multi{height:auto;align-items:flex-start;padding:11px 16px;white-space:normal;
@@ -1961,11 +1995,32 @@ var messages=[],status=null,infoItems=[],muted=false;
 var pendingInput=null,secureMode=false,pastedFull=null;
 var post=function(o){if(window.ipc&&window.ipc.postMessage)window.ipc.postMessage(JSON.stringify(o));};
 function rc(r){return r==='fae'?'fae':((r==='you'||r==='user')?'you':'');}
-var fadeTimer=null,fadeOut=null;
-function clearFade(){if(fadeTimer){clearTimeout(fadeTimer);fadeTimer=null;}
- if(fadeOut){clearTimeout(fadeOut);fadeOut=null;}line.classList.remove('fading');}
+var captionFollowing=true,logFollowing=true;
+var programmaticCaptionScroll=false,programmaticLogScroll=false;
+function atBottom(el){return el.scrollHeight-el.scrollTop-el.clientHeight<=12;}
+function beginScrollMutation(el,isCaption){
+ var follow=isCaption?captionFollowing:logFollowing;
+ if(isCaption)programmaticCaptionScroll=true;else programmaticLogScroll=true;
+ return {follow:follow,top:el.scrollTop};}
+function finishScrollMutation(el,s,isCaption){requestAnimationFrame(function(){
+ el.scrollTop=s.follow?el.scrollHeight:s.top;
+ requestAnimationFrame(function(){
+  if(isCaption){programmaticCaptionScroll=false;captionFollowing=s.follow||atBottom(el);}
+  else{programmaticLogScroll=false;logFollowing=s.follow||atBottom(el);}});});}
+function scrollToBottom(el,isCaption){
+ if(isCaption)programmaticCaptionScroll=true;else programmaticLogScroll=true;
+ el.scrollTop=el.scrollHeight;requestAnimationFrame(function(){
+  if(isCaption)programmaticCaptionScroll=false;else programmaticLogScroll=false;});}
+txt.addEventListener('scroll',function(){
+ if(!programmaticCaptionScroll)captionFollowing=atBottom(txt);});
+log.addEventListener('scroll',function(){
+ if(!programmaticLogScroll)logFollowing=atBottom(log);});
+if(window.ResizeObserver){new ResizeObserver(function(){
+ if(captionFollowing)scrollToBottom(txt,true);}).observe(txt);}
+function setCaptionText(text){var s=beginScrollMutation(txt,true);
+ txt.textContent=text;finishScrollMutation(txt,s,true);}
 // Collapsed pill height: taller when the info indicator (second line) is shown
-// so the green-dot line isn't clipped. Matches the Rust clamp (52..240).
+// so the green-dot line isn't clipped. Matches the Rust clamp (52..320).
 function baseHeight(){return infoItems.length?78:52;}
 function sizePill(isMsg){
  if(shell.classList.contains('expanded'))return;
@@ -1981,15 +2036,8 @@ function sizePill(isMsg){
   line.classList.toggle('multi',multi);shell.classList.toggle('multi',multi);
   // Grow to fit, capped generously; beyond the cap the caption text scrolls.
   var h=multi?Math.min(320,Math.max(60,sh+30)):baseHeight();
-  post({type:'pill_resize',height:h});});}
-// Dwell: keep a reply visible long enough to READ before fading to the hint.
-// Scaled to length (base + ~50ms/char, capped 30s); longer while muted, since a
-// text-first reply is only read, never heard.
-function fadeDelay(text){var len=(text||'').length;var base=muted?9000:6000;
- return Math.min(30000,base+50*len);}
-function armFade(ms){fadeTimer=setTimeout(function(){line.classList.add('fading');
- fadeOut=setTimeout(function(){line.className='muted';dot.className='';
-  txt.textContent='Hold right ⌥ to talk · click to see conversation';line.classList.remove('fading');sizePill(false);},360);},ms);}
+  post({type:'pill_resize',height:h});
+  if(captionFollowing)scrollToBottom(txt,true);});}
 // Make a spoken reply readable: keep any real structure (newlines), else break
 // a run-on paragraph into one line per sentence (caption style) so it doesn't
 // read as a single dense block.
@@ -1997,19 +2045,18 @@ function formatBody(t){t=(t||'').trim();
  if(t.indexOf('\n')>=0)return t;
  return t.replace(/([.!?])\s+(?=[A-Z0-9"'(‘“])/g,'$1\n');}
 function renderLine(){
- clearFade();
- if(status){line.className=(status.kind||'');dot.className=status.live?'live':'';
-  txt.textContent=status.text;line.classList.toggle('muted',status.muted===true);sizePill(false);return;}
  var m=messages[messages.length-1];
- if(m){line.className='';dot.className=rc(m.role);txt.textContent=formatBody(m.text);
-  if(!shell.classList.contains('expanded')){sizePill(true);armFade(fadeDelay(m.text));}}
- else{line.className='muted';dot.className='';txt.textContent='Hold right ⌥ to talk · click to see conversation';sizePill(false);}
+ if(status&&!(m&&m.streaming===true)){captionFollowing=true;line.className=(status.kind||'');dot.className=status.live?'live':'';
+  setCaptionText(status.text);line.classList.toggle('muted',status.muted===true);sizePill(false);return;}
+ if(m){line.className='';dot.className=rc(m.role);setCaptionText(formatBody(m.text));
+  if(!shell.classList.contains('expanded'))sizePill(true);}
+ else{captionFollowing=true;line.className='muted';dot.className='';setCaptionText('Hold right ⌥ to talk · click to see conversation');sizePill(false);}
 }
-function renderLog(){log.innerHTML='';messages.forEach(function(m){
+function renderLog(){var s=beginScrollMutation(log,false);log.innerHTML='';messages.forEach(function(m){
  var e=document.createElement('div');e.className='msg '+rc(m.role);
  var d=document.createElement('span');d.className='d';
  var b=document.createElement('span');b.className='b';b.textContent=formatBody(m.text);
- e.appendChild(d);e.appendChild(b);log.appendChild(e);});log.scrollTop=log.scrollHeight;}
+ e.appendChild(d);e.appendChild(b);log.appendChild(e);});finishScrollMutation(log,s,false);}
 window.__faeSetMessages=function(a){messages=a||[];shell.classList.add('show');renderLine();
  if(shell.classList.contains('expanded'))renderLog();};
 window.__faeSetStatus=function(kind,text,opts){opts=opts||{};
@@ -2672,7 +2719,7 @@ fn install_edit_menubar() -> Result<(), muda::Error> {
 
 #[cfg(test)]
 mod v4_tests {
-    use super::{apply_audio_patch, rms_to_level};
+    use super::{apply_audio_patch, rms_to_level, OrbUiModel};
     use crate::protocol::AudioPatch;
 
     fn approx(level: Option<f32>, expected: f32) -> bool {
@@ -2730,5 +2777,51 @@ mod v4_tests {
         let mut level = Some(0.6);
         apply_audio_patch(AudioPatch::Unchanged, &mut level);
         assert_eq!(level, Some(0.6));
+    }
+
+    #[test]
+    fn distinct_nonempty_streaming_text_is_active() {
+        let mut model = OrbUiModel::new();
+        model.set_streaming_text("A response in progress".to_string());
+
+        assert!(model.has_distinct_streaming_text());
+    }
+
+    #[test]
+    fn finalized_fae_or_assistant_message_suppresses_identical_streaming_text() {
+        for role in ["fae", "assistant"] {
+            let mut model = OrbUiModel::new();
+            model.set_streaming_text("The completed response".to_string());
+            model.push_message(role.to_string(), "The completed response".to_string());
+
+            assert!(
+                !model.has_distinct_streaming_text(),
+                "finalized {role} message should suppress the identical transient"
+            );
+        }
+    }
+
+    #[test]
+    fn user_or_different_trailing_message_does_not_suppress_streaming_text() {
+        let mut user_trailing = OrbUiModel::new();
+        user_trailing.set_streaming_text("Shared text".to_string());
+        user_trailing.push_message("user".to_string(), "Shared text".to_string());
+        assert!(user_trailing.has_distinct_streaming_text());
+
+        let mut different_assistant = OrbUiModel::new();
+        different_assistant.set_streaming_text("Current response".to_string());
+        different_assistant.push_message("assistant".to_string(), "Earlier response".to_string());
+        assert!(different_assistant.has_distinct_streaming_text());
+    }
+
+    #[test]
+    fn clearing_streaming_text_removes_transient() {
+        let mut model = OrbUiModel::new();
+        model.set_streaming_text("A response in progress".to_string());
+        assert!(model.has_distinct_streaming_text());
+
+        model.set_streaming_text(String::new());
+
+        assert!(!model.has_distinct_streaming_text());
     }
 }

--- a/native/rust/fae-ui-shell/src/main.rs
+++ b/native/rust/fae-ui-shell/src/main.rs
@@ -194,6 +194,7 @@ impl OrbUiModel {
 
     fn clear_messages(&mut self) {
         self.messages.clear();
+        self.streaming_text.clear();
     }
 
     fn set_streaming_text(&mut self, text: String) {
@@ -2004,9 +2005,8 @@ function beginScrollMutation(el,isCaption){
  return {follow:follow,top:el.scrollTop};}
 function finishScrollMutation(el,s,isCaption){requestAnimationFrame(function(){
  el.scrollTop=s.follow?el.scrollHeight:s.top;
- requestAnimationFrame(function(){
-  if(isCaption){programmaticCaptionScroll=false;captionFollowing=s.follow||atBottom(el);}
-  else{programmaticLogScroll=false;logFollowing=s.follow||atBottom(el);}});});}
+ if(isCaption){programmaticCaptionScroll=false;captionFollowing=s.follow;}
+ else{programmaticLogScroll=false;logFollowing=s.follow;}});}
 function scrollToBottom(el,isCaption){
  if(isCaption)programmaticCaptionScroll=true;else programmaticLogScroll=true;
  el.scrollTop=el.scrollHeight;requestAnimationFrame(function(){
@@ -2812,6 +2812,19 @@ mod v4_tests {
         different_assistant.set_streaming_text("Current response".to_string());
         different_assistant.push_message("assistant".to_string(), "Earlier response".to_string());
         assert!(different_assistant.has_distinct_streaming_text());
+    }
+
+    #[test]
+    fn clear_messages_removes_finalized_and_streaming_text() {
+        let mut model = OrbUiModel::new();
+        model.push_message("assistant".to_string(), "A finalized response".to_string());
+        model.set_streaming_text("A new response in progress".to_string());
+        assert!(model.has_distinct_streaming_text());
+
+        model.clear_messages();
+
+        assert!(model.messages.is_empty());
+        assert!(!model.has_distinct_streaming_text());
     }
 
     #[test]

--- a/native/rust/fae-ui-shell/src/protocol.rs
+++ b/native/rust/fae-ui-shell/src/protocol.rs
@@ -70,6 +70,12 @@ pub enum ShellCommand {
         role: String,
         text: String,
     },
+    /// Accumulated assistant text while a response is still streaming. Kept
+    /// separate from finalized conversation history so the pill can follow
+    /// live output without duplicating the final transcript entry.
+    ConversationStream {
+        text: String,
+    },
     SchedulerSnapshot {
         tasks: Vec<SchedulerTask>,
     },
@@ -259,6 +265,23 @@ mod tests {
             _ => false,
         };
         assert!(has_message);
+        Ok(())
+    }
+
+    #[test]
+    fn decodes_conversation_stream_with_multiline_accumulated_text() -> Result<(), serde_json::Error>
+    {
+        let command: ShellCommand = serde_json::from_str(
+            r#"{"type":"conversation_stream","text":"First line\nSecond line\nThird line"}"#,
+        )?;
+
+        let has_multiline_text = match command {
+            ShellCommand::ConversationStream { text } => {
+                text == "First line\nSecond line\nThird line"
+            }
+            _ => false,
+        };
+        assert!(has_multiline_text);
         Ok(())
     }
 


### PR DESCRIPTION
## Release validation

- [ ] Release validation: N/A — no runtime/UI/policy/routing change.
      Reason:

- [ ] Release validation: done — the relevant checklist phases passed.
      Evidence:

- [x] Release validation: blocker — this PR is intentionally NOT release-ready.
      Blocker/issue: Visual-only owner verification required for #47 before merge; see the exact morning test below and `.pi-subagents/deliverables/OWNER-TEST-PLAN.md`.

## Summary

Fixes owner finding #47: the conversation pill no longer collapses on a wall-clock timer while Fae is speaking. It is latched to live content and conversation state, receives accumulated `streamingText`, follows long streamed output only while already at the bottom, preserves manual scroll-up, and re-engages follow when the owner returns to the bottom. Finalized/transient dedup prevents a duplicate final response, and explicit collapse invalidates the native height cache.

**Visual-gated PR — DO NOT MERGE overnight.** Park after review, green CI, and Meta diff-verification. The owner will visually verify and merge in the morning.

## Change type

- [ ] Rust (crates/)
- [x] Swift (native/macos/)
- [x] Docs / CI / tooling
- [x] Other: Rust orb UI shell

## Verification

- `cargo fmt --all` — pass
- strict `cargo clippy --all-features --all-targets` — pass
- `cargo check --workspace --all-targets` — pass
- `cargo test --all-features` — 27 passed
- `swift build` — pass
- embedded pill JavaScript syntax parse — pass
- `git diff --check` — pass
- no app launch and no `:7433` access

## Owner morning visual test

1. Send a long turn; confirm the pill stays open while Fae speaks and follows streamed text.
2. Scroll upward mid-speech; confirm new text does not pull the view back to the bottom.
3. Return to the bottom; confirm automatic following resumes.
4. Confirm the final response appears once, remains readable after speech, and collapses only when the owner is done or begins the next interaction.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the conversation pill so streamed replies stay visible while Fae is speaking. The main changes are:

- Adds a Swift bridge event for accumulated streaming text.
- Renders streaming text as a transient Rust-side transcript entry.
- Reworks pill scroll-follow behavior for collapsed and expanded views.
- Updates collapsed pill height caching and release validation notes.

<h3>Confidence Score: 4/5</h3>

The streaming pill flow needs a state cleanup fix before merging.

- Clearing the conversation can leave old streamed assistant text active.
- A delayed resize can leave the collapsed pill at an old streamed height.
- The protocol addition and basic transient deduplication are otherwise straightforward.

native/rust/fae-ui-shell/src/main.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/checklists/app-release-validation.md | Adds the long streamed-response owner validation scenario. |
| native/macos/Fae/Sources/Fae/RustUiShellController.swift | Adds the `streamingText` bridge subscription and sends `conversation_stream` events. |
| native/rust/fae-ui-shell/src/main.rs | Adds transient streaming state, scroll-follow JavaScript, and height-cache handling; the new state needs cleanup on clear/reset. |
| native/rust/fae-ui-shell/src/protocol.rs | Adds the `conversation_stream` protocol command and decoding coverage. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `native/rust/fae-ui-shell/src/main.rs`, line 195-197 ([link](https://github.com/saorsa-labs/fae/blob/f97a2b855bd81ac2a508c831f0528d974aa4b5ce/native/rust/fae-ui-shell/src/main.rs#L195-L197)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale Stream Survives Clear**

   When Reset Conversation clears the finalized transcript, `clear_messages()` leaves the new `streaming_text` field intact. If a streamed reply was present and Swift does not emit a changed `conversation_stream` value, `has_distinct_streaming_text()` treats the orphaned text as active because `messages` is empty, so the pill can show the previous assistant fragment after the reset.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: native/rust/fae-ui-shell/src/main.rs
   Line: 195-197

   Comment:
   **Stale Stream Survives Clear**

   When Reset Conversation clears the finalized transcript, `clear_messages()` leaves the new `streaming_text` field intact. If a streamed reply was present and Swift does not emit a changed `conversation_stream` value, `has_distinct_streaming_text()` treats the orphaned text as active because `messages` is empty, so the pill can show the previous assistant fragment after the reset.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
native/rust/fae-ui-shell/src/main.rs:195-197
**Stale Stream Survives Clear**

When Reset Conversation clears the finalized transcript, `clear_messages()` leaves the new `streaming_text` field intact. If a streamed reply was present and Swift does not emit a changed `conversation_stream` value, `has_distinct_streaming_text()` treats the orphaned text as active because `messages` is empty, so the pill can show the previous assistant fragment after the reset.

```suggestion
    fn clear_messages(&mut self) {
        self.messages.clear();
        self.streaming_text.clear();
    }
```

### Issue 2 of 2
native/rust/fae-ui-shell/src/main.rs:1755
**Late Resize Reopens Collapsed Height**

A collapse now resets the cached height to `COLLAPSED_PILL.height`, but delayed `pill_resize` messages from the previous streamed caption can still be accepted after `expanded` becomes false. In that timing, the explicit collapse to 52px is overwritten by an old measured stream height, leaving the collapsed pill stuck tall until another resize event corrects it.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): latch conversation pill to stre..."](https://github.com/saorsa-labs/fae/commit/f97a2b855bd81ac2a508c831f0528d974aa4b5ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43434266)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->