### PR TITLE
chore(lint): scope forbidden lints to non-test production, keep -D warnings for tests

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -86,12 +86,21 @@ jobs:
           # CI is the ONLY place its unit tests (incl. the integrity-rejection
           # test) compile + run. macOS ci.yml never sees them.
           env -u RUSTFLAGS cargo fmt -p fae-daemon -p fae-engine -p fae-metaopt -- --check
-          env -u RUSTFLAGS cargo clippy -p fae-daemon --bin fae-daemon -p fae-engine --all-targets --all-features \
+          # -D warnings across ALL targets (incl. unit + integration tests) — the
+          # broad safety net; tests get warnings-as-errors but may use unwrap/
+          # expect/panic.
+          env -u RUSTFLAGS cargo clippy -p fae-daemon -p fae-engine -p fae-metaopt --all-targets --all-features \
+            -- -D warnings
+          # Production-safety forbidden lints (`-D clippy::panic/unwrap_used/
+          # expect_used`) scoped to `--lib --bins` — PRODUCTION code only, never
+          # test targets (unit or integration). Crate roots also carry
+          # `#![cfg_attr(not(test), deny(...))]` as the in-source belt.
+          env -u RUSTFLAGS cargo clippy -p fae-daemon -p fae-engine --lib --bins --all-features \
             -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
           # fae-metaopt (M3 recipe surface): strict clippy + tests now blocking
           # on CI (M5-D). The boundary guard below covers the daemon↔metaopt
           # structural split; this covers correctness.
-          env -u RUSTFLAGS cargo clippy -p fae-metaopt --all-targets --all-features \
+          env -u RUSTFLAGS cargo clippy -p fae-metaopt --lib --bins --all-features \
             -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
           # Workspace compile gate (M5-D): every crate must at least COMPILE on
           # Linux before merge. nextest stays per-crate (platform-sensitive tests).

--- a/crates/fae-acp/src/lib.rs
+++ b/crates/fae-acp/src/lib.rs
@@ -16,6 +16,7 @@
     not(test),
     deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
 )]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
 use std::path::Path;
 use std::str::FromStr;

--- a/crates/fae-audio/src/lib.rs
+++ b/crates/fae-audio/src/lib.rs
@@ -4,6 +4,7 @@
     not(test),
     deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
 )]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/fae-control-plane/src/lib.rs
+++ b/crates/fae-control-plane/src/lib.rs
@@ -15,6 +15,7 @@
     not(test),
     deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
 )]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
 use std::collections::HashSet;
 

--- a/crates/fae-envelope-gate/src/lib.rs
+++ b/crates/fae-envelope-gate/src/lib.rs
@@ -7,6 +7,7 @@
     not(test),
     deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
 )]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
 // M6-A (2026-06-27): the gate is a dumb, schema-versioned, signature-checked
 // CARRIER. It must stay schema-agnostic — it does not (and must not) depend on

--- a/crates/fae-metaopt/src/lib.rs
+++ b/crates/fae-metaopt/src/lib.rs
@@ -13,6 +13,7 @@
     not(test),
     deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)
 )]
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used, clippy::panic))]
 
 pub mod conductor_recipe;
 pub mod optimizer;

--- a/crates/justfile
+++ b/crates/justfile
@@ -15,16 +15,21 @@ default: check
 # Full validation — zero warnings, all tests.
 #
 # The clippy invocations MIRROR .github/workflows/ci-linux.yml so a green local
-# `just check` means a green CI: the workspace-wide `-D warnings` pass is the
-# broad safety net, and the per-crate passes add the strict production-safety
-# lints (`-D clippy::panic -D clippy::unwrap_used -D clippy::expect_used`) that
-# CI enforces on the daemon binary, fae-engine, and fae-metaopt.
+# `just check` means a green CI: the workspace-wide `-D warnings` pass (all
+# targets, incl. tests) is the broad safety net, and the per-crate passes add
+# the strict production-safety lints (`-D clippy::panic -D clippy::unwrap_used
+# -D clippy::expect_used`) that CI enforces on the daemon binary, fae-engine,
+# and fae-metaopt. Those forbidden lints are scoped to `--lib --bins`
+# (production code only) — test code (unit + integration) stays under
+# `-D warnings` but may use unwrap/expect/panic. Crate roots also carry
+# `#![cfg_attr(not(test), deny(...))]` + `#![cfg_attr(test, allow(...))]` as the
+# in-source belt for ad-hoc/IDE clippy runs.
 check:
     cargo fmt --all -- --check
     cargo clippy --all-targets --all-features -- -D warnings
-    cargo clippy -p fae-daemon --bin fae-daemon -p fae-engine --all-targets --all-features \
+    cargo clippy -p fae-daemon -p fae-engine --lib --bins --all-features \
         -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
-    cargo clippy -p fae-metaopt --all-targets --all-features \
+    cargo clippy -p fae-metaopt --lib --bins --all-features \
         -- -D warnings -D clippy::panic -D clippy::unwrap_used -D clippy::expect_used
     cargo test --all-features
 


### PR DESCRIPTION
## Release validation

- [x] Release validation: N/A — no runtime/UI/policy/routing change.
      Reason: lint/CI-config only — scopes clippy forbidden lints to production (--lib --bins); no model/prompt/voice/STT/TTS/memory/scheduler/skills/orb/policy surface touched.

- [ ] Release validation: done — the relevant checklist phases passed.
      Evidence:

- [ ] Release validation: blocker — this PR is intentionally NOT release-ready.
      Blocker/issue:

## Change type
chore (lint/CI configuration)

## Summary
Scopes the production-safety forbidden lints (`clippy::unwrap_used`, `expect_used`, `panic`) to **non-test production code**, while keeping `-D warnings` on **all** targets including tests.

**Why:** a global strict-test clippy run was blocked by unwrap/expect/panic in test code (unit tests in fae-control-plane; integration tests in fae-symphony-runner) — task #51. Tests legitimately use unwrap/expect; the forbidden lints should only guard production.

**How:**
- justfile + ci-linux.yml: forbidden-lint clippy passes now use `--lib --bins` (production targets only) instead of `--all-targets`; a separate `--all-targets -- -D warnings` pass keeps warnings-as-errors on all test code.
- 5 crate roots (fae-control-plane/audio/acp/metaopt/envelope-gate) gain the `#![cfg_attr(test, allow(...))]` companion to their `#![cfg_attr(not(test), deny(...))]`, matching fae-engine/daemon/pii-membrane.

**Verified:** both split passes green; negative test (a temp `unwrap()` in fae-engine production correctly fails clippy); `cargo fmt --all -- --check` clean. Resolves task #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- attestation re-eval b32596aa -->
