### PR TITLE
feat(collaborate): add tailnet forwards and stores

### DIFF
--- a/docs/checklists/app-release-validation.md
+++ b/docs/checklists/app-release-validation.md
@@ -204,6 +204,8 @@ server-side dangerous scope. Validate the live boundary:
 - [ ] Recall output shows trustworthy provenance labels for imported artifacts or derived digests.
 - [ ] Scheduler list/create/update/delete/trigger flows work.
 - [ ] Skills list/add/edit/remove/execute flows work.
+- [ ] With a second trusted x0x machine online and connect forwarding enabled, the `collaborate` skill can add a numeric-loopback tailnet forward, carry bytes through it, list the exact mapping, and remove the listener.
+- [ ] Two trusted x0x agents can create/join a replicated store, set/get the same text value across agents, list its key, and replicate its removal.
 - [ ] Staged skill drafts can be listed, inspected, and only applied or dismissed after explicit user confirmation.
 - [ ] Any generated or edited artifacts appear where the UI says they will.
 

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/MANIFEST.json
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/MANIFEST.json
@@ -21,16 +21,18 @@
   "integrity": {
     "algorithm": "sha256",
     "checksums": {
-      "SKILL.md": "0fbf21551ccc88147e9de13d4ba1c72c8cfcf64f6d51fdcc10d0df214aba965d",
+      "SKILL.md": "119e5b868516b0a5a89e297dce2233e7b26fb4f78fd66c704235c1177f16f8e7",
       "scripts/_x0x.py": "3dc2115b95528096cf475b575497b9798f9073ae446863664b908f7ae7fde546",
       "scripts/contacts.py": "32f794ccd5e58ee0a63d49b96755ee0f5727fe89079e1e3573b1bff8abd2c8a2",
       "scripts/ensure.py": "d1e4e00a9abf05fd2843420013fa3a6ff808e5405c9fe8e15721385be1abac2f",
       "scripts/files.py": "90b6f8807512ca2cbb5700f79ba03d24654c4b34235e8d74e463d8d2a105c4f7",
+      "scripts/forwards.py": "64f9bbe4dcb5177b880b5f30b4a5c4f46fb2d71d5e0664424225da1ed67a865f",
       "scripts/groups.py": "ee4bedb4113d8a277ad47a30d716ab8ab96558827ab99cbdf3576df47fd87af2",
       "scripts/gui.py": "cc6c5a38033f6428cd63ce707d587540c7a31fdba2dfae9a1b5f40d3ff613946",
       "scripts/kanban.py": "762ebb66104a7a7d75c8fc7f3853f320ea0b9e27161bf3618cd576e430c39666",
       "scripts/message.py": "c4458d1bb8751a90d071474f18ae17ea1c55fd89cfb48b3bd3973a7116957c87",
       "scripts/presence.py": "a35798fbc987335ce0c0320041ff80094030570f57edaa0e16337c9a7652e951",
+      "scripts/stores.py": "e13500ddc3c736903ca7a228634552c9ce8f4150022578d409d268f01fdf443b",
       "scripts/swarm.py": "927925ccffe5507611cd6e2048fcc8c27b97b1abcf0b9690e7ec00f521502796"
     },
     "signature": null

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/SKILL.md
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: collaborate
-description: Connect with other Fae, friends, and their agents over x0x — messages, spaces, kanban, files. Use for "share my card", "add this person", or when the user pastes an x0x contact card.
+description: Collaborate over x0x — contacts, messages, spaces, boards, files, presence, trusted-machine port forwards, and replicated stores. Use for sharing cards, connecting people, or cross-device work.
 metadata:
   author: fae
   version: "1.0"
@@ -9,9 +9,10 @@ metadata:
 You are operating Fae's **Collaborate** skill — the bridge that lets the user work
 together with other people and agents over the **x0x** decentralized network. It
 gives the user the same collaboration the communitas app offers (spaces, messages,
-kanban, swarm, files, presence) by driving the local **x0xd** daemon over its
-localhost REST API, and it shows the rich UI in the user's **browser** via x0x's
-own GUI.
+kanban, swarm, files, presence), plus tailnet port-forwarding between the owner's
+trusted machines and replicated key-value stores, by driving the local **x0xd**
+daemon over its localhost REST API. It shows the rich UI in the user's **browser**
+via x0x's own GUI.
 
 ## What this connects
 
