### PR TITLE
fix(runtime): identify stale Fae sidecars (#46)

### DIFF
--- a/crates/fae-engine/src/llamacpp_adapter.rs
+++ b/crates/fae-engine/src/llamacpp_adapter.rs
@@ -249,6 +249,44 @@ fn sidecar_pidfile(
     pidfile_root.map(|root| root.join(format!("llama-server.{port}.pid")))
 }
 
+fn process_executable(command_line: &str) -> &str {
+    command_line
+        .split_once(" -")
+        .map_or(command_line, |(executable, _)| executable)
+        .trim()
+        .trim_matches(|character| character == '\'' || character == '"')
+}
+
+fn held_port_message(port: u16, our_binary: &str, holder: Option<&(u32, String)>) -> String {
+    let Some((pid, command_line)) = holder else {
+        return format!(
+            "port {port} is still held after reclaim, but the listener process could not be \
+             identified; refusing to spawn a colliding sidecar — inspect the port holder and \
+             relaunch"
+        );
+    };
+    let executable = process_executable(command_line);
+    if std::path::Path::new(executable)
+        .file_name()
+        .is_some_and(|name| name == "llama-server")
+    {
+        return format!(
+            "port {port} is held by llama-server pid {pid} at {executable:?}, from a different \
+             install path than configured {our_binary:?}; the ownership check refused to kill \
+             it. Run `just kill-stale-sidecars` to remove stale Fae llama-servers, then relaunch"
+        );
+    }
+    let executable = if executable.is_empty() {
+        "<unknown executable>"
+    } else {
+        executable
+    };
+    format!(
+        "port {port} is held by non-Fae process pid {pid} ({executable:?}); the ownership check \
+         refused to kill it. Stop that process or free the port, then relaunch"
+    )
+}
+
 /// Reclaim `port` if it is squatted by a stale `llama-server` from a prior
 /// unclean daemon death (SIGKILL / crash / jetsam). Called by
 /// [`LlamaServerHandle::spawn`] BEFORE launching a fresh sidecar, so the new
@@ -293,8 +331,8 @@ async fn reclaim_port_if_held(
                     send_signal(pid, "KILL");
                 }
             }
-            // cmdline mismatch ⇒ recycled PID (not ours): do NOT kill a stranger.
-            // Fall through to the port-free gate, which fails loud if still held.
+            // Full-path mismatch: preserve the fail-closed ownership gate. The
+            // timeout path queries the actual listener PID before reporting it.
         }
     }
     // Wait for the port to go free WITH a timeout. Never bind on a held port.
