### PR TITLE
ci(linux): replace zig daemon proof with native docker

### DIFF
--- a/.github/workflows/linux-render-spike.yml
+++ b/.github/workflows/linux-render-spike.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/linux-render-spike.yml"
       - "crates/**"
       - "native/rust/fae-ui-shell/**"
+      - "native/docker/**"
       - "docs/architecture/linux-render-spike-2026-06.md"
   push:
     branches: [main]
@@ -14,6 +15,7 @@ on:
       - ".github/workflows/linux-render-spike.yml"
       - "crates/**"
       - "native/rust/fae-ui-shell/**"
+      - "native/docker/**"
       - "docs/architecture/linux-render-spike-2026-06.md"
 
 concurrency:
@@ -62,13 +64,6 @@ jobs:
           components: clippy, rustfmt
           targets: x86_64-unknown-linux-gnu
 
-      - name: Install Zig and cargo-zigbuild
-        run: |
-          set -euo pipefail
-          curl -fsSL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz -o /tmp/zig.tar.xz
-          tar -xf /tmp/zig.tar.xz -C /tmp
-          echo "/tmp/zig-linux-x86_64-0.13.0" >> "$GITHUB_PATH"
-          cargo install cargo-zigbuild --locked
 
       - name: Check Rust orb shell formatting
         working-directory: native/rust/fae-ui-shell
@@ -154,29 +149,16 @@ jobs:
         working-directory: crates
         run: cargo build -p fae-daemon --all-features
 
-      # zigbuild packaging-proof: build WITHOUT the `parakeet` feature. zig's
-      # hermetic cross-sysroot lacks GNU libstdc++ (and targets older glibc), so
-      # it cannot link sherpa-onnx's prebuilt C++ static lib; `parakeet` is a
-      # default-on cargo feature, excluded here via --no-default-features. Native
-      # ci-linux (both arches) + macOS build WITH it. The packaged/zigbuilt Linux
-      # daemon temporarily ships without Parakeet (gap; see PR description).
-      - name: P1 deferred proof — zigbuild fae-daemon for Linux x86_64 (no parakeet feature)
-        working-directory: crates
-        run: cargo zigbuild --target x86_64-unknown-linux-gnu -p fae-daemon --no-default-features
-
-      - name: Verify zigbuilt binary runtime deps (ldd)
-        working-directory: crates
+      # Native Docker packaging proof: unlike the former Zig cross-build, this
+      # builds the shipping feature set, including sherpa-onnx/Parakeet. The
+      # digest-pinned Ubuntu image keeps GNU libstdc++ and glibc in one native
+      # sysroot; the Dockerfile fails on missing or unexpected runtime deps.
+      - name: Build all-feature fae-daemon in pinned Ubuntu 24.04 image
         run: |
-          set -euo pipefail
-          BIN="target/x86_64-unknown-linux-gnu/debug/fae-daemon"
-          test -x "$BIN"
-          echo "=== ldd $BIN ==="
-          ldd "$BIN" | tee /tmp/ldd.txt
-          # This build excludes the `parakeet` feature (no sherpa-onnx), so it
-          # must NOT pull in sherpa/onnxruntime shared runtime deps. Fail if any
-          # leaked in (a C++ dep slipped past the feature gate).
-          if grep -Ei 'lib(onnxruntime|sherpa|kaldi|openfst)' /tmp/ldd.txt; then
-            echo "ERROR: no-parakeet zigbuild pulled in sherpa/onnxruntime shared deps" >&2
-            exit 1
-          fi
-          echo "runtime deps OK: no sherpa/onnxruntime deps in the no-parakeet zigbuild"
+          docker build \
+            --pull \
+            --platform linux/amd64 \
+            --progress plain \
+            --file native/docker/fae-daemon.Dockerfile \
+            --tag "fae-daemon-linux-proof:${GITHUB_SHA}" \
+            .

--- a/native/docker/fae-daemon.Dockerfile
+++ b/native/docker/fae-daemon.Dockerfile
@@ -20,6 +20,12 @@ RUN apt-get update \
 
 COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
 COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup
+COPY --chmod=0755 \
+    native/docker/verify-fae-daemon-runtime-deps.sh \
+    native/docker/test-verify-fae-daemon-runtime-deps.sh \
+    /usr/local/bin/
+RUN /usr/local/bin/test-verify-fae-daemon-runtime-deps.sh \
+    /usr/local/bin/verify-fae-daemon-runtime-deps.sh
 
 WORKDIR /workspace
 COPY vendor/ vendor/