@@ -78,6 +79,8 @@ Always run `ensure` first in a session if you are unsure the daemon is up.
 | `presence` | Who is online / discover agents (`action`: `online`/`find`/`foaf`). |
 | `swarm` | Publish a task to a topic or read results (`action`: `publish`/`read`/`subscribe`). |
 | `files` | Send a file to an agent / list / accept / reject transfers (`action`: `send`/`list`/`accept`/`reject`). |
+| `forwards` | Forward a local TCP port to a loopback service on a trusted peer machine (`action`: `list`/`add`/`rm`). Use only for the owner's trusted fleet and numeric loopback endpoints. |
+| `stores` | Share replicated key-value state between agents (`action`: `list`/`create`/`join`/`keys`/`get`/`set`/`rm`). Values are text encoded safely for x0x transport. |
 
 All scripts accept an optional `instance` param to target a named x0x identity
 (`x0x --name alice`); omit it for the default identity.
@@ -92,6 +95,8 @@ All scripts accept an optional `instance` param to target a named x0x identity
 - "Summarise the unread messages in Falcon." → `message read {group_id}` → summarise the result aloud.
 - "Add a card 'ship the daemon' to the board." → `kanban add {list_id, title:"ship the daemon"}`.
 - "Send the design doc to the team." → `files send {agent_id, path}`.
