### PR TITLE
fix(ui): persist orb hide through speech reveal (#48)

### DIFF
--- a/docs/checklists/app-release-validation.md
+++ b/docs/checklists/app-release-validation.md
@@ -112,6 +112,9 @@ These scenarios are mandatory for the new canonical UI shell once it is included
 - [ ] Default menu (9 items): Talk to Fae · Settings… · [Hand off submenu if fleet non-empty] · Reset Conversation · Hide Fae · Stop · Ask Fae for Help · Rescue Mode… · Quit Fae. Engineering items (Scheduler, Skills, Edit Soul, Edit Custom Instructions, permissions ×6, Memory Inbox) are NOT present unless `ui.advancedMenus = true` in config (applies at next launch).
 - [ ] Rust shell menu does not include Cowork or Open Work with Fae.
 - [ ] Stop, Hide, and Quit perform their expected action.
+- [ ] Right Option alone still performs hold-to-talk; Right Option+Shift toggles Fae visibility exactly once without starting or submitting a PTT capture, in either modifier order.
+- [ ] After Hide Fae, routine startup/status/Listening/Thinking traffic does not resurrect the orb; the next real Speaking transition reveals orb and pill, and the final Quiescent transition re-hides both.
+- [ ] Hiding during active speech takes effect immediately and same-state playback updates do not bounce either window visible; an explicit Show during speech remains visible after the turn.
 - [ ] Open Browser/Data Panel opens an orb-launched browser/webview surface for charts, data, documents, and video.
 - [ ] Scheduler and Skills open orb-owned temporary panels rather than Cowork.
 - [ ] Rich output does not require a permanent canvas or Cowork surface.

--- a/native/macos/Fae/Sources/Fae/Core/GlobalHotkeyManager.swift
+++ b/native/macos/Fae/Sources/Fae/Core/GlobalHotkeyManager.swift
@@ -1,6 +1,83 @@
 import AppKit
 import Carbon
 
+enum RightOptionChordAction: Equatable {
+    case schedulePTT
+    case cancelScheduledPTT
+    case pressPTT
+    case releasePTT
+    case toggleVisibility
+}
+
+struct RightOptionChordState {
+    private let pttEnabled: Bool
+
+    init(pttEnabled: Bool = true) {
+        self.pttEnabled = pttEnabled
+    }
+    private(set) var rightOptionDown = false
+    private(set) var shiftDown = false
+    private(set) var pendingPTT = false
+    private(set) var pttActive = false
+    private(set) var visibilityChordLatched = false
+
+    mutating func rightOptionChanged(isDown: Bool, shiftIsDown: Bool) -> [RightOptionChordAction] {
+        shiftDown = shiftIsDown
+        if isDown {
+            guard !rightOptionDown else { return [] }
+            rightOptionDown = true
+            if shiftDown {
+                visibilityChordLatched = true
+                return [.toggleVisibility]
+            }
+            guard pttEnabled else { return [] }
+            pendingPTT = true
+            return [.schedulePTT]
+        }
+
+        guard rightOptionDown else { return [] }
+        rightOptionDown = false
+        if visibilityChordLatched {
+            visibilityChordLatched = false
+            pendingPTT = false
+            return []
+        }
+        if pendingPTT {
+            pendingPTT = false
+            return [.cancelScheduledPTT, .pressPTT, .releasePTT]
+        }
+        if pttActive {
+            pttActive = false
+            return [.releasePTT]
+        }
+        return []
+    }
+
+    mutating func shiftChanged(isDown: Bool) -> [RightOptionChordAction] {
+        shiftDown = isDown
+        guard isDown, rightOptionDown, !pttActive, !visibilityChordLatched else {
+            return []
+        }
+        visibilityChordLatched = true
+        if pendingPTT {
+            pendingPTT = false
+            return [.cancelScheduledPTT, .toggleVisibility]
+        }
+        return [.toggleVisibility]
+    }
+
+    mutating func pttDelayElapsed() -> [RightOptionChordAction] {
+        guard pendingPTT, rightOptionDown, !shiftDown, !visibilityChordLatched else { return [] }
+        pendingPTT = false
+        pttActive = true
+        return [.pressPTT]
+    }
+
+    mutating func reset() {
+        self = RightOptionChordState(pttEnabled: pttEnabled)
+    }
+}
+
 /// Manages a global hotkey that summons Fae from anywhere on the system.
 ///
 /// Uses `NSEvent.addGlobalMonitorForEvents` to listen for keyboard events
@@ -23,9 +100,15 @@ final class GlobalHotkeyManager {
     private var pttKeyUpMonitor: Any?
     private var pttLocalMonitor: Any?
     private var pttLocalKeyUpMonitor: Any?
+    private var visibilityChordMonitor: Any?
+    private var visibilityChordLocalMonitor: Any?
     private var pttOnPress: (() -> Void)?
     private var pttOnRelease: (() -> Void)?
     private var pttKeyIsDown: Bool = false
+    private var pttOnToggleVisibility: (() -> Void)?
+    private var rightOptionChordState = RightOptionChordState()
+    private var pttDisambiguationTask: Task<Void, Never>?
+    private static let pttChordDisambiguationNanoseconds: UInt64 = 150_000_000
 
     /// Modifier flag for a modifier key code, or nil for regular keys (which
     /// use keyDown/keyUp monitors instead of flagsChanged).
@@ -76,7 +159,8 @@ final class GlobalHotkeyManager {
     func startHoldToTalk(
         keyCode: UInt16 = GlobalHotkeyManager.holdToTalkKeyCode,
         onPress: @escaping () -> Void,
-        onRelease: @escaping () -> Void
+        onRelease: @escaping () -> Void,
+        onToggleVisibility: @escaping () -> Void = {}
     ) {
         // Clean up any existing PTT monitor
         stopHoldToTalk()
@@ -84,6 +168,8 @@ final class GlobalHotkeyManager {
         self.pttOnPress = onPress
         self.pttOnRelease = onRelease
         self.pttKeyIsDown = false
+        self.pttOnToggleVisibility = onToggleVisibility
+        self.rightOptionChordState = RightOptionChordState(pttEnabled: keyCode == Self.holdToTalkKeyCode)
 
         // Only start if Accessibility is trusted (don't re-prompt here)
         let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: false] as CFDictionary
@@ -96,7 +182,22 @@ final class GlobalHotkeyManager {
         // itself is frontmost (settings open, just launched) the key would
         // be invisible. Register a local monitor alongside so the hold works
         // everywhere.
-        if let flag = Self.modifierFlag(for: keyCode) {
+        if keyCode == Self.holdToTalkKeyCode {
+            let handleFlags: (NSEvent) -> Void = { [weak self] event in
+                guard event.keyCode == Self.holdToTalkKeyCode
+                        || event.keyCode == 56
+                        || event.keyCode == 60
+                else { return }
+                DispatchQueue.main.async { [weak self] in
+                    self?.handleRightOptionChordEvent(event)
+                }
+            }
+            pttMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, handler: handleFlags)
+            pttLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+                handleFlags(event)
+                return event
+            }
+        } else if let flag = Self.modifierFlag(for: keyCode) {
             let handleFlags: (NSEvent) -> Void = { [weak self] event in
                 guard event.keyCode == keyCode else { return }
                 DispatchQueue.main.async { [weak self] in
@@ -148,7 +249,75 @@ final class GlobalHotkeyManager {
                 return event
             }
         }
+        if keyCode != Self.holdToTalkKeyCode {
+            let handleVisibilityChord: (NSEvent) -> Void = { [weak self] event in
+                guard event.keyCode == Self.holdToTalkKeyCode
+                        || event.keyCode == 56
+                        || event.keyCode == 60
+                else { return }
+                DispatchQueue.main.async { [weak self] in
+                    self?.handleRightOptionChordEvent(event)
+                }
+            }
+            visibilityChordMonitor = NSEvent.addGlobalMonitorForEvents(
+                matching: .flagsChanged,
+                handler: handleVisibilityChord
+            )
+            visibilityChordLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+                handleVisibilityChord(event)
+                return event
+            }
+        }
         NSLog("GlobalHotkeyManager: hold-to-talk monitor started (keyCode %d)", keyCode)
+    }
+
+    private func handleRightOptionChordEvent(_ event: NSEvent) {
+        let shiftIsDown = event.modifierFlags.contains(.shift)
+        let actions: [RightOptionChordAction]
+        if event.keyCode == Self.holdToTalkKeyCode {
+            actions = rightOptionChordState.rightOptionChanged(
+                isDown: event.modifierFlags.contains(.option),
+                shiftIsDown: shiftIsDown
+            )
+        } else {
+            actions = rightOptionChordState.shiftChanged(isDown: shiftIsDown)
+        }
+        applyRightOptionChordActions(actions)
+    }
+
+    private func applyRightOptionChordActions(_ actions: [RightOptionChordAction]) {
+        for action in actions {
+            switch action {
+            case .schedulePTT:
+                pttDisambiguationTask?.cancel()
+                pttDisambiguationTask = Task { [weak self] in
+                    do {
+                        try await Task.sleep(nanoseconds: Self.pttChordDisambiguationNanoseconds)
+                    } catch {
+                        return
+                    }
+                    guard let self else { return }
+                    self.pttDisambiguationTask = nil
+                    self.applyRightOptionChordActions(self.rightOptionChordState.pttDelayElapsed())
+                }
+            case .cancelScheduledPTT:
+                pttDisambiguationTask?.cancel()
+                pttDisambiguationTask = nil
+            case .pressPTT:
+                guard !pttKeyIsDown else { continue }
+                pttKeyIsDown = true
+                NSLog("GlobalHotkeyManager: PTT press (Right Option)")
+                pttOnPress?()
+            case .releasePTT:
+                guard pttKeyIsDown else { continue }
+                pttKeyIsDown = false
+                NSLog("GlobalHotkeyManager: PTT release (Right Option)")
+                pttOnRelease?()
+            case .toggleVisibility:
+                NSLog("GlobalHotkeyManager: toggle Fae visibility (Right Option+Shift)")
+                pttOnToggleVisibility?()
+            }
+        }
     }
 
     /// Stop hold-to-talk monitoring only (leaves summon hotkey intact).
@@ -171,9 +340,24 @@ final class GlobalHotkeyManager {
             NSEvent.removeMonitor(m)
             pttLocalKeyUpMonitor = nil
         }
+        if let m = visibilityChordMonitor {
+            NSEvent.removeMonitor(m)
+            visibilityChordMonitor = nil
+        }
+        if let m = visibilityChordLocalMonitor {
+            NSEvent.removeMonitor(m)
+            visibilityChordLocalMonitor = nil
+        }
+        pttDisambiguationTask?.cancel()
+        pttDisambiguationTask = nil
+        if pttKeyIsDown {
+            pttOnRelease?()
+        }
         pttKeyIsDown = false
+        rightOptionChordState.reset()
         pttOnPress = nil
         pttOnRelease = nil
+        pttOnToggleVisibility = nil
     }
 
     private func startMonitor() {

--- a/native/macos/Fae/Sources/Fae/FaeApp.swift
+++ b/native/macos/Fae/Sources/Fae/FaeApp.swift
@@ -761,6 +761,9 @@ class FaeAppDelegate: NSObject, NSApplicationDelegate {
             },
             onRelease: {
                 NotificationCenter.default.post(name: .faePTTReleased, object: nil)
+            },
+            onToggleVisibility: { [weak self] in
+                self?.rustUiShell.toggleFaeVisibility()
             }
         )
     }

--- a/native/macos/Fae/Sources/Fae/RustUiShellController.swift
+++ b/native/macos/Fae/Sources/Fae/RustUiShellController.swift
@@ -152,6 +152,12 @@ final class RustUiShellController: PillInputRouting {
         send(["type": "cancel_input"])
     }
 
+    /// Toggle the Rust host's persistent owner-hidden latch. The host remains
+    /// authoritative because it also owns transient reveal-on-speech.
+    func toggleFaeVisibility() {
+        send(["type": "toggle_visibility"])
+    }
+
     func startIfAvailable() {
         guard process == nil else { return }
         guard let binaryURL = resolveShellBinary() else {

--- a/native/macos/Fae/Tests/HandoffTests/GlobalHotkeyManagerPTTTests.swift
+++ b/native/macos/Fae/Tests/HandoffTests/GlobalHotkeyManagerPTTTests.swift
@@ -50,4 +50,93 @@ struct GlobalHotkeyManagerPTTTests {
         // PTT should still be active after stop() — only summon is stopped
         manager.stopHoldToTalk()
     }
+
+    @Test("Shift then Right Option toggles once without PTT")
+    func shiftThenRightOptionTogglesOnceWithoutPTT() {
+        var state = RightOptionChordState()
+
+        #expect(state.shiftChanged(isDown: true) == [])
+        #expect(state.rightOptionChanged(isDown: true, shiftIsDown: true) == [.toggleVisibility])
+        #expect(state.rightOptionChanged(isDown: true, shiftIsDown: true) == [])
+        #expect(state.pttDelayElapsed() == [])
+        #expect(state.rightOptionChanged(isDown: false, shiftIsDown: true) == [])
+        #expect(state.shiftChanged(isDown: false) == [])
+    }
+
+    @Test("Right Option then Shift cancels pending PTT and toggles once")
+    func shiftDuringPendingPTTCancelsAndTogglesOnce() {
+        var state = RightOptionChordState()
+
+        #expect(state.rightOptionChanged(isDown: true, shiftIsDown: false) == [.schedulePTT])
+        #expect(state.shiftChanged(isDown: true) == [.cancelScheduledPTT, .toggleVisibility])
+        #expect(state.shiftChanged(isDown: true) == [])
+        #expect(state.pttDelayElapsed() == [])
+        #expect(state.rightOptionChanged(isDown: false, shiftIsDown: true) == [])
+    }
+
+    @Test("Right Option alone schedules presses after delay and releases")
+    func rightOptionAloneRunsDelayedPTTLifecycle() {
+        var state = RightOptionChordState()
+
+        #expect(state.rightOptionChanged(isDown: true, shiftIsDown: false) == [.schedulePTT])
+        #expect(state.pttDelayElapsed() == [.pressPTT])
+        #expect(state.rightOptionChanged(isDown: false, shiftIsDown: false) == [.releasePTT])
+    }
+
+    @Test("Right Option released before delay retains PTT semantics")
+    func rightOptionReleasedBeforeDelayRetainsPTTSemantics() {
+        var state = RightOptionChordState()
+
+        #expect(state.rightOptionChanged(isDown: true, shiftIsDown: false) == [.schedulePTT])
+        #expect(
+            state.rightOptionChanged(isDown: false, shiftIsDown: false)
+                == [.cancelScheduledPTT, .pressPTT, .releasePTT]
+        )
+        #expect(state.pttDelayElapsed() == [])
+    }
+
+    @Test("Shift after active PTT does not toggle and release still fires")
+    func shiftAfterActivePTTDoesNotToggle() {
+        var state = RightOptionChordState()
+
+        #expect(state.rightOptionChanged(isDown: true, shiftIsDown: false) == [.schedulePTT])
+        #expect(state.pttDelayElapsed() == [.pressPTT])
+        #expect(state.shiftChanged(isDown: true) == [])
+        #expect(state.rightOptionChanged(isDown: false, shiftIsDown: true) == [.releasePTT])
+    }
+
+    @Test("Repeated held events do not duplicate actions")
+    func repeatedHeldEventsDoNotDuplicateActions() {
+        var chordState = RightOptionChordState()
+
+        #expect(chordState.shiftChanged(isDown: true) == [])
+        #expect(chordState.rightOptionChanged(isDown: true, shiftIsDown: true) == [.toggleVisibility])
+        #expect(chordState.shiftChanged(isDown: true) == [])
+        #expect(chordState.rightOptionChanged(isDown: true, shiftIsDown: true) == [])
+        #expect(chordState.rightOptionChanged(isDown: false, shiftIsDown: true) == [])
+        #expect(chordState.rightOptionChanged(isDown: false, shiftIsDown: true) == [])
+
+        var pttState = RightOptionChordState()
+        #expect(pttState.rightOptionChanged(isDown: true, shiftIsDown: false) == [.schedulePTT])
+        #expect(pttState.rightOptionChanged(isDown: true, shiftIsDown: false) == [])
+        #expect(pttState.pttDelayElapsed() == [.pressPTT])
+        #expect(pttState.pttDelayElapsed() == [])
+        #expect(pttState.rightOptionChanged(isDown: false, shiftIsDown: false) == [.releasePTT])
+        #expect(pttState.rightOptionChanged(isDown: false, shiftIsDown: false) == [])
+    }
+
+    @Test("Right Option visibility chord remains available when PTT is disabled")
+    func rightOptionVisibilityChordRemainsAvailableWhenPTTIsDisabled() {
+        var state = RightOptionChordState(pttEnabled: false)
+
+        #expect(state.rightOptionChanged(isDown: true, shiftIsDown: false) == [])
+        #expect(state.shiftChanged(isDown: true) == [.toggleVisibility])
+        #expect(state.shiftChanged(isDown: true) == [])
+        #expect(state.rightOptionChanged(isDown: true, shiftIsDown: true) == [])
+        #expect(state.rightOptionChanged(isDown: false, shiftIsDown: true) == [])
+        #expect(state.shiftChanged(isDown: false) == [])
+
+        #expect(state.shiftChanged(isDown: true) == [])
+        #expect(state.rightOptionChanged(isDown: true, shiftIsDown: true) == [.toggleVisibility])
+    }
 }

--- a/native/rust/fae-ui-shell/src/main.rs
+++ b/native/rust/fae-ui-shell/src/main.rs
@@ -648,6 +648,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // (assistant.generating / audio.level / playback_ended). Derives the orb
     // mode WITHOUT the thinking→idle→thinking / speaking→idle→speaking flicker.
     let mut orb_state_machine = orb_state::OrbStateMachine::new();
+    let mut orb_visibility = OrbVisibilityState::new();
     // Stable epoch for the state machine's `now_ms` clock (monotonic).
     let process_start = Instant::now();
     // Last OrbUiState we applied from the state machine — lets us skip redundant
@@ -707,7 +708,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 multiline,
                 placeholder,
             })) => {
-                window.set_visible(true);
+                window.set_visible(orb_visibility.should_be_visible());
                 pill_request_input(
                     &mut pill,
                     window,
@@ -717,6 +718,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     multiline,
                     placeholder.as_deref(),
                 );
+                pill.window.set_visible(window.is_visible());
                 window.request_redraw();
             }
             // UX auto-cancel: Swift saw a new turn start while a `request_input`