@@ -45,11 +51,4 @@ RUN set -eu; \
     ! grep -F 'not found' /tmp/fae-daemon.ldd; \
     grep -F 'libstdc++.so.6' /tmp/fae-daemon.ldd; \
     ! grep -Ei 'lib(onnxruntime|sherpa|kaldi|openfst)' /tmp/fae-daemon.ldd; \
-    awk '{ print $1 }' /tmp/fae-daemon.ldd \
-        | sed 's#^.*/##' \
-        | sort -u \
-        | grep -Ev '^(linux-vdso\.so\.1|ld-linux-x86-64\.so\.2|libasound\.so\.2|libc\.so\.6|libdl\.so\.2|libgcc_s\.so\.1|libm\.so\.6|libpthread\.so\.0|librt\.so\.1|libstdc\+\+\.so\.6)$' \
-        > /tmp/fae-daemon-unexpected-libs.txt \
-        || true; \
-    test ! -s /tmp/fae-daemon-unexpected-libs.txt \
-        || { echo 'ERROR: unexpected fae-daemon runtime dependencies:' >&2; cat /tmp/fae-daemon-unexpected-libs.txt >&2; exit 1; }
+    /usr/local/bin/verify-fae-daemon-runtime-deps.sh /tmp/fae-daemon.ldd

--- a/native/docker/fae-daemon.Dockerfile
+++ b/native/docker/fae-daemon.Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+# Build-only Linux daemon proof. This image is never published.
+FROM rust:1.96.0-bookworm@sha256:c993d32d95cc146bd12c84d66f0b924a6a96f3988325f39c144f2f9893dea120 AS rust-toolchain
+
+FROM ubuntu:24.04@sha256:52df9b1ee71626e0088f7d400d5c6b5f7bb916f8f0c82b474289a4ece6cf3faf
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:${PATH}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+        libasound2-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
+COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup
+
+WORKDIR /workspace
+COPY vendor/ vendor/
+COPY crates/ crates/
+
+WORKDIR /workspace/crates
+RUN rustc --version | grep -F 'rustc 1.96.0 '
+RUN cargo build --locked --release -p fae-daemon --all-features
+
+# These rlibs exist only when fae-daemon's default-on `parakeet` feature
+# compiled both the sherpa wrapper and its native sys crate. This closes the
+# old no-feature Zig gap.
+RUN test -n "$(find target/release/deps -name 'libsherpa_onnx-*.rlib' -print -quit)" \
+    && test -n "$(find target/release/deps -name 'libsherpa_onnx_sys-*.rlib' -print -quit)"
+
+# Preserve the Parakeet packaging bar: sherpa/ONNX remain static, libstdc++ is
+# the only C++ runtime, and every other dynamic dependency is an expected ALSA
+# or glibc runtime library. Any new dependency fails this build proof.
+RUN set -eu; \
+    bin=target/release/fae-daemon; \
+    test -x "$bin"; \
+    ldd "$bin" | tee /tmp/fae-daemon.ldd; \
+    ! grep -F 'not found' /tmp/fae-daemon.ldd; \
+    grep -F 'libstdc++.so.6' /tmp/fae-daemon.ldd; \
+    ! grep -Ei 'lib(onnxruntime|sherpa|kaldi|openfst)' /tmp/fae-daemon.ldd; \
+    awk '{ print $1 }' /tmp/fae-daemon.ldd \
+        | sed 's#^.*/##' \
+        | sort -u \
+        | grep -Ev '^(linux-vdso\.so\.1|ld-linux-x86-64\.so\.2|libasound\.so\.2|libc\.so\.6|libdl\.so\.2|libgcc_s\.so\.1|libm\.so\.6|libpthread\.so\.0|librt\.so\.1|libstdc\+\+\.so\.6)$' \
+        > /tmp/fae-daemon-unexpected-libs.txt \
+        || true; \
+    test ! -s /tmp/fae-daemon-unexpected-libs.txt \
+        || { echo 'ERROR: unexpected fae-daemon runtime dependencies:' >&2; cat /tmp/fae-daemon-unexpected-libs.txt >&2; exit 1; }