+- "Forward local port 15432 to port 22 on my other machine." → `forwards add {local_addr:"127.0.0.1:15432", peer_agent, target_host:"127.0.0.1", target_port:22}`. Confirm the other machine is trusted and its connect policy allows the target.
+- "Share this setting with my other agents." → `stores create {name, topic}` or `stores join {store_id}`, then `stores set {store_id, key, value}`. Use `stores get` to read it back.
 
 When you open the GUI, tell the user it's in their browser. When you read messages,
 say if history might be partial (some history is browser-local, only signed group

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts/forwards.py
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts/forwards.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Manage x0x tailnet TCP port-forwards.
+
+Actions (params.action):
+  list (default) — list configured forwards.
+  add            — create a forward (local_addr, peer_agent, target_host, target_port).
+  rm             — remove a forward (local_addr).
+"""
+
+import ipaddress
+import os
+import sys
+import urllib.parse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _x0x import X0x, X0xError, read_params, emit, fail  # noqa: E402
+
+
+def _port(value, label: str) -> int:
+    if isinstance(value, bool):
+        raise X0xError(f"The {label} port must be between 1 and 65535.")
+    if isinstance(value, int):
+        port = value
+    elif isinstance(value, str) and value.isdigit():
+        port = int(value)
+    else:
+        raise X0xError(f"The {label} port must be between 1 and 65535.")
+    if not 1 <= port <= 65535:
+        raise X0xError(f"The {label} port must be between 1 and 65535.")
+    return port
+
+
+def _loopback_ip(value, label: str) -> str:
+    text = str(value or "").strip()
+    try:
+        address = ipaddress.ip_address(text)
+    except ValueError:
+        raise X0xError(f"The {label} must be a numeric loopback address, such as 127.0.0.1.") from None
+    if not address.is_loopback:
+        raise X0xError(f"The {label} must be a loopback address on this machine.")
+    return address.compressed
+
+
+def _local_address(value) -> tuple[str, int]:
+    text = str(value or "").strip()
+    if text.startswith("["):
+        closing = text.find("]")
+        host = text[1:closing] if closing > 0 else ""
+        separator = text[closing + 1:closing + 2] if closing >= 0 else ""
+        port_text = text[closing + 2:] if separator == ":" else ""
+    else:
+        host, separator, port_text = text.rpartition(":")
+    if separator != ":" or not host or not port_text:
+        raise X0xError("The local address must look like 127.0.0.1:15432.")
+    host = _loopback_ip(host, "local address")
+    port = _port(port_text, "local")
+    normalized = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+    return normalized, port
+
+
+def _peer_agent(value) -> str:
+    agent = str(value or "").strip().lower()
+    if len(agent) != 64 or any(char not in "0123456789abcdef" for char in agent):
+        raise X0xError("I need a valid 64-character agent id for the other machine.")
+    return agent
+
+
+def do_add(client: X0x, params: dict) -> dict:
+    local_addr, local_port = _local_address(params.get("local_addr"))
+    peer_agent = _peer_agent(params.get("peer_agent"))
+    target_host = _loopback_ip(params.get("target_host"), "target host")
+    target_port = _port(params.get("target_port"), "target")
+    body = {
+        "local_addr": local_addr,
+        "peer_agent": peer_agent,
+        "target_host": target_host,
+        "target_port": target_port,
+    }
+    try:
+        resp = client.post("/forwards", body)
+    except X0xError:
+        short_peer = peer_agent[:12] + "…"
+        raise X0xError(
+            "I couldn't create that tunnel. "
+            f"Is {short_peer} online, trusted, and allowed by this machine's connect policy?"
+        ) from None
+    return {
+        "ok": True,
+        "local_addr": resp.get("local_addr", local_addr),
+        "peer_agent": resp.get("peer_agent", peer_agent),
+        "target_host": target_host,
+        "target_port": target_port,
+        "summary": f"Forwarding local port {local_port} to port {target_port} on that machine.",
+    }
+
+
+def do_list(client: X0x) -> dict:
+    try:
+        resp = client.get("/forwards")
+    except X0xError:
+        raise X0xError("I couldn't list the tailnet forwards right now.") from None
+    forwards = resp.get("forwards", []) or []
+    summary = (
+        f"{len(forwards)} tailnet forward(s) configured."
+        if forwards
+        else "No tailnet forwards are configured."
+    )
+    return {"ok": True, "forwards": forwards, "count": len(forwards), "summary": summary}
+
+
+def do_rm(client: X0x, params: dict) -> dict:
+    local_addr, local_port = _local_address(params.get("local_addr"))
+    encoded_addr = urllib.parse.quote(local_addr, safe="")
+    try:
+        resp = client.delete(f"/forwards/{encoded_addr}")
+    except X0xError:
+        raise X0xError(f"I couldn't remove the forward on local port {local_port}.") from None
+    return {
+        "ok": True,
+        "local_addr": local_addr,
+        "removed": bool(resp.get("removed", True)),
+        "summary": f"Removed the forward on local port {local_port}.",
+    }
+
+
+def main() -> None:
+    params = read_params()
+    action = str(params.get("action") or "list").strip().lower()
+    client = X0x(params.get("instance"))
+    try:
+        client.require_running()
+        if action == "list":
+            emit(do_list(client))
+        elif action == "add":
+            emit(do_add(client, params))
+        elif action == "rm":
+            emit(do_rm(client, params))
+        else:
+            fail(f"Unknown action '{action}'. Use list, add, or rm.")
+    except X0xError as error:
+        fail(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts/stores.py
+++ b/native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts/stores.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Manage replicated x0x key-value stores.
+
+Actions (params.action):
+  list (default) — list joined stores.
+  create         — create a store (name, topic).
+  join           — join a store (store_id).
+  keys           — list keys (store_id).
+  get            — read a value (store_id, key).
+  set            — write text (store_id, key, value; optional content_type).
+  rm             — remove a value (store_id, key).
+"""
+
+import os
+import sys
+import urllib.parse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _x0x import X0x, X0xError, b64, unb64_text, read_params, emit, fail  # noqa: E402
+
+
+def _required_text(value, message: str, *, max_length: int = 1024) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise X0xError(message)
+    text = value.strip()
+    if len(text) > max_length or any(ord(char) < 32 for char in text):
+        raise X0xError(message)
+    return text
+
+
+def _store_id(params: dict) -> str:
+    return _required_text(
+        params.get("store_id"),
+        "Which shared store? I need its store_id.",
+    )
+
+
+def _key(params: dict) -> str:
+    return _required_text(
+        params.get("key"),
+        "Which value? I need its key.",
+    )
+
+
+def _segment(value: str) -> str:
+    return urllib.parse.quote(value, safe="")
+
+
+def do_list(client: X0x) -> dict:
+    try:
+        resp = client.get("/stores")
+    except X0xError:
+        raise X0xError("I couldn't list the shared stores right now.") from None
+    stores = resp.get("stores", []) or []
+    summary = f"{len(stores)} shared store(s) joined." if stores else "No shared stores are joined yet."
+    return {"ok": True, "stores": stores, "count": len(stores), "summary": summary}
+
+
+def do_create(client: X0x, params: dict) -> dict:
+    name = _required_text(params.get("name"), "A shared store needs both a name and a topic.")
+    topic = _required_text(params.get("topic"), "A shared store needs both a name and a topic.")
+    try:
+        resp = client.post("/stores", {"name": name, "topic": topic})
+    except X0xError:
+        raise X0xError("I couldn't create that shared store.") from None
+    store_id = resp.get("id", topic)
+    return {
+        "ok": True,
+        "id": store_id,
+        "name": name,
+        "topic": topic,
+        "summary": f"Created the shared store '{name}'.",
+    }
+
+
+def do_join(client: X0x, params: dict) -> dict:
+    store_id = _store_id(params)
+    try:
+        resp = client.post(f"/stores/{_segment(store_id)}/join")
+    except X0xError:
+        raise X0xError("I couldn't join that shared store.") from None
+    joined_id = resp.get("id", store_id)
+    return {"ok": True, "id": joined_id, "summary": "Joined the shared store."}
+
+
+def do_keys(client: X0x, params: dict) -> dict:
+    store_id = _store_id(params)
+    try:
+        resp = client.get(f"/stores/{_segment(store_id)}/keys")
+    except X0xError:
+        raise X0xError("I couldn't list the keys in that shared store.") from None
+    keys = resp.get("keys", []) or []
+    summary = f"{len(keys)} key(s) in that shared store." if keys else "That shared store has no keys yet."
+    return {
+        "ok": True,
+        "store_id": store_id,
+        "keys": keys,
+        "count": len(keys),
+        "summary": summary,
+    }
+
+
+def do_get(client: X0x, params: dict) -> dict:
+    store_id = _store_id(params)
+    key = _key(params)
+    try:
+        resp = client.get(f"/stores/{_segment(store_id)}/{_segment(key)}")
+    except X0xError:
+        raise X0xError("I couldn't read that value from the shared store.") from None
+    encoded = resp.get("value") or ""
+    return {
+        **resp,
+        "ok": True,
+        "store_id": store_id,
+        "key": resp.get("key", key),
+        "value": encoded,
+        "value_text": unb64_text(encoded),
+        "summary": f"Read '{key}' from the shared store.",
+    }
+
+
+def do_set(client: X0x, params: dict) -> dict:
+    store_id = _store_id(params)
+    key = _key(params)
+    if "value" not in params or not isinstance(params["value"], str):
+        raise X0xError("I need a text value to save; an empty string is allowed.")
+    value = params["value"]
+    body = {"value": b64(value)}
+    if params.get("content_type") is not None:
+        content_type = _required_text(
+            params.get("content_type"),
+            "The content_type must be a non-empty media type.",
+            max_length=255,
+        )
+        body["content_type"] = content_type
+    try:
+        client.put(f"/stores/{_segment(store_id)}/{_segment(key)}", body)
+    except X0xError:
+        raise X0xError("I couldn't save that value to the shared store.") from None
+    return {
+        "ok": True,
+        "store_id": store_id,
+        "key": key,
+        "content_type": body.get("content_type", "application/octet-stream"),
+        "summary": f"Saved '{key}' in the shared store.",
+    }
+
+
+def do_rm(client: X0x, params: dict) -> dict:
+    store_id = _store_id(params)
+    key = _key(params)
+    try:
+        client.delete(f"/stores/{_segment(store_id)}/{_segment(key)}")
+    except X0xError:
+        raise X0xError("I couldn't remove that value from the shared store.") from None
+    return {
+        "ok": True,
+        "store_id": store_id,
+        "key": key,
+        "summary": f"Removed '{key}' from the shared store.",
+    }
+
+
+def main() -> None:
+    params = read_params()
+    action = str(params.get("action") or "list").strip().lower()
+    client = X0x(params.get("instance"))
+    try:
+        client.require_running()
+        if action == "list":
+            emit(do_list(client))
+        elif action == "create":
+            emit(do_create(client, params))
+        elif action == "join":
+            emit(do_join(client, params))
+        elif action == "keys":
+            emit(do_keys(client, params))
+        elif action == "get":
+            emit(do_get(client, params))
+        elif action == "set":
+            emit(do_set(client, params))
+        elif action == "rm":
+            emit(do_rm(client, params))
+        else:
+            fail(f"Unknown action '{action}'. Use list, create, join, keys, get, set, or rm.")
+    except X0xError as error:
+        fail(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test_collaborate_skill_scripts.py
+++ b/tests/python/test_collaborate_skill_scripts.py
@@ -1,0 +1,343 @@
+import base64
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from urllib.parse import quote
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = (
+    REPO_ROOT
+    / "native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts"
+)
+NO_BODY = object()
+
+
+def load_script(module_name, filename):
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT_DIR / filename)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {filename}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+forwards = load_script("collaborate_forwards_contract", "forwards.py")
+stores = load_script("collaborate_stores_contract", "stores.py")
+
+
+class RecordingClient:
+    def __init__(self, response=None, error=None):
+        self.response = {} if response is None else response
+        self.error = error
+        self.calls = []
+
+    def _call(self, method, path, body=NO_BODY):
+        self.calls.append((method, path, body))
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+    def get(self, path):
+        return self._call("GET", path)
+
+    def post(self, path, body=NO_BODY):
+        return self._call("POST", path, body)
+
+    def put(self, path, body=NO_BODY):
+        return self._call("PUT", path, body)
+
+    def delete(self, path):
+        return self._call("DELETE", path)
+
+
+class CollaborateSkillScriptContractTests(unittest.TestCase):
+    PEER_AGENT = "a" * 64
+    STORE_ID = "team/store?rev=1#west coast"
+    KEY = "profile/name?lang=en#preferred value"
+    ENCODED_STORE_ID = quote(STORE_ID, safe="")
+    ENCODED_KEY = quote(KEY, safe="")
+
+    def test_forwards_add_posts_exact_contract(self):
+        client = RecordingClient(response={"local_addr": "127.0.0.1:15432"})
+
+        forwards.do_add(
+            client,
+            {
+                "local_addr": "127.0.0.1:15432",
+                "peer_agent": self.PEER_AGENT.upper(),
+                "target_host": "127.0.0.2",
+                "target_port": "443",
+                "ignored": "must not reach the daemon",
+            },
+        )
+
+        self.assertEqual(
+            client.calls,
+            [
+                (
+                    "POST",
+                    "/forwards",
+                    {
+                        "local_addr": "127.0.0.1:15432",
+                        "peer_agent": self.PEER_AGENT,
+                        "target_host": "127.0.0.2",
+                        "target_port": 443,
+                    },
+                )
+            ],
+        )
+
+    def test_forwards_list_gets_exact_contract(self):
+        client = RecordingClient(response={"forwards": []})
+
+        forwards.do_list(client)
+
+        self.assertEqual(client.calls, [("GET", "/forwards", NO_BODY)])
+
+    def test_forwards_rm_deletes_percent_encoded_local_address(self):
+        client = RecordingClient(response={"removed": True})
+
+        forwards.do_rm(client, {"local_addr": "127.0.0.1:15432"})
+
+        self.assertEqual(
+            client.calls,
+            [("DELETE", "/forwards/127.0.0.1%3A15432", NO_BODY)],
+        )
+
+    def test_stores_list_gets_exact_contract(self):
+        client = RecordingClient(response={"stores": []})
+
+        stores.do_list(client)
+
+        self.assertEqual(client.calls, [("GET", "/stores", NO_BODY)])
+
+    def test_stores_create_posts_exact_contract(self):
+        client = RecordingClient(response={"id": "created-store"})
+
+        stores.do_create(
+            client,
+            {
+                "name": " Shared plans ",
+                "topic": " fae/project ",
+                "ignored": "must not reach the daemon",
+            },
+        )
+
+        self.assertEqual(
+            client.calls,
+            [
+                (
+                    "POST",
+                    "/stores",
+                    {"name": "Shared plans", "topic": "fae/project"},
+                )
+            ],
+        )
+
+    def test_stores_join_posts_bodyless_encoded_store_id(self):
+        client = RecordingClient(response={"id": self.STORE_ID})
+
+        stores.do_join(client, {"store_id": self.STORE_ID})
+
+        self.assertEqual(
+            client.calls,
+            [("POST", f"/stores/{self.ENCODED_STORE_ID}/join", NO_BODY)],
+        )
+
+    def test_stores_keys_gets_encoded_store_id(self):
+        client = RecordingClient(response={"keys": []})
+
+        stores.do_keys(client, {"store_id": self.STORE_ID})
+
+        self.assertEqual(
+            client.calls,
+            [("GET", f"/stores/{self.ENCODED_STORE_ID}/keys", NO_BODY)],
+        )
+
+    def test_stores_get_gets_each_encoded_path_segment(self):
+        client = RecordingClient(response={"key": self.KEY, "value": "aGVsbG8="})
+
+        stores.do_get(client, {"store_id": self.STORE_ID, "key": self.KEY})
+
+        self.assertEqual(
+            client.calls,
+            [
+                (
+                    "GET",
+                    f"/stores/{self.ENCODED_STORE_ID}/{self.ENCODED_KEY}",
+                    NO_BODY,
+                )
+            ],
+        )
+
+    def test_stores_set_puts_encoded_segments_and_base64_body(self):
+        client = RecordingClient()
+        value = "hello / 日本語"
+        encoded_value = base64.b64encode(value.encode("utf-8")).decode("ascii")
+        path = f"/stores/{self.ENCODED_STORE_ID}/{self.ENCODED_KEY}"
+
+        stores.do_set(
+            client,
+            {
+                "store_id": self.STORE_ID,
+                "key": self.KEY,
+                "value": value,
+                "content_type": "text/plain; charset=utf-8",
+            },
+        )
+        stores.do_set(
+            client,
+            {"store_id": self.STORE_ID, "key": self.KEY, "value": ""},
+        )
+
+        self.assertEqual(
+            client.calls,
+            [
+                (
+                    "PUT",
+                    path,
+                    {
+                        "value": encoded_value,
+                        "content_type": "text/plain; charset=utf-8",
+                    },
+                ),
+                ("PUT", path, {"value": ""}),
+            ],
+        )
+
+    def test_stores_rm_deletes_bodyless_encoded_segments(self):
+        client = RecordingClient()
+
+        stores.do_rm(client, {"store_id": self.STORE_ID, "key": self.KEY})
+
+        self.assertEqual(
+            client.calls,
+            [
+                (
+                    "DELETE",
+                    f"/stores/{self.ENCODED_STORE_ID}/{self.ENCODED_KEY}",
+                    NO_BODY,
+                )
+            ],
+        )
+
+    def test_invalid_forward_inputs_fail_before_client_call(self):
+        cases = [
+            {
+                "local_addr": "not-an-address",
+                "peer_agent": self.PEER_AGENT,
+                "target_host": "127.0.0.1",
+                "target_port": 443,
+            },
+            {
+                "local_addr": "127.0.0.1:15432",
+                "peer_agent": "not-an-agent-id",
+                "target_host": "127.0.0.1",
+                "target_port": 443,
+            },
+            {
+                "local_addr": "127.0.0.1:15432",
+                "peer_agent": self.PEER_AGENT,
+                "target_host": "127.0.0.1",
+                "target_port": 0,
+            },
+            {
+                "local_addr": "127.0.0.1:15432",
+                "peer_agent": self.PEER_AGENT,
+                "target_host": "127.0.0.1",
+                "target_port": 22.5,
+            },
+        ]
+        for params in cases:
+            with self.subTest(params=params):
+                client = RecordingClient()
+                with self.assertRaises(forwards.X0xError):
+                    forwards.do_add(client, params)
+                self.assertEqual(client.calls, [])
+
+    def test_non_loopback_forward_inputs_fail_before_client_call(self):
+        cases = [
+            {
+                "local_addr": "192.0.2.10:15432",
+                "peer_agent": self.PEER_AGENT,
+                "target_host": "127.0.0.1",
+                "target_port": 443,
+            },
+            {
+                "local_addr": "127.0.0.1:15432",
+                "peer_agent": self.PEER_AGENT,
+                "target_host": "192.0.2.20",
+                "target_port": 443,
+            },
+        ]
+        for params in cases:
+            with self.subTest(params=params):
+                client = RecordingClient()
+                with self.assertRaises(forwards.X0xError):
+                    forwards.do_add(client, params)
+                self.assertEqual(client.calls, [])
+
+    def test_missing_store_inputs_fail_before_client_call(self):
+        cases = [
+            (stores.do_join, {}),
+            (stores.do_keys, {}),
+            (stores.do_get, {"key": self.KEY}),
+            (stores.do_set, {"key": self.KEY, "value": "value"}),
+            (stores.do_rm, {"key": self.KEY}),
+            (stores.do_get, {"store_id": self.STORE_ID}),
+            (stores.do_set, {"store_id": self.STORE_ID, "value": "value"}),
+            (stores.do_rm, {"store_id": self.STORE_ID}),
+            (stores.do_set, {"store_id": self.STORE_ID, "key": self.KEY}),
+        ]
+        for action, params in cases:
+            with self.subTest(action=action.__name__, params=params):
+                client = RecordingClient()
+                with self.assertRaises(stores.X0xError):
+                    action(client, params)
+                self.assertEqual(client.calls, [])
+
+    def test_x0x_errors_are_voice_safe_bounded_and_redacted(self):
+        marker = "MARKER_SECRET_DO_NOT_SPEAK"
+        raw_detail = f"{marker}: bearer token and daemon traceback"
+        cases = [
+            (forwards.do_list, ()),
+            (
+                forwards.do_add,
+                (
+                    {
+                        "local_addr": "127.0.0.1:15432",
+                        "peer_agent": self.PEER_AGENT,
+                        "target_host": "127.0.0.1",
+                        "target_port": 443,
+                    },
+                ),
+            ),
+            (forwards.do_rm, ({"local_addr": "127.0.0.1:15432"},)),
+            (stores.do_list, ()),
+            (stores.do_create, ({"name": "plans", "topic": "fae/plans"},)),
+            (stores.do_join, ({"store_id": self.STORE_ID},)),
+            (stores.do_keys, ({"store_id": self.STORE_ID},)),
+            (stores.do_get, ({"store_id": self.STORE_ID, "key": self.KEY},)),
+            (
+                stores.do_set,
+                ({"store_id": self.STORE_ID, "key": self.KEY, "value": "value"},),
+            ),
+            (stores.do_rm, ({"store_id": self.STORE_ID, "key": self.KEY},)),
+        ]
+        for action, args in cases:
+            with self.subTest(action=action.__name__):
+                client = RecordingClient(error=stores.X0xError(raw_detail))
+                with self.assertRaises(stores.X0xError) as raised:
+                    action(client, *args)
+                message = str(raised.exception)
+                self.assertNotIn(marker, message)
+                self.assertNotIn(raw_detail, message)
+                self.assertLessEqual(len(message), 200)
+                self.assertEqual(len(client.calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Release validation

- [ ] Release validation: N/A — no runtime/UI/policy/routing change.
      Reason:

- [ ] Release validation: done — the relevant checklist phases passed.
      Evidence:

- [x] Release validation: blocker — this PR is intentionally NOT release-ready.
      Blocker/issue: Two-machine tailnet tunnel and cross-agent replicated-store scenarios require the owner's second trusted machine; recorded in docs/checklists/app-release-validation.md and .pi-subagents/deliverables/OWNER-TEST-PLAN.md.

## Summary

- add `forwards.py` for source-verified x0x v0.30.1 tailnet add/list/rm with numeric-loopback validation and encoded removal paths
- add `stores.py` for replicated KV create/list/join/keys/get/set/rm with per-segment path encoding and base64 values
- add 14 daemon-free contract tests pinning every method, path, body, failure-before-I/O case, and voice-safe error boundary
- recompute all 13 collaborate skill SHA-256 checksums and document both capabilities
- keep remote execution explicitly out of scope under task #52

## Change type

- [ ] Rust (crates/)
- [ ] Swift (native/macos/)
- [x] Docs / CI / tooling
- [x] Other: bundled collaborate skill Python resources

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds collaborate skill support for tailnet forwards and replicated stores. The main changes are:

- New `forwards.py` actions for add, list, and remove.
- New `stores.py` actions for create, join, keys, get, set, and remove.
- Updated skill docs, checksums, and release-validation checklist items.
- New Python contract tests for request paths, bodies, and validation errors.

<h3>Confidence Score: 4/5</h3>

The changed flow is close, but daemon response handling can report incorrect store values and forward cleanup state.

- Store reads can turn malformed or missing values into successful empty text.
- Store creation can hand back a topic when the daemon does not provide an id.
- Forward removal can report success without confirmation from the daemon.

stores.py and forwards.py

<details open><summary><h3>Security Review</h3></summary>

The new forward helper limits client inputs to loopback addresses and trusted-peer usage, but removal can be reported as successful without explicit daemon confirmation. That can leave a local listener active after Fae says it was removed.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts/forwards.py | Adds tailnet forward list/add/remove actions with loopback and port validation, but removal success is assumed when the daemon response lacks confirmation. |
| native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts/stores.py | Adds replicated store actions with encoded path segments and base64 values, but missing or malformed response fields can be treated as successful data. |
| tests/python/test_collaborate_skill_scripts.py | Adds request-contract and validation tests for the new scripts. |
| native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/SKILL.md | Documents the new forwards and stores actions. |
| native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/MANIFEST.json | Registers the new scripts and updated skill checksum. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts/stores.py:114-121
**Malformed Values Become Empty**

When another agent or daemon version returns a missing, null, or non-base64 `value`, this path still returns `ok: True` with `value_text` set to an empty string. Callers can then report that a replicated value is empty instead of surfacing a store protocol or data error.

### Issue 2 of 3
native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts/stores.py:70
**Missing Store Id Becomes Topic**

If `POST /stores` succeeds but returns a response without `id`, this reports the topic as the new store id. Follow-up `join`, `keys`, `get`, `set`, or `rm` calls will then address `/stores/{topic}/...`, which can fail against the actual store while the create step looked successful.

### Issue 3 of 3
native/macos/Fae/Sources/Fae/Resources/Skills/collaborate/scripts/forwards.py:125
**Unconfirmed Removal Reports Success**

If the daemon returns an empty or schema-mismatched DELETE response, this defaults `removed` to `True` and tells the caller the forward was removed. A listener can remain active while Fae reports that the local port was cleaned up.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(release): add collaborate tailnet a..."](https://github.com/saorsa-labs/fae/commit/5abc9d69c8cc4c7d4dd4e760615398ec6cc4c457) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43566574)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->