@@ -736,6 +738,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     command,
                     &mut state,
                     &mut orb_ui,
+                    &mut orb_visibility,
                     window,
                     &mut web_panels,
                     control_flow,
@@ -851,6 +854,13 @@ fn main() -> Result<(), Box<dyn Error>> {
                         &mut last_applied_mode,
                         &mut thinking_since,
                     );
+                    if let Some(visible) = orb_visibility.on_mode(mode) {
+                        window.set_visible(visible);
+                        pill.window.set_visible(visible);
+                    }
+                    if !orb_visibility.should_be_visible() {
+                        state.set_active(false);
+                    }
                 }
                 // Forward info updates to the pill model (Step 3: the indicator).
                 if let OrbDaemonEvent::InfoUpdate(items) = &event {
@@ -1010,6 +1020,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                     &mut last_applied_mode,
                     &mut thinking_since,
                 );
+                if let Some(visible) = orb_visibility.on_mode(mode) {
+                    window.set_visible(visible);
+                    pill.window.set_visible(visible);
+                }
                 // Tick the thinking counter once a second (refresh_pill dedupes
                 // by content, so per-frame calls only repaint on text change).
                 if thinking_since.is_some() {
@@ -1467,6 +1481,7 @@ fn apply_bridge_command(
     command: ShellCommand,
     state: &mut State,
     orb_ui: &mut OrbUiModel,
+    orb_visibility: &mut OrbVisibilityState,
     window: &Window,
     web_panels: &mut [WebPanel],
     control_flow: &mut ControlFlow,
@@ -1488,10 +1503,10 @@ fn apply_bridge_command(
                     FaeUiState::Thinking | FaeUiState::Speaking | FaeUiState::Listening
                 );
                 orb_ui.ui_mode = ui_state;
-                state.set_active(active);
+                state.set_active(active && orb_visibility.should_be_visible());
                 state.set_emotion(ui_state, feeling.as_deref());
                 state.set_status_progress(None, false);
-                window.set_visible(true);
+                window.set_visible(orb_visibility.should_be_visible());
             }
             state.set_audio(audio);
         }