@@ -307,9 +345,12 @@ async fn reclaim_port_if_held(
             return Ok(());
         }
         if std::time::Instant::now() >= free_deadline {
-            return Err(EngineError::Load(format!(
-                "port {port} is still held after reclaim; refusing to spawn a sidecar \
-                 that would collide — free the port (or kill the holder) and relaunch"
+            let holder = port_listener_pid(port)
+                .map(|pid| (pid, process_command_line(pid).unwrap_or_default()));
+            return Err(EngineError::Load(held_port_message(
+                port,
+                our_binary,
+                holder.as_ref(),
             )));
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -1553,6 +1594,54 @@ mod tests {
                 "required": ["city"]
             }),
         }
+    }
+
+    #[test]
+    fn held_port_message_identifies_stale_fae_llama_server_from_different_install() {
+        let holder = (
+            4242,
+            "/old/Fae.app/Contents/Resources/LlamaCpp/llama-server -m model.gguf".to_owned(),
+        );
+        let configured_binary = "/new/Fae.app/Contents/Resources/LlamaCpp/llama-server";
+
+        let message = held_port_message(18080, configured_binary, Some(&holder));
+
+        assert!(message.contains("port 18080"));
+        assert!(message.contains("pid 4242"));
+        assert!(message.contains("llama-server"));
+        assert!(message.contains("/old/Fae.app/Contents/Resources/LlamaCpp/llama-server"));
+        assert!(message.contains(configured_binary));
+        assert!(message.contains("different install path"));
+        assert!(message.contains("ownership check refused to kill it"));
+        assert!(message.contains("just kill-stale-sidecars"));
+    }
+
+    #[test]
+    fn held_port_message_identifies_non_fae_holder_without_fae_kill_recipe() {
+        let holder = (25509, "/opt/homebrew/bin/llama serve".to_owned());
+
+        let message = held_port_message(
+            18080,
+            "/new/Fae.app/Contents/Resources/LlamaCpp/llama-server",
+            Some(&holder),
+        );
+
+        assert!(message.contains("pid 25509"));
+        assert!(message.contains("/opt/homebrew/bin/llama serve"));
+        assert!(message.contains("ownership check refused to kill it"));
+        assert!(!message.contains("llama-server"));
+        assert!(!message.contains("just kill-stale-sidecars"));
+    }
+
+    #[test]
+    fn held_port_message_reports_unidentified_listener_without_holder() {
+        let message = held_port_message(
+            18080,
+            "/new/Fae.app/Contents/Resources/LlamaCpp/llama-server",
+            None,
+        );
+
+        assert!(message.contains("listener process could not be identified"));
     }
 
     #[test]

--- a/docs/checklists/app-release-validation.md
+++ b/docs/checklists/app-release-validation.md
@@ -71,6 +71,8 @@ Suggested screenshot root:
 - [ ] `just test-serve` exposes `/health` on `127.0.0.1:7433`.
 - [ ] The active local text model and configured vision model are visible in Settings without truncation.
 - [ ] The runtime reports the expected local text model, context size, tool mode, and llama.cpp source (`FAE_LLAMA_SHARED_SERVER_URL` attached shared server vs Fae-owned sidecar).
+- [ ] With port 18080 held by a `llama-server` from another Fae app-bundle path, daemon startup fails loud with the real listener PID/executable, explains the cross-install mismatch, and recommends `just kill-stale-sidecars`; it never kills the mismatched process automatically.
+- [ ] `just kill-stale-sidecars` defaults to a dry-run, lists only executables ending in `/Fae.app/Contents/Resources/LlamaCpp/llama-server`, leaves `/opt/homebrew/bin/llama serve` and bare/non-Fae llama processes untouched, and requires the explicit `kill` action before TERM → grace → KILL.
 - [ ] The active local text model matches `FaeConfig.recommendedModel()`. Active (Qwen fallback — Gemma 4 pending mlx-swift-lm): `Qwen3.5-9B-Unsloth` (≥16 GB) / `Qwen3.5-4B` (8–15 GB) / `Qwen3.5-2B-OptiQ` (<8 GB). Target (Gemma 4, not yet available): `E4B` (16–31 GB) / `E2B` (<16 GB) / `26B-A4B` (≥32 GB).
 - [ ] On a cache-cleared or clean-install machine, first local text-model load completes without `Worker command timed out: load` while model download is in progress.
 - [ ] Any stale onboarding, memory, scheduler, or approval state needed for the scenario is reset intentionally through the test server.

--- a/justfile
+++ b/justfile
@@ -92,6 +92,87 @@ _kill-fae:
         sleep 1
     fi
 
+# List stale Fae app-bundled llama-servers. Pass `kill` explicitly to terminate
+# the printed processes (TERM → 2s grace → KILL). Bare `llama-server`/`llama`
+# names and non-Fae install paths are never targets.
+kill-stale-sidecars action="dry-run":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ACTION="{{action}}"
+    case "$ACTION" in
+        dry-run|kill) ;;
+        *) echo "Usage: just kill-stale-sidecars [dry-run|kill]" >&2; exit 2 ;;
+    esac
+
+    is_fae_llama_server() {
+        local command_line="$1"
+        local executable="${command_line%% -*}"
+        executable="${executable#"${executable%%[![:space:]]*}"}"
+        executable="${executable%"${executable##*[![:space:]]}"}"
+        [[ "$executable" == */Fae.app/Contents/Resources/LlamaCpp/llama-server ]]
+    }
+
+    # Permanent safety fixture for the owner's live Homebrew llama process.
+    if is_fae_llama_server "/opt/homebrew/bin/llama serve"; then
+        echo "Safety assertion failed: non-Fae Homebrew llama matched" >&2
+        exit 1
+    fi
+
+    pids=()
+    commands=()
+    while read -r pid command_line; do
+        if is_fae_llama_server "$command_line"; then
+            pids+=("$pid")
+            commands+=("$command_line")
+            if [[ "$ACTION" == "dry-run" ]]; then
+                echo "DRY RUN: would terminate Fae llama-server pid $pid: $command_line"
+            fi
+        fi
+    done < <(ps -axo pid=,command=)
+
+    if ((${#pids[@]} == 0)); then
+        echo "No stale Fae app-bundled llama-server processes found."
+        exit 0
+    fi
+    if [[ "$ACTION" == "dry-run" ]]; then
+        echo "Review the list, then run: just kill-stale-sidecars kill"
+        exit 0
+    fi
+
+    termed=()
+    for index in "${!pids[@]}"; do
+        pid="${pids[$index]}"
+        expected="${commands[$index]}"
+        current="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+        current="${current#"${current%%[![:space:]]*}"}"
+        current="${current%"${current##*[![:space:]]}"}"
+        if [[ "$current" != "$expected" ]] || ! is_fae_llama_server "$current"; then
+            echo "Skipping pid $pid: identity changed before TERM" >&2
+            termed+=("0")
+            continue
+        fi
+        echo "Sending TERM to Fae llama-server pid $pid"
+        kill -TERM "$pid"
+        termed+=("1")
+    done
+
+    sleep 2
+    for index in "${!pids[@]}"; do
+        [[ "${termed[$index]}" == "1" ]] || continue
+        pid="${pids[$index]}"
+        expected="${commands[$index]}"
+        kill -0 "$pid" 2>/dev/null || continue
+        current="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+        current="${current#"${current%%[![:space:]]*}"}"
+        current="${current%"${current##*[![:space:]]}"}"
+        if [[ "$current" != "$expected" ]] || ! is_fae_llama_server "$current"; then
+            echo "Skipping pid $pid: identity changed before KILL" >&2
+            continue
+        fi
+        echo "Sending KILL to Fae llama-server pid $pid"
+        kill -KILL "$pid"
+    done
+
 # Build, bundle, sign, and launch the native app (production mode).
 # Orb-first: embeds the Rust orb shell + daemon (the only product UI + brain).
 run-native: build-ui-shell build-daemon build _bundle-app _embed-ui-shell _embed-daemon _embed-llamacpp-runtime _embed-kokoro-model _sign-bundle _kill-fae


### PR DESCRIPTION
## Release validation

- [x] Release validation: N/A — no runtime/UI/policy/routing change.
  - Reason: Headless failure-diagnostic and owner-invoked maintenance recipe only; automatic sidecar ownership/reclaim behavior remains unchanged and fail-closed.
- [ ] Release validation: blocker — this PR is intentionally NOT release-ready.
  - Blocker/issue: <!-- link to the tracking issue or the explicit blocker -->

## Summary

Fixes owner finding #46. When a sidecar port remains occupied by a process Fae refuses to kill, the timeout now re-queries the real listener and names its PID and executable. A cross-install app-bundled `llama-server` is identified explicitly, including the configured-vs-holder path mismatch and the ownership refusal. Adds `just kill-stale-sidecars`: dry-run by default, exact Fae.app runtime suffix only, and explicit `kill` action for TERM → grace → KILL.

## Change type

- [x] Rust (`crates/`)
- [ ] Swift (`native/macos/`)
- [x] Docs / CI / tooling
- [x] Other: root Justfile maintenance recipe

## Verification

- [x] Three focused `held_port_message` tests pass.
- [x] `just --dry-run kill-stale-sidecars` validates recipe syntax.
- [x] `just kill-stale-sidecars` performs a no-kill dry-run by default.
- [x] Live PID 25509 `/opt/homebrew/bin/llama serve` remained alive and absent from targets after the dry-run.
- [x] `cd crates && env -u RUSTFLAGS just check` passes: format, broad Clippy, strict daemon/engine/metaopt Clippy, and all workspace tests.
- [x] `cargo check --workspace --all-targets` passes.
- [x] `git diff --check` passes.
- [x] Release-validation checklist includes the cross-install failure and recipe safety scenarios.

## Kill-safety invariants

- Automatic reclaim still calls the unchanged `cmdline_is_our_sidecar`: full configured/canonical binary path required; mismatch is never killed.
- Recipe matcher accepts only an executable ending exactly in `/Fae.app/Contents/Resources/LlamaCpp/llama-server`.
- Bare `llama-server`, bare `llama`, `/opt/homebrew/bin/llama serve`, and other install layouts do not match.
- Bare recipe invocation is dry-run. Actual signaling requires `just kill-stale-sidecars kill`.
- PID and full command line are re-read and must exactly match immediately before TERM and again before KILL, preventing PID-recycle/identity-change kills.

## Diagnostic privacy

The timeout reports only the local listener PID and executable prefix. It does not include the holder's model arguments or environment and does not log credentials.

## Baseline note

The global all-workspace strict test-target Clippy command remains blocked by four pre-existing, approved test-only `fae-control-plane` unwraps. Canonical production gates pass; no baseline code was changed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves stale llama sidecar diagnostics and adds a manual cleanup recipe.

- Re-queries the listener PID and command line when reclaim times out.
- Adds held-port messages for cross-install and non-Fae holders.
- Adds focused tests for the new diagnostics.
- Adds release checklist coverage and `just kill-stale-sidecars`.

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after small cleanup to diagnostics and recipe matching.

- Automatic reclaim still fails closed before spawning on a held port.
- The new cleanup recipe re-checks process identity before each signal.
- The remaining issues can mislead cleanup or miss stale sidecars in specific path shapes.

crates/fae-engine/src/llamacpp_adapter.rs and justfile

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/fae-engine/src/llamacpp_adapter.rs | Adds held-port diagnostic helpers, timeout listener re-querying, and tests for the new messages. |
| justfile | Adds a dry-run-by-default stale sidecar cleanup recipe with identity checks before TERM and KILL. |
| docs/checklists/app-release-validation.md | Adds validation steps for cross-install sidecar diagnostics and cleanup recipe safety. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
crates/fae-engine/src/llamacpp_adapter.rs:270-278
**Basename Triggers Wrong Remedy**

When the port holder is a non-Fae executable named `llama-server`, this branch still says it is from a different configured install path and recommends `just kill-stale-sidecars`. That recipe only matches paths ending in `/Fae.app/Contents/Resources/LlamaCpp/llama-server`, so `/usr/local/bin/llama-server` would not be removed and the user would be sent to a no-op cleanup path while the port stays blocked.

### Issue 2 of 2
justfile:109-112
**Path Segment Breaks Matching**

The executable parser cuts the command line at the first ` -*` sequence anywhere in the string. If Fae is installed under a path such as `/Applications/Fae - Beta/Fae.app/Contents/Resources/LlamaCpp/llama-server -m ...`, the extracted executable becomes `/Applications/Fae`, so the dry-run and kill modes omit a real stale Fae sidecar and leave the held port unresolved.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): identify stale Fae sidecar..."](https://github.com/saorsa-labs/fae/commit/dcde07f79398bc6cc947be2b419f65803a01af15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43453715)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->