### PR TITLE
fix(daemon): warn on incomplete OpenRouter env (#45)

### DIFF
--- a/crates/fae-daemon/src/main.rs
+++ b/crates/fae-daemon/src/main.rs
@@ -690,13 +690,39 @@ struct ConductorCloudLane {
 /// keeps the local-only default (fail closed). The API key is moved into the
 /// adapter and never logged, never printed, never placed on the NDJSON socket,
 /// and never in a `CloudRequest`.
+fn missing_openrouter_contract_fields(
+    base_url: &Option<String>,
+    model_id: &Option<String>,
+    api_key: &Option<String>,
+) -> Option<&'static str> {
+    api_key.as_ref()?;
+    match (base_url.is_none(), model_id.is_none()) {
+        (true, true) => Some("FAE_REMOTE_BASE_URL, FAE_REMOTE_MODEL"),
+        (true, false) => Some("FAE_REMOTE_BASE_URL"),
+        (false, true) => Some("FAE_REMOTE_MODEL"),
+        (false, false) => None,
+    }
+}
+
 fn conductor_cloud_lane_from_env(mode: conductor::ModelMode) -> Option<ConductorCloudLane> {
     if mode != conductor::ModelMode::AllAvailable {
         return None;
     }
-    let base_url = first_non_empty_env(["FAE_REMOTE_BASE_URL"])?;
-    let model_id = first_non_empty_env(["FAE_REMOTE_MODEL"])?;
-    let api_key = first_non_empty_env(["FAE_OPENROUTER_API_KEY"])?;
+    let base_url = first_non_empty_env(["FAE_REMOTE_BASE_URL"]);
+    let model_id = first_non_empty_env(["FAE_REMOTE_MODEL"]);
+    let api_key = first_non_empty_env(["FAE_OPENROUTER_API_KEY"]);
+    if let Some(missing_fields) = missing_openrouter_contract_fields(&base_url, &model_id, &api_key)
+    {
+        tracing::warn!(
+            missing_fields,
+            "FAE_OPENROUTER_API_KEY is set but the OpenRouter startup contract is incomplete; \
+             cloud routing remains disabled"
+        );
+        return None;
+    }
+    let base_url = base_url?;
+    let model_id = model_id?;
+    let api_key = api_key?;
     let worker_id = conductor::workers::openrouter_worker_id(&model_id);
     let adapter = fae_engine::OpenRouterAdapter::new(fae_engine::OpenRouterConfig {
         base_url,
@@ -2633,6 +2659,34 @@ approved_by = "test"
 created_at = "test"
 "#
         )
+    }
+
+    #[test]
+    fn missing_openrouter_contract_fields_reports_exact_missing_fields() {
+        let base_url = Some("https://openrouter.ai/api/v1".to_owned());
+        let model_id = Some("openai/gpt-4.1".to_owned());
+        let api_key = Some("test-key".to_owned());
+
+        assert_eq!(
+            missing_openrouter_contract_fields(&None, &model_id, &api_key),
+            Some("FAE_REMOTE_BASE_URL")
+        );
+        assert_eq!(
+            missing_openrouter_contract_fields(&base_url, &None, &api_key),
+            Some("FAE_REMOTE_MODEL")
+        );
+        assert_eq!(
+            missing_openrouter_contract_fields(&None, &None, &api_key),
+            Some("FAE_REMOTE_BASE_URL, FAE_REMOTE_MODEL")
+        );
+        assert_eq!(
+            missing_openrouter_contract_fields(&base_url, &model_id, &api_key),
+            None
+        );
+        assert_eq!(
+            missing_openrouter_contract_fields(&None, &None, &None),
+            None
+        );
     }
 
     #[test]

--- a/docs/checklists/app-release-validation.md
+++ b/docs/checklists/app-release-validation.md
@@ -362,6 +362,7 @@ Mandatory when: `llm.privacyLane`, `llm.cloudDailyBudgetUSD`, cloud API key, or
 - [ ] Set lane = "all", store an API key, restart the daemon (`just run-dev`).
 - [ ] Confirm `DaemonLLMEngine` log line "cloud lane active (lane=all, …)" appears.
 - [ ] Confirm `FAE_OPENROUTER_API_KEY` does NOT appear in `~/Library/Logs/` or NSLog output.
+- [ ] With lane = "all" and `FAE_OPENROUTER_API_KEY` set, unset either `FAE_REMOTE_BASE_URL` or `FAE_REMOTE_MODEL`; confirm startup warns that the OpenRouter contract is incomplete, names the missing configuration fields without logging the key, and keeps cloud routing disabled.
 - [ ] Set lane = "local"; confirm the log line does NOT appear (no cloud vars injected).
 
 ### 13.4 Fallback surface


### PR DESCRIPTION
## Release validation

- [x] Release validation: N/A — no runtime/UI/policy/routing change.
  - Reason: Headless observability-only warning; cloud routing decisions remain fail-closed and byte-for-byte unchanged for complete, key-absent, and lane-disabled contracts.
- [ ] Release validation: blocker — this PR is intentionally NOT release-ready.
  - Blocker/issue: <!-- link to the tracking issue or the explicit blocker -->

## Summary

Fixes owner finding #45. When the all-available lane is selected and `FAE_OPENROUTER_API_KEY` is set but `FAE_REMOTE_BASE_URL` or `FAE_REMOTE_MODEL` is missing/empty, daemon startup now emits a structured warning naming the exact missing configuration fields and keeps cloud routing disabled. The API-key value is never passed to tracing, formatting, or debug output.

## Change type

- [x] Rust (`crates/`)
- [ ] Swift (`native/macos/`)
- [x] Docs / CI / tooling
- [ ] Other: <!-- describe -->

## Verification

- [x] Focused missing-field predicate test passes.
- [x] `cd crates && env -u RUSTFLAGS just check` passes: format, broad Clippy, strict daemon/engine/metaopt Clippy, and all workspace tests.
- [x] `cargo check --workspace --all-targets` passes.
- [x] `git diff --check` passes.
- [x] Release-validation checklist includes the incomplete-contract startup warning scenario.

## Security invariants

- Warning records only static configuration variable names in structured `missing_fields`.
- `FAE_OPENROUTER_API_KEY`'s value is never formatted, debug-printed, or attached to the tracing event.
- Missing contract remains fail-closed; no cloud worker is registered.
- Key absent or privacy/model mode below `AllAvailable` remains quiet.

## Baseline note

The global all-workspace strict test-target Clippy command is blocked by four pre-existing `fae-control-plane` test `unwrap()` calls. The canonical gate passes, including strict production Clippy for `fae-daemon`, `fae-engine`, and `fae-metaopt`; the baseline cleanup is explicitly out of scope.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a daemon warning for incomplete OpenRouter startup configuration. The main changes are:

- A helper that reports missing `FAE_REMOTE_BASE_URL` and `FAE_REMOTE_MODEL` fields.
- A startup warning when `FAE_OPENROUTER_API_KEY` is set but the OpenRouter contract is incomplete.
- A focused unit test for the missing-field helper.
- A release checklist item for the incomplete-contract warning path.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Complete OpenRouter configuration still enables the cloud lane.
- Missing or empty required fields still keep cloud routing disabled.
- The warning does not include the API key value.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/fae-daemon/src/main.rs | Adds the missing OpenRouter contract warning while keeping incomplete configuration fail-closed. |
| docs/checklists/app-release-validation.md | Documents release validation for the incomplete OpenRouter contract warning. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(daemon): warn on incomplete OpenRout..."](https://github.com/saorsa-labs/fae/commit/22c1b27c11e071e166304a2fa2f64ddc6e32e860) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43448650)</sub>

<!-- /greptile_comment -->