--- a/native/docker/fae-daemon.Dockerfile.dockerignore
+++ b/native/docker/fae-daemon.Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+**
+!crates/
+!crates/**
+!vendor/
+!vendor/**
+!native/
+!native/docker/
+!native/docker/fae-daemon.Dockerfile
+!native/docker/fae-daemon.Dockerfile.dockerignore

--- a/native/docker/test-verify-fae-daemon-runtime-deps.sh
+++ b/native/docker/test-verify-fae-daemon-runtime-deps.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+checker=${1:-"$(dirname "$0")/verify-fae-daemon-runtime-deps.sh"}
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+printf '%s\n' \
+    'linux-vdso.so.1 (0x00007fff)' \
+    'libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fff)' \
+    'libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fff)' \
+    '/lib64/ld-linux-x86-64.so.2 (0x00007fff)' \
+    > "$tmpdir/allowed.ldd"
+"$checker" "$tmpdir/allowed.ldd"
+
+cp "$tmpdir/allowed.ldd" "$tmpdir/unexpected.ldd"
+printf '%s\n' \
+    'libbogus.so.1 => /opt/surprise/libbogus.so.1 (0x00007fff)' \
+    >> "$tmpdir/unexpected.ldd"
+
+if "$checker" "$tmpdir/unexpected.ldd" 2> "$tmpdir/rejection.txt"; then
+    echo 'ERROR: checker accepted an unexpected runtime dependency' >&2
+    exit 1
+fi
+
+grep -F 'libbogus.so.1' "$tmpdir/rejection.txt" > /dev/null

--- a/native/docker/verify-fae-daemon-runtime-deps.sh
+++ b/native/docker/verify-fae-daemon-runtime-deps.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <ldd-output>" >&2
+    exit 2
+fi
+
+ldd_output=$1
+unexpected=$(
+    awk '{ print $1 }' "$ldd_output" \
+        | sed 's#^.*/##' \
+        | sort -u \
+        | grep -Ev '^(linux-vdso\.so\.1|ld-linux-x86-64\.so\.2|libasound\.so\.2|libc\.so\.6|libdl\.so\.2|libgcc_s\.so\.1|libm\.so\.6|libpthread\.so\.0|librt\.so\.1|libstdc\+\+\.so\.6)$' \
+        || true
+)
+
+if [ -n "$unexpected" ]; then
+    echo "ERROR: unexpected fae-daemon runtime dependencies:" >&2
+    printf '%s\n' "$unexpected" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Release validation

- [x] Release validation: N/A — no runtime/UI/policy/routing change.
      Reason: CI-only replacement of a reduced-feature Zig link proof with a native all-feature Docker build proof.

- [ ] Release validation: done — the relevant checklist phases passed.
      Evidence:

- [ ] Release validation: blocker — this PR is intentionally NOT release-ready.
      Blocker/issue:

## Summary

- replace only the linux-render-spike cargo-zigbuild/no-Parakeet leg with a native linux/amd64 Ubuntu 24.04 Docker build
- digest-pin both Rust and Ubuntu base images and build fae-daemon with --locked --release --all-features
- prove sherpa-onnx and sherpa-onnx-sys compiled, require libstdc++.so.6, and reject missing, shared sherpa/ONNX, or unexpected runtime dependencies
- preserve all WebKitGTK/Xvfb render thresholds; leave ci-linux.yml and release-linux.yml byte-unchanged

## Change type

- [ ] Rust (crates/)
- [ ] Swift (native/macos/)
- [x] Docs / CI / tooling
- [ ] Other:

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the Linux daemon proof with a native Docker build. The main changes are:

- Adds `native/docker/**` to the Linux render spike workflow triggers.
- Replaces the reduced-feature Zig build with a pinned Ubuntu Docker build.
- Builds `fae-daemon` with `--locked --release --all-features`.
- Adds checks for sherpa rlibs and expected runtime libraries.
- Adds a Dockerfile-specific ignore file for the build context.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The Docker build context includes the workspace and vendored sources needed by the new proof.
- The feature and runtime dependency checks match the stated native packaging validation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/linux-render-spike.yml | Replaces the old Zig no-Parakeet proof with a native Docker build and updates trigger paths for Docker proof changes. |
| native/docker/fae-daemon.Dockerfile | Adds the pinned Ubuntu build proof, all-feature daemon build, sherpa artifact checks, and runtime dependency allowlist. |
| native/docker/fae-daemon.Dockerfile.dockerignore | Adds a deny-by-default build context that re-includes the crate sources, vendored sources, and Docker proof files. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(linux): replace zig daemon proof with..."](https://github.com/saorsa-labs/fae/commit/78ef9b5f329dc8c09bba8568afe5d68302d3ce41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43457977)</sub>

<!-- /greptile_comment -->