@@ -1502,14 +1517,14 @@ fn apply_bridge_command(
         } => {
             let should_show = !matches!(phase.as_str(), "running" | "stopped");
             orb_ui.set_status(phase, message, progress);
-            state.set_active(should_show);
+            state.set_active(should_show && orb_visibility.should_be_visible());
             state.set_status_progress(orb_ui.status_progress, should_show);
             if let Some(progress) = orb_ui.status_progress {
                 state.set_audio(AudioPatch::Set(progress));
             }
-            // Status changes animate the orb but never hide it (S18: the orb
-            // is the talk button and must stay clickable while idle).
-            window.set_visible(true);
+            // Startup/status animation respects the explicit owner-hidden latch;
+            // routine bridge traffic must never resurrect a hidden orb.
+            window.set_visible(orb_visibility.should_be_visible());
         }
         ShellCommand::Conversation { role, text } => {
             // The pill (the conversation surface) is refreshed by the event
@@ -1541,12 +1556,23 @@ fn apply_bridge_command(
             refresh_settings_panels(web_panels, orb_ui);
         }
         ShellCommand::Show => {
+            let visible = orb_visibility.show();
             state.set_active(true);
-            window.set_visible(true);
+            window.set_visible(visible);
         }
         ShellCommand::Hide => {
+            let visible = orb_visibility.hide();
             state.set_active(false);
-            window.set_visible(false);
+            window.set_visible(visible);
+        }
+        ShellCommand::ToggleVisibility => {
+            let visible = orb_visibility.toggle();
+            let mode_active = matches!(
+                orb_ui.ui_mode,
+                FaeUiState::Thinking | FaeUiState::Speaking | FaeUiState::Listening
+            );
+            state.set_active(visible && mode_active);
+            window.set_visible(visible);
         }
         ShellCommand::RequestInput { .. } => {
             // UX W1: intercepted in the event loop (it drives the pill directly
@@ -1623,6 +1649,67 @@ struct PillPanel {
 /// here would halve the pill on a 2x screen and crush the composer layout.
 const COLLAPSED_PILL: LogicalSize<u32> = LogicalSize::new(360, 52);
 const EXPANDED_PILL: LogicalSize<u32> = LogicalSize::new(360, 440);
+
+/// Explicit owner visibility preference plus the temporary reveal granted to
+/// one assistant speaking stretch. Thinking never overrides the hidden latch;
+/// only a transition into Speaking reveals, and final Quiescent re-hides.
+#[derive(Debug)]
+struct OrbVisibilityState {
+    user_hidden: bool,
+    transient_speech_reveal: bool,
+    last_mode: orb_state::OrbMode,
+}
+
+impl OrbVisibilityState {
+    fn new() -> Self {
+        Self {
+            user_hidden: false,
+            transient_speech_reveal: false,
+            last_mode: orb_state::OrbMode::Quiescent,
+        }
+    }
+
+    fn should_be_visible(&self) -> bool {
+        !self.user_hidden || self.transient_speech_reveal
+    }
+
+    fn hide(&mut self) -> bool {
+        self.user_hidden = true;
+        self.transient_speech_reveal = false;
+        false
+    }
+
+    fn show(&mut self) -> bool {
+        self.user_hidden = false;
+        self.transient_speech_reveal = false;
+        true
+    }
+
+    fn toggle(&mut self) -> bool {
+        if self.user_hidden {
+            self.show()
+        } else {
+            self.hide()
+        }
+    }
+
+    fn on_mode(&mut self, mode: orb_state::OrbMode) -> Option<bool> {
+        let entering_speaking =
+            self.last_mode != orb_state::OrbMode::Speaking && mode == orb_state::OrbMode::Speaking;
+        self.last_mode = mode;
+
+        if entering_speaking && self.user_hidden {
+            self.transient_speech_reveal = true;
+            return Some(true);
+        }
+        if mode == orb_state::OrbMode::Quiescent && self.user_hidden && self.transient_speech_reveal
+        {
+            self.transient_speech_reveal = false;
+            return Some(false);
+        }
+        None
+    }
+}
 
 /// Orb long-press gesture state: hold ≥ [`LONG_PRESS_MS`] without moving past
 /// [`PRESS_SLOP_PX`] → talk (release sends); move first → drag the orb.
@@ -1762,7 +1849,6 @@ fn pill_request_input(
 ) {
     pill.expanded = true;
     pill.pending_input = Some(request_id.clone());
-    pill.window.set_visible(true);
     pill.window.set_inner_size(EXPANDED_PILL);
     position_pill(orb_window, pill);
     let payload = serde_json::json!({
@@ -2672,8 +2758,8 @@ fn install_edit_menubar() -> Result<(), muda::Error> {
 
 #[cfg(test)]
 mod v4_tests {
-    use super::{apply_audio_patch, rms_to_level};
-    use crate::protocol::AudioPatch;
+    use super::{apply_audio_patch, rms_to_level, OrbVisibilityState};
+    use crate::{orb_state::OrbMode, protocol::AudioPatch};
 
     fn approx(level: Option<f32>, expected: f32) -> bool {
         level.map(|v| (v - expected).abs() < 1e-5).unwrap_or(false)
@@ -2730,5 +2816,67 @@ mod v4_tests {
         let mut level = Some(0.6);
         apply_audio_patch(AudioPatch::Unchanged, &mut level);
         assert_eq!(level, Some(0.6));
+    }
+
+    #[test]
+    fn hidden_preference_survives_thinking() {
+        let mut visibility = OrbVisibilityState::new();
+        assert!(!visibility.hide());
+
+        assert_eq!(visibility.on_mode(OrbMode::Thinking), None);
+        assert!(!visibility.should_be_visible());
+    }
+
+    #[test]
+    fn entering_speaking_transiently_reveals_hidden_orb() {
+        let mut visibility = OrbVisibilityState::new();
+        visibility.hide();
+        visibility.on_mode(OrbMode::Thinking);
+
+        assert_eq!(visibility.on_mode(OrbMode::Speaking), Some(true));
+        assert!(visibility.should_be_visible());
+    }
+
+    #[test]
+    fn repeated_speaking_does_not_retrigger_transient_reveal() {
+        let mut visibility = OrbVisibilityState::new();
+        visibility.hide();
+        assert_eq!(visibility.on_mode(OrbMode::Speaking), Some(true));
+
+        assert_eq!(visibility.on_mode(OrbMode::Speaking), None);
+        assert!(visibility.should_be_visible());
+    }
+
+    #[test]
+    fn final_quiescent_rehides_transiently_revealed_orb() {
+        let mut visibility = OrbVisibilityState::new();
+        visibility.hide();
+        visibility.on_mode(OrbMode::Speaking);
+
+        assert_eq!(visibility.on_mode(OrbMode::Quiescent), Some(false));
+        assert!(!visibility.should_be_visible());
+    }
+
+    #[test]
+    fn explicit_show_during_transient_reveal_prevents_rehide() {
+        let mut visibility = OrbVisibilityState::new();
+        visibility.hide();
+        visibility.on_mode(OrbMode::Speaking);
+
+        assert!(visibility.show());
+        assert_eq!(visibility.on_mode(OrbMode::Quiescent), None);
+        assert!(visibility.should_be_visible());
+    }
+
+    #[test]
+    fn hide_during_speaking_blocks_same_mode_reveal() {
+        let mut visibility = OrbVisibilityState::new();
+        visibility.hide();
+        visibility.on_mode(OrbMode::Speaking);
+
+        assert!(!visibility.hide());
+        assert!(!visibility.should_be_visible());
+        assert_eq!(visibility.on_mode(OrbMode::Speaking), None);
+        assert!(!visibility.should_be_visible());
     }
 }

--- a/native/rust/fae-ui-shell/src/protocol.rs
+++ b/native/rust/fae-ui-shell/src/protocol.rs
@@ -115,6 +115,7 @@ pub enum ShellCommand {
     ClearConversation,
     Show,
     Hide,
+    ToggleVisibility,
     Quit,
 }
 
@@ -372,6 +373,13 @@ mod tests {
             _ => false,
         };
         assert!(decoded);
+        Ok(())
+    }
+
+    #[test]
+    fn decodes_toggle_visibility_command() -> Result<(), serde_json::Error> {
+        let command: ShellCommand = serde_json::from_str(r#"{"type":"toggle_visibility"}"#)?;
+        assert!(matches!(command, ShellCommand::ToggleVisibility));
         Ok(())
     }
 }


### PR DESCRIPTION
## Release validation

- [ ] Release validation: N/A — no runtime/UI/policy/routing change.
  - Reason: <!-- one line; e.g. "docs-only typo fix" -->
- [x] Release validation: blocker — this PR is intentionally NOT release-ready.
  - Blocker/issue: Owner visual verification required for the global chord and real speech reveal/re-hide lifecycle; see the exact checklist below and `.pi-subagents/deliverables/OWNER-TEST-PLAN.md`.

## Summary

Fixes owner finding #48. Hide Fae now sets a Rust-authoritative hidden latch that routine state traffic cannot override. Right Option+Shift toggles that latch without starting PTT; Right Option alone retains PTT behavior through a 150 ms chord-disambiguation window. A hidden orb and pill reveal only on a real Speaking transition and re-hide on final Quiescent unless the owner explicitly showed them. Hiding mid-speech is immediate and same-state playback cannot bounce the windows visible.

## Change type

- [ ] Rust (`crates/`)
- [x] Swift (`native/macos/`)
- [x] Docs / CI / tooling
- [x] Other: Rust orb UI shell (`native/rust/fae-ui-shell`)

## Verification

- [x] `just check-ui-shell`
- [x] `cargo test --all-features` in `native/rust/fae-ui-shell` — 29 passed
- [x] `swift test --filter GlobalHotkeyManagerPTTTests` — 11 passed
- [x] `swift build`
- [x] `git diff --check`

## Owner visual gate — DO NOT MERGE

- [ ] Right Option+Shift hides the orb; both modifier orders toggle exactly once and never start or submit PTT.
- [ ] Right Option alone starts PTT and release submits normally; it never toggles Hide Fae.
- [ ] While hidden, a real spoken reply reveals orb + pill with text, keeps them visible through speech, and re-hides after final Quiescent.
- [ ] Toggling Hide during active speech hides immediately without a same-turn bounce; explicit Show during speech remains visible afterward.

## Notes

- No app or `:7433` harness launch was performed in this worktree.
- Production Rust adds no `unwrap`, `expect`, or `panic!`.
- PR must remain parked after G3; owner performs the visual gate in the morning.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes Fae visibility owner-controlled across the Swift hotkey path and Rust UI shell. The main changes are:

- Right Option+Shift toggles Fae visibility without starting hold-to-talk.
- Right Option hold-to-talk uses a short chord-disambiguation delay.
- Swift sends a new `toggle_visibility` command to the Rust shell.
- The Rust shell tracks an owner-hidden latch with temporary reveal during speech.
- Release validation docs and focused hotkey/visibility tests were updated.

<h3>Confidence Score: 4/5</h3>

The changed visibility flow needs fixes around hidden request-input prompts and pill synchronization.

- A hidden Fae can receive `request_input` while the pill remains invisible.
- Rust hide/toggle paths rely on reading orb window visibility back before syncing the pill.
- The quick-tap Right Option path now compresses press and release into one batch, which can produce an empty capture turn.

native/rust/fae-ui-shell/src/main.rs; native/macos/Fae/Sources/Fae/Core/GlobalHotkeyManager.swift

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| native/macos/Fae/Sources/Fae/Core/GlobalHotkeyManager.swift | Adds the Right Option chord state machine, delayed PTT actions, visibility toggle callback, and monitor cleanup. |
| native/macos/Fae/Sources/Fae/FaeApp.swift | Wires the visibility chord callback to the Rust UI shell controller. |
| native/macos/Fae/Sources/Fae/RustUiShellController.swift | Adds the `toggle_visibility` JSON command sender for the Rust shell. |
| native/rust/fae-ui-shell/src/main.rs | Adds the owner-hidden visibility state and speech reveal logic, with follow-up needed around request-input and pill visibility synchronization. |
| native/rust/fae-ui-shell/src/protocol.rs | Adds decoding support and a test for the new `ToggleVisibility` shell command. |
| native/macos/Fae/Tests/HandoffTests/GlobalHotkeyManagerPTTTests.swift | Adds unit coverage for Right Option chord ordering, quick release, repeated events, and disabled-PTT visibility toggles. |
| docs/checklists/app-release-validation.md | Adds owner validation checks for the new visibility chord and speech reveal lifecycle. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
native/rust/fae-ui-shell/src/main.rs:708
**Hidden Request Input Surface**

When `request_input` arrives after the owner has hidden Fae, this path keeps the orb hidden and then mirrors that hidden state onto the pill. The input request is still active, but the only UI for answering it is invisible, so the user cannot complete the prompt.

### Issue 2 of 3
native/rust/fae-ui-shell/src/main.rs:1566
**Rust Hide Leaves Pill State Stale**

`ShellCommand::Hide` updates only the orb window here, while the pill is synchronized later through `window.is_visible()`. If the toolkit reports the previous visibility until the window update is processed, hiding during an expanded pill can leave the pill visible even though the owner-hidden latch is set.

### Issue 3 of 3
native/macos/Fae/Sources/Fae/Core/GlobalHotkeyManager.swift:44-48
**Quick Tap Collapses Capture**

Releasing Right Option before the 150 ms disambiguation delay now emits `.pressPTT` and `.releasePTT` in the same action batch. The app handles those notifications with async `pttStart` and `pttStop` tasks, so a quick tap can stop before capture setup has completed and produce an empty or lost hold-to-talk turn.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): persist orb hide through speech..."](https://github.com/saorsa-labs/fae/commit/060d09f01f1ec84c8de4cf5badd117c68c94f59e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43444164)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->